### PR TITLE
test(e2e): add UNION/UNION ALL integration tests — SPA-132

### DIFF
--- a/crates/sparrowdb/tests/spa_132_union.rs
+++ b/crates/sparrowdb/tests/spa_132_union.rs
@@ -1,0 +1,222 @@
+//! SPA-132: UNION / UNION ALL — integration tests.
+//!
+//! Exercises the full parse → bind → execute path on a real tempdir-backed
+//! database (no mocks, real WAL and catalog).
+//!
+//! Syntax: `MATCH ... RETURN ... UNION [ALL] MATCH ... RETURN ...`
+//! - `UNION ALL` — concatenates both row sets, keeping duplicates.
+//! - `UNION`     — concatenates and deduplicates identical rows.
+
+use sparrowdb::GraphDb;
+use sparrowdb_execution::types::Value;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn open_db(dir: &std::path::Path) -> GraphDb {
+    GraphDb::open(dir).expect("open db")
+}
+
+// ── Test 1: UNION ALL combines results from both sides ────────────────────────
+
+#[test]
+fn union_combines_results() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    db.execute("CREATE (:Person {name: 'Alice', age: 30})").unwrap();
+    db.execute("CREATE (:Person {name: 'Bob', age: 25})").unwrap();
+    db.execute("CREATE (:Person {name: 'Carol', age: 35})").unwrap();
+
+    // UNION ALL of two disjoint WHERE-filtered sides — combined they cover all 3 rows.
+    let result = db
+        .execute(
+            "MATCH (n:Person) WHERE n.age > 28 RETURN n.age \
+             UNION ALL \
+             MATCH (n:Person) WHERE n.age < 28 RETURN n.age",
+        )
+        .expect("UNION ALL must succeed");
+
+    // Left: Alice(30), Carol(35) = 2 rows; Right: Bob(25) = 1 row → total 3.
+    assert_eq!(
+        result.rows.len(),
+        3,
+        "UNION ALL of age>28 and age<28 must return 3 rows, got {:?}",
+        result.rows
+    );
+    assert_eq!(result.columns, vec!["n.age"]);
+}
+
+// ── Test 2: UNION deduplicates identical rows ─────────────────────────────────
+
+#[test]
+fn union_deduplicates() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    db.execute("CREATE (:Person {name: 'Alice', age: 30})").unwrap();
+    db.execute("CREATE (:Person {name: 'Bob', age: 25})").unwrap();
+
+    // Both sides return all Person ages — UNION must deduplicate so we get 2 unique rows.
+    let result = db
+        .execute(
+            "MATCH (n:Person) RETURN n.age \
+             UNION \
+             MATCH (n:Person) RETURN n.age",
+        )
+        .expect("UNION must succeed");
+
+    // Without dedup we'd get 4 rows; with dedup we get 2 unique ages.
+    assert_eq!(
+        result.rows.len(),
+        2,
+        "UNION must deduplicate, expected 2 unique age rows, got {:?}",
+        result.rows
+    );
+}
+
+// ── Test 3: UNION ALL keeps duplicates ───────────────────────────────────────
+
+#[test]
+fn union_all_keeps_duplicates() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    db.execute("CREATE (:Person {name: 'Alice', age: 30})").unwrap();
+    db.execute("CREATE (:Person {name: 'Bob', age: 25})").unwrap();
+
+    // Both sides return all Person ages — UNION ALL must keep all 4 rows (2+2).
+    let result = db
+        .execute(
+            "MATCH (n:Person) RETURN n.age \
+             UNION ALL \
+             MATCH (n:Person) RETURN n.age",
+        )
+        .expect("UNION ALL must succeed");
+
+    assert_eq!(
+        result.rows.len(),
+        4,
+        "UNION ALL must keep duplicates, expected 4 rows (2+2), got {:?}",
+        result.rows
+    );
+}
+
+// ── Test 4: UNION combining different label sets ──────────────────────────────
+
+#[test]
+fn union_different_label_sets() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    db.execute("CREATE (:Person {name: 'Alice'})").unwrap();
+    db.execute("CREATE (:Person {name: 'Bob'})").unwrap();
+    db.execute("CREATE (:Company {name: 'Acme'})").unwrap();
+
+    // UNION names from Person label and Company label — both project n.name.
+    let result = db
+        .execute(
+            "MATCH (n:Person) RETURN n.name \
+             UNION ALL \
+             MATCH (n:Company) RETURN n.name",
+        )
+        .expect("UNION ALL across label sets must succeed");
+
+    // 2 Person rows + 1 Company row = 3 total.
+    assert_eq!(
+        result.rows.len(),
+        3,
+        "UNION ALL across Person+Company must return 3 rows, got {:?}",
+        result.rows
+    );
+    assert_eq!(result.columns, vec!["n.name"]);
+
+    // All values must be non-null.
+    for row in &result.rows {
+        assert_ne!(
+            row[0],
+            Value::Null,
+            "expected non-null name in union result, got {:?}",
+            row
+        );
+    }
+}
+
+// ── Test 5: UNION when left side produces no rows ────────────────────────────
+//
+// Both sides scan the same label but left uses a WHERE predicate that matches
+// no nodes.  The engine must return only the right-side rows (no error).
+
+#[test]
+fn union_empty_left() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    db.execute("CREATE (:Person {name: 'Alice', age: 30})").unwrap();
+    db.execute("CREATE (:Person {name: 'Bob', age: 25})").unwrap();
+
+    // Left side: WHERE age > 100 → matches nobody (0 rows).
+    // Right side: no predicate → 2 rows.
+    let result = db
+        .execute(
+            "MATCH (n:Person) WHERE n.age > 100 RETURN n.age \
+             UNION ALL \
+             MATCH (n:Person) RETURN n.age",
+        )
+        .expect("UNION ALL with empty left must succeed");
+
+    assert_eq!(
+        result.rows.len(),
+        2,
+        "when left produces no rows, UNION ALL must return right-side rows, got {:?}",
+        result.rows
+    );
+
+    // All returned values must be non-null integers.
+    for row in &result.rows {
+        assert!(
+            matches!(row[0], Value::Int64(_)),
+            "expected Int64 age values from right side, got {:?}",
+            row[0]
+        );
+    }
+}
+
+// ── Test 6: UNION when right side produces no rows ───────────────────────────
+//
+// Both sides scan the same label but right uses a WHERE predicate that matches
+// no nodes.  The engine must return only the left-side rows (no error).
+
+#[test]
+fn union_empty_right() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    db.execute("CREATE (:Person {name: 'Alice', age: 30})").unwrap();
+    db.execute("CREATE (:Person {name: 'Bob', age: 25})").unwrap();
+
+    // Left side: no predicate → 2 rows.
+    // Right side: WHERE age > 100 → matches nobody (0 rows).
+    let result = db
+        .execute(
+            "MATCH (n:Person) RETURN n.age \
+             UNION ALL \
+             MATCH (n:Person) WHERE n.age > 100 RETURN n.age",
+        )
+        .expect("UNION ALL with empty right must succeed");
+
+    assert_eq!(
+        result.rows.len(),
+        2,
+        "when right produces no rows, UNION ALL must return left-side rows, got {:?}",
+        result.rows
+    );
+
+    // All returned values must be non-null integers.
+    for row in &result.rows {
+        assert!(
+            matches!(row[0], Value::Int64(_)),
+            "expected Int64 age values from left side, got {:?}",
+            row[0]
+        );
+    }
+}


### PR DESCRIPTION
## **User description**
## Summary

- Adds `crates/sparrowdb/tests/spa_132_union.rs` with 6 integration tests covering all UNION semantics on real disk (tempdir-backed `GraphDb`, real WAL and catalog, no mocks)
- Tests: `union_combines_results`, `union_deduplicates`, `union_all_keeps_duplicates`, `union_different_label_sets`, `union_empty_left`, `union_empty_right`
- Empty-side tests use `WHERE` predicates that return 0 rows rather than non-existent labels (the binder rejects unknown labels in `MATCH` by design — consistent with existing engine behavior)

## Test plan

- [x] `cargo test --test spa_132_union` — all 6 tests pass
- [x] `cargo test` — full suite green, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add end-to-end coverage for UNION and UNION ALL query behavior**

### What Changed
- Added integration tests that run UNION queries against a real database, covering result combination, duplicate removal, and duplicate preservation
- Added coverage for UNION across different labels so name results from separate node types can be returned together
- Added coverage for cases where one side returns no rows, confirming the other side still returns results without error

### Impact
`✅ Safer UNION query behavior`
`✅ Fewer query result mismatches`
`✅ Clearer coverage for empty-side UNION queries`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
