### PR TITLE
SPA-166: Flush node store to disk on CREATE — MATCH finds created nodes

### DIFF
--- a/crates/sparrowdb-storage/src/node_store.rs
+++ b/crates/sparrowdb-storage/src/node_store.rs
@@ -144,9 +144,17 @@ impl NodeStore {
     }
 
     /// Read the `u64` stored at `slot` in the given column file.
+    ///
+    /// Returns `Ok(0)` when the column file does not exist yet — a missing file
+    /// means no value has ever been written for this `(label_id, col_id)` pair,
+    /// which is represented as the zero bit-pattern (SPA-166).
     fn read_col_slot(&self, label_id: u32, col_id: u32, slot: u32) -> Result<u64> {
         let path = self.col_path(label_id, col_id);
-        let bytes = fs::read(&path).map_err(Error::Io)?;
+        let bytes = match fs::read(&path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+            Err(e) => return Err(Error::Io(e)),
+        };
         let offset = slot as usize * 8;
         if bytes.len() < offset + 8 {
             return Err(Error::NotFound);


### PR DESCRIPTION
## **User description**
## Summary

- The SPA-164 tombstone check in `execute_scan` reads `col_id = 0u32` (the literal integer zero) to detect deleted nodes
- Column IDs are FNV-1a hashes of property names, so `col_0.bin` is **never created** by `execute_create`
- `read_col_slot` propagated the `NotFound` I/O error, causing every `MATCH` to fail with `os error 2` after any `CREATE`
- Fix: return `Ok(0)` from `read_col_slot` when the column file is absent — absence means "no value written", which is distinct from the `u64::MAX` tombstone sentinel

## Change

Single-file change in `crates/sparrowdb-storage/src/node_store.rs`: `read_col_slot` now returns `Ok(0)` on `ErrorKind::NotFound` instead of propagating the I/O error.

## Test plan

- [x] Reproduce: `CREATE (:Person {name: 'Alice'})` exits 0; subsequent `MATCH (p:Person) RETURN p.name` returned `os error 2` — confirmed before fix
- [x] After fix: two separate process invocations persist and read nodes correctly
- [x] `cargo test --workspace` — all 0 failures across all crates
- [x] Alice and Bob nodes created in separate CLI invocations are visible in subsequent MATCH scan

Closes SPA-166

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep MATCH working after CREATE**

### What Changed
- A missing column file is now treated as “no value yet” instead of an error
- After creating nodes, later MATCH queries can read them without failing with a file-not-found error
- Nodes without a stored property value are still recognized correctly

### Impact
`✅ MATCH works after CREATE`
`✅ Fewer file-not-found query failures`
`✅ Reliable reads for newly created nodes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
