### PR TITLE
SPA-160: Unify col_id hash — storage and engine must agree

### DIFF
--- a/crates/sparrowdb-common/src/lib.rs
+++ b/crates/sparrowdb-common/src/lib.rs
@@ -100,6 +100,25 @@ impl From<std::io::Error> for Error {
 /// Crate-wide result type.
 pub type Result<T> = std::result::Result<T, Error>;
 
+// ── Canonical column-ID derivation ───────────────────────────────────────────
+
+/// Derive a stable `u32` column ID from a property key name.
+///
+/// Uses FNV-1a 32-bit hash for deterministic, catalog-free mapping.
+/// This is the **single authoritative implementation** — both the storage
+/// layer and the execution engine must call this function so that the
+/// `col_id` written to disk and the `col_id` used at query time always agree.
+pub fn col_id_of(name: &str) -> u32 {
+    const FNV_PRIME: u32 = 16_777_619;
+    const OFFSET_BASIS: u32 = 2_166_136_261;
+    let mut hash = OFFSET_BASIS;
+    for byte in name.bytes() {
+        hash ^= byte as u32;
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use sparrowdb_catalog::catalog::Catalog;
-use sparrowdb_common::{NodeId, Result};
+use sparrowdb_common::{col_id_of, NodeId, Result};
 use sparrowdb_cypher::ast::{
     BinOpKind, Expr, Literal, MatchStatement, ReturnItem, SortDir, Statement,
 };
@@ -402,17 +402,14 @@ fn extract_return_column_names(items: &[ReturnItem]) -> Vec<String> {
 }
 
 /// Map a property name like "col_0" or "name" to a col_id.
+///
+/// Uses the canonical [`sparrowdb_common::col_id_of`] FNV-1a hash so that
+/// this always agrees with what the storage layer wrote to disk (SPA-160).
 fn prop_name_to_col_id(name: &str) -> u32 {
     if let Some(suffix) = name.strip_prefix("col_") {
         suffix.parse().unwrap_or(0)
     } else {
-        // Hash the name to an id for non-prefixed properties.
-        // In production the catalog would provide field_id.
-        let mut h: u32 = 5381;
-        for b in name.bytes() {
-            h = h.wrapping_mul(33).wrapping_add(b as u32);
-        }
-        h % 64
+        col_id_of(name)
     }
 }
 

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -28,7 +28,7 @@
 //! ```
 
 use sparrowdb_catalog::catalog::Catalog;
-use sparrowdb_common::{EdgeId, Error, NodeId, Result, TxnId};
+use sparrowdb_common::{col_id_of, EdgeId, Error, NodeId, Result, TxnId};
 use sparrowdb_execution::{Engine, QueryResult};
 use sparrowdb_storage::csr::CsrForward;
 use sparrowdb_storage::edge_store::{EdgeStore, RelTableId};
@@ -785,16 +785,10 @@ fn write_mutation_wal(
 
 /// Derive a stable `u32` column ID from a property key name.
 ///
-/// Uses FNV-1a 32-bit hash for deterministic, catalog-free mapping.
+/// Delegates to [`sparrowdb_common::col_id_of`] — the single canonical
+/// FNV-1a implementation shared by storage and execution (SPA-160).
 pub fn fnv1a_col_id(key: &str) -> u32 {
-    const FNV_PRIME: u32 = 16_777_619;
-    const OFFSET_BASIS: u32 = 2_166_136_261;
-    let mut hash = OFFSET_BASIS;
-    for byte in key.bytes() {
-        hash ^= byte as u32;
-        hash = hash.wrapping_mul(FNV_PRIME);
-    }
-    hash
+    col_id_of(key)
 }
 
 // ── Private helpers ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause**: `prop_name_to_col_id` in the execution engine used a DJB2-like hash (seed `5381`, multiply-by-33, mod 64) while the storage layer used FNV-1a (seed `2166136261`, xor-then-multiply by `16777619`). The two functions produced different `col_id` values for the same property name, so Cypher property reads looked up the wrong column files and returned wrong or missing data.
- Added `col_id_of(name: &str) -> u32` to `sparrowdb-common` as the single canonical FNV-1a implementation.
- Replaced the divergent hash body in `sparrowdb-execution::engine::prop_name_to_col_id` with `sparrowdb_common::col_id_of`.
- Made the public `sparrowdb::fnv1a_col_id` (used by tests) a thin wrapper around the same canonical function.

No on-disk format changes — FNV-1a was already what the storage layer wrote to disk.

Closes SPA-160
Fixes https://github.com/ryaker/SparrowDB/issues/23

## Test plan

- [ ] `cargo test --workspace` — all tests pass (confirmed locally)
- [ ] `cargo clippy --all-targets -- -D warnings` — no errors (confirmed locally)
- [ ] `cargo fmt --all` — no formatting changes (confirmed locally)
- [ ] Manual: write a node with a named property, read it back via Cypher `MATCH (n) RETURN n.prop` — value should now be correct instead of null/wrong

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep property column IDs consistent between storage and queries**

### What Changed
- Property names now map to the same column ID everywhere, so values written to disk are read back correctly during Cypher queries.
- Non-prefixed property names no longer use a different hash path in the query engine; they use the same shared mapping as storage.
- The public helper used by tests now points to the same shared logic, removing the chance of drift between code paths.

### Impact
`✅ Correct property reads`
`✅ Fewer missing or wrong field values`
`✅ More reliable Cypher query results`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
