### PR TITLE
SPA-158, SPA-159: Register rel type in catalog; make merge_node idempotent

### DIFF
--- a/crates/sparrowdb-catalog/src/catalog.rs
+++ b/crates/sparrowdb-catalog/src/catalog.rs
@@ -75,6 +75,17 @@ impl Catalog {
         Ok(id)
     }
 
+    /// Find or create a label by name, returning its id.
+    ///
+    /// If the label already exists, returns the existing id.
+    /// If it does not exist, creates it and returns the new id.
+    pub fn get_or_create_label_id(&mut self, name: &str) -> Result<LabelId> {
+        if let Some(id) = self.get_label(name)? {
+            return Ok(id);
+        }
+        self.create_label(name)
+    }
+
     /// Look up a label by name.
     pub fn get_label(&self, name: &str) -> Result<Option<LabelId>> {
         Ok(self
@@ -94,6 +105,22 @@ impl Catalog {
     }
 
     // --- Relationship table CRUD ---
+
+    /// Find or create a relationship table entry for `(src_label_id, dst_label_id, rel_type)`.
+    ///
+    /// If a matching entry already exists, returns its id.
+    /// Otherwise creates a new entry, persists it to disk, and returns the new id.
+    pub fn get_or_create_rel_type_id(
+        &mut self,
+        src_label_id: u16,
+        dst_label_id: u16,
+        rel_type: &str,
+    ) -> Result<RelTableId> {
+        if let Some(id) = self.get_rel_table(src_label_id, dst_label_id, rel_type)? {
+            return Ok(id);
+        }
+        self.create_rel_table(src_label_id, dst_label_id, rel_type)
+    }
 
     /// Create a new relationship table entry.
     pub fn create_rel_table(

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -568,6 +568,8 @@ impl<'db> WriteTx<'db> {
     /// SPA-126: Create a directed edge `src → dst` with the given type.
     ///
     /// Appends to the edge delta log and queues an `EdgeCreate` WAL record.
+    /// Registers the relationship type name in the catalog so that queries
+    /// like `MATCH (a)-[:REL]->(b)` can resolve the type (SPA-158).
     /// Returns the new [`EdgeId`].
     pub fn create_edge(
         &mut self,
@@ -576,8 +578,20 @@ impl<'db> WriteTx<'db> {
         rel_type: &str,
         _props: HashMap<String, Value>,
     ) -> Result<EdgeId> {
-        let mut es = EdgeStore::open(&self.inner.path, RelTableId(0))?;
-        let edge_id = es.create_edge(src, RelTableId(0), dst)?;
+        // Derive label IDs from the packed node IDs (upper 32 bits).
+        let src_label_id = (src.0 >> 32) as u16;
+        let dst_label_id = (dst.0 >> 32) as u16;
+
+        // Register (or retrieve) the rel type in the catalog so that the
+        // binder can resolve `[:REL_TYPE]` patterns in Cypher queries.
+        // The catalog returns a u64 id; the storage layer uses a u32 newtype.
+        let catalog_rel_id =
+            self.catalog
+                .get_or_create_rel_type_id(src_label_id, dst_label_id, rel_type)?;
+        let rel_table_id = RelTableId(catalog_rel_id as u32);
+
+        let mut es = EdgeStore::open(&self.inner.path, rel_table_id)?;
+        let edge_id = es.create_edge(src, rel_table_id, dst)?;
         self.wal_mutations.push(WalMutation::EdgeCreate {
             edge_id,
             src,

--- a/crates/sparrowdb/tests/phase7_mutation.rs
+++ b/crates/sparrowdb/tests/phase7_mutation.rs
@@ -526,3 +526,123 @@ fn write_write_conflict_path_returns_error() {
 
     drop(dir);
 }
+
+// ── SPA-158: create_edge registers rel type in catalog ────────────────────────
+
+/// After `create_edge`, the relationship type name must be persisted in the
+/// catalog so that Cypher queries with `[:REL_TYPE]` can resolve the type.
+#[test]
+fn create_edge_registers_rel_type_in_catalog() {
+    let (dir, db) = make_db();
+
+    // Create two nodes with label_id=0.
+    let (alice, bob);
+    {
+        let mut tx = db.begin_write().unwrap();
+        alice = tx.create_node(0, &[(0u32, Value::Int64(1))]).unwrap();
+        bob = tx.create_node(0, &[(0u32, Value::Int64(2))]).unwrap();
+        tx.commit().unwrap();
+    }
+
+    // Create an edge with rel_type "KNOWS".
+    {
+        let mut tx = db.begin_write().unwrap();
+        tx.create_edge(alice, bob, "KNOWS", HashMap::new())
+            .expect("create_edge must succeed");
+        tx.commit().unwrap();
+    }
+
+    // Reopen the catalog and verify "KNOWS" is registered.
+    {
+        let catalog = sparrowdb_catalog::catalog::Catalog::open(dir.path()).unwrap();
+        let tables = catalog.list_rel_tables().unwrap();
+        let found = tables.iter().any(|(_, _, rt)| rt == "KNOWS");
+        assert!(
+            found,
+            "rel type 'KNOWS' must be persisted in catalog after create_edge, got: {tables:?}"
+        );
+    }
+
+    drop(dir);
+}
+
+/// Calling `create_edge` twice with the same rel_type must not create duplicate
+/// catalog entries — the second call is idempotent in the catalog.
+#[test]
+fn create_edge_rel_type_catalog_idempotent() {
+    let (dir, db) = make_db();
+
+    let (a, b);
+    {
+        let mut tx = db.begin_write().unwrap();
+        a = tx.create_node(0, &[(0u32, Value::Int64(10))]).unwrap();
+        b = tx.create_node(0, &[(0u32, Value::Int64(20))]).unwrap();
+        tx.commit().unwrap();
+    }
+
+    // Create the same rel_type twice across two transactions.
+    for _ in 0..2 {
+        let mut tx = db.begin_write().unwrap();
+        tx.create_edge(a, b, "FOLLOWS", HashMap::new())
+            .expect("create_edge must succeed");
+        tx.commit().unwrap();
+    }
+
+    // Only one catalog entry should exist for "FOLLOWS".
+    {
+        let catalog = sparrowdb_catalog::catalog::Catalog::open(dir.path()).unwrap();
+        let tables = catalog.list_rel_tables().unwrap();
+        let count = tables.iter().filter(|(_, _, rt)| rt == "FOLLOWS").count();
+        assert_eq!(
+            count, 1,
+            "rel type 'FOLLOWS' must appear exactly once in catalog, got: {tables:?}"
+        );
+    }
+
+    drop(dir);
+}
+
+// ── SPA-159: merge_node is idempotent within the same transaction ─────────────
+
+/// Calling `merge_node` twice within a single `WriteTx` must return the same
+/// `NodeId` — the second call must find the node written by the first call
+/// (visible through the in-memory node store) rather than creating a new slot.
+#[test]
+fn merge_node_idempotent_within_single_tx() {
+    let (dir, db) = make_db();
+
+    let mut props = HashMap::new();
+    props.insert("name".to_string(), Value::Int64(9001));
+
+    let (id1, id2);
+    {
+        let mut tx = db.begin_write().unwrap();
+        id1 = tx
+            .merge_node("Topic", props.clone())
+            .expect("first merge_node");
+        id2 = tx
+            .merge_node("Topic", props.clone())
+            .expect("second merge_node within same tx");
+        tx.commit().unwrap();
+    }
+
+    assert_eq!(
+        id1, id2,
+        "merge_node called twice within the same tx must return the same NodeId"
+    );
+
+    // Verify only one node was created.
+    let store = sparrowdb_storage::node_store::NodeStore::open(dir.path()).unwrap();
+    let catalog = sparrowdb_catalog::catalog::Catalog::open(dir.path()).unwrap();
+    let label_id = catalog
+        .get_label("Topic")
+        .unwrap()
+        .expect("Topic label must exist") as u32;
+    let hwm = store.hwm_for_label(label_id).unwrap();
+    assert_eq!(
+        hwm, 1,
+        "exactly one node must exist after two identical merges in same tx"
+    );
+
+    drop(dir);
+}


### PR DESCRIPTION
## **User description**
## Summary

- **SPA-158**: `create_edge` now calls `catalog.get_or_create_rel_type_id(src_label_id, dst_label_id, rel_type)` before writing the edge delta, persisting the relationship type name→id mapping to disk. Without this, `MATCH (a)-[:KNOWS]->(b)` failed with "unknown relationship type: KNOWS" because the binder could not find the type in the catalog.
- **SPA-159**: Added `Catalog::get_or_create_label_id` and `get_or_create_rel_type_id` helpers (idempotent find-or-create, persisted on first call). The existing `merge_node` scan logic was correct for cross-transaction usage (existing test already passed); the same-tx idempotency path is now explicitly tested.

## Changes

- `crates/sparrowdb-catalog/src/catalog.rs`: Added `get_or_create_label_id` and `get_or_create_rel_type_id` methods
- `crates/sparrowdb/src/lib.rs`: Fixed `create_edge` to derive label IDs from packed NodeIds and register the rel type in the catalog before writing the edge delta
- `crates/sparrowdb/tests/phase7_mutation.rs`: Three new integration tests

## Test plan

- [ ] `create_edge_registers_rel_type_in_catalog` — verifies the rel type name is in the catalog after `create_edge`
- [ ] `create_edge_rel_type_catalog_idempotent` — verifies calling `create_edge` twice with the same rel_type produces exactly one catalog entry
- [ ] `merge_node_idempotent_within_single_tx` — verifies `merge_node` called twice in the same `WriteTx` returns the same `NodeId` and creates only one node
- [ ] All existing tests continue to pass (`cargo test --workspace`)
- [ ] `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings` clean

Closes SPA-158
Closes SPA-159
Fixes https://github.com/ryaker/SparrowDB/issues/21
Fixes https://github.com/ryaker/SparrowDB/issues/22

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Register relationship types when edges are created and keep repeated merges from creating duplicates**

### What Changed
- Creating an edge now saves its relationship type in the catalog, so queries like `MATCH (a)-[:KNOWS]->(b)` can find and use that type later.
- Creating the same relationship type again reuses the existing catalog entry instead of adding a duplicate.
- Calling `merge_node` twice in the same write transaction now returns the same node and creates only one record.
- Added tests that cover relationship type registration, duplicate prevention, and same-transaction merge behavior.

### Impact
`✅ Fewer missing relationship type errors in graph queries`
`✅ No duplicate relationship type entries after repeated edge creation`
`✅ Fewer duplicate nodes from repeated merges in one transaction`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
