### PR TITLE
SPA-162: Fix checkpoint deadlock after write transactions

### DIFF
--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -252,8 +252,16 @@ impl GraphDb {
     /// records, and publish the new `wal_checkpoint_lsn` to the metapage.
     ///
     /// Acquires the writer lock for the duration — no concurrent writes.
+    ///
+    /// Returns [`Error::WriterBusy`] immediately if a [`WriteTx`] is currently
+    /// active, rather than blocking indefinitely.  This prevents deadlocks on
+    /// single-threaded callers and avoids unbounded waits on multi-threaded ones.
     pub fn checkpoint(&self) -> Result<()> {
-        let _guard = self.inner.write_lock.lock().unwrap();
+        let _guard = self
+            .inner
+            .write_lock
+            .try_lock()
+            .map_err(|_| Error::WriterBusy)?;
         let catalog = Catalog::open(&self.inner.path)?;
         let node_store = NodeStore::open(&self.inner.path)?;
         let (rel_table_ids, n_nodes) =
@@ -266,8 +274,16 @@ impl GraphDb {
     /// node's neighbor list by `(dst_node_id)` ascending.
     ///
     /// Acquires the writer lock for the duration — no concurrent writes.
+    ///
+    /// Returns [`Error::WriterBusy`] immediately if a [`WriteTx`] is currently
+    /// active, rather than blocking indefinitely.  This prevents deadlocks on
+    /// single-threaded callers and avoids unbounded waits on multi-threaded ones.
     pub fn optimize(&self) -> Result<()> {
-        let _guard = self.inner.write_lock.lock().unwrap();
+        let _guard = self
+            .inner
+            .write_lock
+            .try_lock()
+            .map_err(|_| Error::WriterBusy)?;
         let catalog = Catalog::open(&self.inner.path)?;
         let node_store = NodeStore::open(&self.inner.path)?;
         let (rel_table_ids, n_nodes) =
@@ -940,5 +956,54 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db = GraphDb::open(dir.path()).unwrap();
         db.optimize().expect("optimize must succeed on empty DB");
+    }
+
+    /// SPA-162: checkpoint() must not deadlock after a write transaction has
+    /// been committed and dropped.
+    #[test]
+    fn checkpoint_does_not_deadlock_after_write() {
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db = Arc::new(GraphDb::open(dir.path()).unwrap());
+
+        // Run a write transaction and commit it.
+        let mut tx = db.begin_write().unwrap();
+        tx.create_node(0, &[]).unwrap();
+        tx.commit().unwrap();
+
+        // checkpoint() must complete without hanging — run it on a thread so
+        // the test runner can time out rather than block the whole suite.
+        let db2 = Arc::clone(&db);
+        let handle = std::thread::spawn(move || {
+            db2.checkpoint().unwrap();
+        });
+        handle
+            .join()
+            .expect("checkpoint thread must complete without panic");
+    }
+
+    /// SPA-162: checkpoint() must return WriterBusy (not deadlock) when a
+    /// WriteTx is currently active.  Before the fix, calling lock() from
+    /// checkpoint() while the same thread held the mutex would hang forever.
+    #[test]
+    fn checkpoint_returns_writer_busy_while_write_tx_active() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = GraphDb::open(dir.path()).unwrap();
+
+        // Hold an active write transaction without committing it.
+        let tx = db.begin_write().unwrap();
+
+        // checkpoint() must return WriterBusy immediately — not deadlock.
+        let result = db.checkpoint();
+        assert!(
+            matches!(result, Err(Error::WriterBusy)),
+            "expected WriterBusy while WriteTx active, got: {result:?}"
+        );
+
+        // Drop the transaction; checkpoint must now succeed.
+        drop(tx);
+        db.checkpoint()
+            .expect("checkpoint must succeed after WriteTx dropped");
     }
 }


### PR DESCRIPTION
## **User description**
## Summary

- `GraphDb::checkpoint()` and `optimize()` called `write_lock.lock()` (blocking), which deadlocks when invoked on the same thread that holds an active `WriteTx` guard (`std::sync::Mutex` is non-reentrant on all major platforms)
- Even on separate threads, the blocking `lock()` gave callers no way to distinguish a genuine hang from "writer is temporarily busy"
- Fix: replace `lock().unwrap()` with `try_lock().map_err(|_| Error::WriterBusy)?` in both `checkpoint()` and `optimize()` — returns immediately with `WriterBusy` if a writer is active

## Root Cause

`checkpoint()` and `optimize()` used `Mutex::lock()` (blocking) to serialize with active writers. If called from the same OS thread that holds the `write_lock` (via an open `WriteTx`), `lock()` blocks forever — `std::sync::Mutex` is not reentrant.

## Fix

Replace blocking `lock()` with non-blocking `try_lock()` in both maintenance methods. If a `WriteTx` is open, the method returns `Error::WriterBusy` immediately. Callers can retry after the writer commits or is dropped.

## Test plan

- [x] `checkpoint_does_not_deadlock_after_write` — commits a write then calls `checkpoint()` from a background thread; must complete without hanging
- [x] `checkpoint_returns_writer_busy_while_write_tx_active` — verifies `WriterBusy` returned immediately while `WriteTx` is open; verifies checkpoint succeeds once the transaction is dropped
- [x] All existing checkpoint/optimize tests pass (`cargo test --workspace`)
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean

Closes SPA-162
Fixes https://github.com/ryaker/SparrowDB/issues/27

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Prevent maintenance tasks from hanging when a write is in progress

### What Changed
- Checkpoint and optimize now return immediately with a busy-writer error if a write transaction is active
- They no longer block forever on the same thread that started the write
- Added coverage for both cases: after a write is committed, and while a write is still open

### Impact
`✅ Fewer database hangs during maintenance`
`✅ Clearer busy-writer errors`
`✅ Safer checkpoint and optimize calls during active writes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Database checkpoint and optimization operations now return immediately when a write operation is in progress, preventing indefinite blocking or failures.

* **Tests**
  * Added test coverage for checkpoint behavior during concurrent write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->