### PR TITLE
SPA-163, SPA-164: Delta log edges visible; skip tombstoned nodes in scan

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -15,6 +15,7 @@ use sparrowdb_cypher::ast::{
 };
 use sparrowdb_cypher::{bind, parse};
 use sparrowdb_storage::csr::CsrForward;
+use sparrowdb_storage::edge_store::{EdgeStore, RelTableId};
 use sparrowdb_storage::node_store::NodeStore;
 
 use crate::types::{QueryResult, Value};
@@ -186,6 +187,15 @@ impl Engine {
             if slot < 1024 || slot % 10_000 == 0 {
                 tracing::trace!(slot = slot, node_id = node_id.0, "scan emit");
             }
+
+            // SPA-164: skip tombstoned nodes.  delete_node writes u64::MAX into
+            // col_0 as the deletion sentinel; nodes in that state must not
+            // appear in scan results.
+            let col0_check = self.store.get_node_raw(node_id, &[0u32])?;
+            if col0_check.iter().any(|&(c, v)| c == 0 && v == u64::MAX) {
+                continue;
+            }
+
             let props = self.store.get_node_raw(node_id, &all_col_ids)?;
 
             // Apply inline prop filter from the pattern.
@@ -277,9 +287,36 @@ impl Engine {
                 continue;
             }
 
+            // SPA-163: read delta log edges for this source node and merge
+            // with CSR neighbors so edges are visible before a checkpoint.
+            let delta_neighbors: Vec<u64> = {
+                let edge_store = EdgeStore::open(&self.db_root, RelTableId(0));
+                match edge_store.and_then(|s| s.read_delta()) {
+                    Ok(records) => records
+                        .into_iter()
+                        .filter(|r| {
+                            let r_src_label = (r.src.0 >> 32) as u32;
+                            let r_src_slot = r.src.0 & 0xFFFF_FFFF;
+                            r_src_label == src_label_id && r_src_slot == src_slot
+                        })
+                        .map(|r| r.dst.0 & 0xFFFF_FFFF)
+                        .collect(),
+                    Err(_) => vec![],
+                }
+            };
+
             // Traverse CSR.
-            let neighbors = self.csr.neighbors(src_slot);
-            for &dst_slot in neighbors {
+            let csr_neighbors = self.csr.neighbors(src_slot);
+            let all_neighbors: Vec<u64> = csr_neighbors
+                .iter()
+                .copied()
+                .chain(delta_neighbors.into_iter())
+                .collect();
+            let mut seen_neighbors: HashSet<u64> = HashSet::new();
+            for &dst_slot in &all_neighbors {
+                if !seen_neighbors.insert(dst_slot) {
+                    continue;
+                }
                 let dst_node = NodeId(((dst_label_id as u64) << 32) | dst_slot);
                 let dst_props = if !col_ids_dst.is_empty() {
                     self.store.get_node_raw(dst_node, &col_ids_dst)?
@@ -369,6 +406,27 @@ impl Engine {
             ids
         };
 
+        // SPA-163: build a slot-level adjacency map from the delta log so that
+        // edges written since the last checkpoint are visible for 2-hop queries.
+        // Map: src_slot → Vec<dst_slot> (only records whose src label matches).
+        let delta_adj: HashMap<u64, Vec<u64>> = {
+            let mut adj: HashMap<u64, Vec<u64>> = HashMap::new();
+            if let Ok(store) = EdgeStore::open(&self.db_root, RelTableId(0)) {
+                if let Ok(records) = store.read_delta() {
+                    for r in records {
+                        let r_src_label = (r.src.0 >> 32) as u32;
+                        let r_src_slot = r.src.0 & 0xFFFF_FFFF;
+                        if r_src_label == src_label_id {
+                            adj.entry(r_src_slot)
+                                .or_default()
+                                .push(r.dst.0 & 0xFFFF_FFFF);
+                        }
+                    }
+                }
+            }
+            adj
+        };
+
         let join = AspJoin::new(&self.csr);
         let mut rows = Vec::new();
 
@@ -397,8 +455,35 @@ impl Engine {
                 continue;
             }
 
-            // Use ASP-Join to get 2-hop fof.
-            let fof_slots = join.two_hop(src_slot)?;
+            // Use ASP-Join to get 2-hop fof from CSR.
+            let mut fof_slots = join.two_hop(src_slot)?;
+
+            // SPA-163: extend with delta-log 2-hop paths.
+            // First-hop delta neighbors of src_slot:
+            let first_hop_delta = delta_adj
+                .get(&src_slot)
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]);
+            if !first_hop_delta.is_empty() {
+                let mut delta_fof: HashSet<u64> = HashSet::new();
+                for &mid_slot in first_hop_delta {
+                    // CSR second hop from mid:
+                    for &fof in self.csr.neighbors(mid_slot) {
+                        delta_fof.insert(fof);
+                    }
+                    // Delta second hop from mid:
+                    if let Some(mid_neighbors) = delta_adj.get(&mid_slot) {
+                        for &fof in mid_neighbors {
+                            delta_fof.insert(fof);
+                        }
+                    }
+                }
+                fof_slots.extend(delta_fof);
+                // Re-deduplicate the combined set.
+                let unique: HashSet<u64> = fof_slots.into_iter().collect();
+                fof_slots = unique.into_iter().collect();
+                fof_slots.sort_unstable();
+            }
 
             for fof_slot in fof_slots {
                 let fof_node = NodeId(((fof_label_id as u64) << 32) | fof_slot);

--- a/crates/sparrowdb/tests/spa163_164_read_path.rs
+++ b/crates/sparrowdb/tests/spa163_164_read_path.rs
@@ -1,0 +1,193 @@
+//! Regression tests for SPA-163 and SPA-164 read-path bugs.
+//!
+//! SPA-163: Edges written via `WriteTx::create_edge` must be visible to hop
+//!          queries *without* a CHECKPOINT.
+//!
+//! SPA-164: Nodes deleted via `WriteTx::delete_node` must not appear in scan
+//!          results.
+
+use sparrowdb::open;
+use sparrowdb_catalog::catalog::Catalog;
+use sparrowdb_execution::types::Value as ExecValue;
+use sparrowdb_storage::node_store::Value;
+use std::collections::HashMap;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn db_dir() -> tempfile::TempDir {
+    tempfile::tempdir().expect("tempdir")
+}
+
+// ── SPA-163: delta log edges visible without checkpoint ───────────────────────
+
+/// Create Person nodes, connect them with a KNOWS edge, then query via MATCH
+/// without calling CHECKPOINT.  The edge lives only in the delta log at this
+/// point; the execution engine must consult the delta log to see it.
+#[test]
+fn spa163_delta_edges_visible_without_checkpoint() {
+    let dir = db_dir();
+    let db = open(dir.path()).expect("open db");
+
+    // Register the Person label and KNOWS relationship so the query engine can
+    // resolve them.  The catalog persists immediately on write; WriteTx does
+    // not expose create_rel_table, so we use the Catalog API directly.
+    let label_id;
+    {
+        let mut cat = Catalog::open(dir.path()).expect("catalog");
+        label_id = cat.create_label("Person").expect("create_label Person") as u32;
+        cat.create_rel_table(label_id as u16, label_id as u16, "KNOWS")
+            .expect("create_rel_table KNOWS");
+    }
+
+    // Create two Person nodes.
+    let alice;
+    let bob;
+    {
+        let mut tx = db.begin_write().unwrap();
+        alice = tx
+            .create_node(label_id, &[(0u32, Value::Int64(1))])
+            .expect("create Alice");
+        bob = tx
+            .create_node(label_id, &[(0u32, Value::Int64(2))])
+            .expect("create Bob");
+        tx.commit().unwrap();
+    }
+
+    // Connect Alice → Bob with a KNOWS edge.  No checkpoint — edge stays in
+    // the delta log.
+    {
+        let mut tx = db.begin_write().unwrap();
+        tx.create_edge(alice, bob, "KNOWS", HashMap::new())
+            .expect("create_edge");
+        tx.commit().unwrap();
+    }
+
+    // Execute a 1-hop query.  The delta log must be merged into the hop result.
+    let result = db
+        .execute("MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN b.col_0")
+        .expect("execute");
+
+    assert!(
+        !result.rows.is_empty(),
+        "SPA-163: delta log edges must be visible without checkpoint; got 0 rows"
+    );
+
+    // Bob's col_0 should be 2.
+    let bob_col0: Vec<i64> = result
+        .rows
+        .iter()
+        .filter_map(|row| match row.first() {
+            Some(ExecValue::Int64(v)) => Some(*v),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        bob_col0.contains(&2),
+        "SPA-163: expected Bob (col_0=2) in results; got {bob_col0:?}"
+    );
+}
+
+// ── SPA-164: tombstoned nodes invisible to scan ───────────────────────────────
+
+/// Create a Person node, delete it, then scan all Person nodes.  The deleted
+/// node must not appear in the results.
+#[test]
+fn spa164_deleted_node_absent_from_scan() {
+    let dir = db_dir();
+    let db = open(dir.path()).expect("open db");
+
+    // Register the Person label.
+    let label_id;
+    {
+        let mut cat = Catalog::open(dir.path()).expect("catalog");
+        label_id = cat.create_label("Person").expect("create_label Person") as u32;
+    }
+
+    // Create Alice (to survive deletion) and Dave (to be deleted).
+    let alice;
+    let dave;
+    {
+        let mut tx = db.begin_write().unwrap();
+        alice = tx
+            .create_node(label_id, &[(0u32, Value::Int64(1))])
+            .expect("create Alice");
+        dave = tx
+            .create_node(label_id, &[(0u32, Value::Int64(4))])
+            .expect("create Dave");
+        tx.commit().unwrap();
+    }
+    let _ = alice; // Alice stays alive.
+
+    // Delete Dave.
+    {
+        let mut tx = db.begin_write().unwrap();
+        tx.delete_node(dave).expect("delete_node");
+        tx.commit().unwrap();
+    }
+
+    // Scan all Person nodes.  Dave must not appear.
+    let result = db
+        .execute("MATCH (n:Person) RETURN n.col_0")
+        .expect("execute");
+
+    let col0_vals: Vec<i64> = result
+        .rows
+        .iter()
+        .filter_map(|row| match row.first() {
+            Some(ExecValue::Int64(v)) => Some(*v),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !col0_vals.contains(&4),
+        "SPA-164: deleted node (col_0=4, Dave) must not appear in scan; got {col0_vals:?}"
+    );
+
+    // Alice (col_0=1) should still be visible.
+    assert!(
+        col0_vals.contains(&1),
+        "SPA-164: live node (col_0=1, Alice) must remain visible; got {col0_vals:?}"
+    );
+}
+
+// ── SPA-164: tombstoned node col_0 sentinel is u64::MAX ─────────────────────
+
+/// Verify that the tombstone value (u64::MAX) stored in col_0 is correctly
+/// detected as "deleted" and not surfaced as an integer row.
+#[test]
+fn spa164_tombstone_sentinel_not_emitted() {
+    let dir = db_dir();
+    let db = open(dir.path()).expect("open db");
+
+    let label_id;
+    {
+        let mut cat = Catalog::open(dir.path()).expect("catalog");
+        label_id = cat.create_label("Widget").expect("create_label Widget") as u32;
+    }
+
+    // Create and immediately delete a single Widget node.
+    let widget;
+    {
+        let mut tx = db.begin_write().unwrap();
+        widget = tx
+            .create_node(label_id, &[(0u32, Value::Int64(42))])
+            .expect("create Widget");
+        tx.commit().unwrap();
+    }
+    {
+        let mut tx = db.begin_write().unwrap();
+        tx.delete_node(widget).expect("delete_node Widget");
+        tx.commit().unwrap();
+    }
+
+    let result = db
+        .execute("MATCH (w:Widget) RETURN w.col_0")
+        .expect("execute");
+
+    assert!(
+        result.rows.is_empty(),
+        "SPA-164: all rows for a fully-deleted label must be empty; got {} rows",
+        result.rows.len()
+    );
+}


### PR DESCRIPTION
## **User description**
## Summary

- **SPA-163**: `execute_one_hop` and `execute_two_hop` now read the edge delta log and merge its entries with CSR neighbors, making edges visible immediately after write without requiring a CHECKPOINT.
- **SPA-164**: `execute_scan` checks each node slot's `col_0` value before emitting it; slots with `col_0 == u64::MAX` (the tombstone sentinel written by `delete_node`) are skipped.
- Three regression tests added in `crates/sparrowdb/tests/spa163_164_read_path.rs` covering both bugs.

## Root causes

**SPA-163**: `execute_one_hop` called `self.csr.neighbors(src_slot)` exclusively. New edges go to `edges/0/delta.log` and are not in the CSR until a `CHECKPOINT` folds them in. Fix: after reading CSR neighbors, open `EdgeStore`, call `read_delta()`, filter records whose `src` matches the current `(src_label_id, src_slot)`, and chain the decoded `dst` slots into the neighbor iteration.

**SPA-164**: `execute_scan` iterated all slots 0..hwm without checking for deletion. `delete_node` writes `u64::MAX` into `col_0.bin` at the node's slot offset. Fix: read `col_0` before emitting the row; `continue` if the value is `u64::MAX`.

## Test plan

- [ ] `cargo test --package sparrowdb --test spa163_164_read_path` — 3 new regression tests, all green
- [ ] `cargo test --workspace` — all existing tests continue to pass (0 failures)
- [ ] `cargo clippy --all-targets -- -D warnings` — no errors
- [ ] `cargo fmt --all` — no diff

Closes SPA-163
Closes SPA-164
Fixes https://github.com/ryaker/SparrowDB/issues/25
Fixes https://github.com/ryaker/SparrowDB/issues/26

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show newly written edges in hop queries and hide deleted nodes from scans**

### What Changed
- 1-hop and 2-hop graph queries now include edges that were just written, even before a checkpoint runs.
- Scans now skip nodes that were deleted, so removed records no longer appear in query results.
- Added regression tests covering visible new edges, missing deleted nodes, and the deleted-node sentinel case.

### Impact
`✅ Faster edge visibility after writes`
`✅ Fewer stale graph query results`
`✅ Clearer scan results after deletions`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
