### PR TITLE
fix(engine): decode string props as Value::String in RETURN (SPA-169)

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -1259,11 +1259,14 @@ fn matches_prop_filter_static(
         let stored_val = props.iter().find(|(c, _)| *c == col_id).map(|(_, v)| *v);
 
         let matches = match &f.value {
-            Literal::Int(n) => stored_val == Some(*n as u64),
+            Literal::Int(n) => {
+                // Int64 values are stored with TAG_INT64 (0x00) in the top byte.
+                // Use StoreValue::to_u64() for canonical encoding (SPA-169).
+                stored_val == Some(StoreValue::Int64(*n).to_u64())
+            }
             Literal::String(s) => {
-                // Strings are stored inline as up to 8 bytes packed into a
-                // u64 (little-endian, zero-padded).  Encode the literal the
-                // same way and compare against the stored raw value (SPA-161).
+                // Strings are stored with TAG_BYTES (0x01) in the top byte.
+                // Encode the literal the same way and compare (SPA-161, SPA-169).
                 stored_val == Some(string_to_raw_u64(s))
             }
             Literal::Param(_) => true, // params always pass in current impl
@@ -1431,16 +1434,13 @@ fn literal_to_store_value(lit: &Literal) -> StoreValue {
     }
 }
 
-/// Encode a string literal the same way the storage layer does (inline ≤ 8 bytes).
+/// Encode a string literal using the type-tagged storage encoding (SPA-169).
 ///
-/// Returns the `u64` that `StoreValue::Bytes(s.as_bytes()).to_u64()` would produce,
-/// allowing WHERE-clause string comparisons against raw column values.
+/// Returns the `u64` that `StoreValue::Bytes(s.as_bytes()).to_u64()` produces
+/// with the new tagged encoding, allowing prop-filter and WHERE-clause
+/// comparisons against stored raw column values.
 fn string_to_raw_u64(s: &str) -> u64 {
-    let b = s.as_bytes();
-    let mut arr = [0u8; 8];
-    let len = b.len().min(8);
-    arr[..len].copy_from_slice(&b[..len]);
-    u64::from_le_bytes(arr)
+    StoreValue::Bytes(s.as_bytes().to_vec()).to_u64()
 }
 
 /// Map a property name like "col_0" or "name" to a col_id.
@@ -1494,6 +1494,19 @@ fn collect_col_ids_for_var(var: &str, column_names: &[String], _label_id: u32) -
     ids
 }
 
+/// Decode a raw `u64` column value (as returned by `get_node_raw`) into the
+/// execution-layer `Value` type.
+///
+/// Uses `StoreValue::from_u64` to honour the type tag embedded in the top
+/// byte (SPA-169), then maps `StoreValue::Bytes` → `Value::String` so that
+/// string properties are returned as strings, not garbage integers.
+fn decode_raw_val(raw: u64) -> Value {
+    match StoreValue::from_u64(raw) {
+        StoreValue::Int64(n) => Value::Int64(n),
+        StoreValue::Bytes(b) => Value::String(String::from_utf8_lossy(&b).into_owned()),
+    }
+}
+
 fn build_row_vals(
     props: &[(u32, u64)],
     var_name: &str,
@@ -1502,7 +1515,7 @@ fn build_row_vals(
     let mut map = HashMap::new();
     for &(col_id, raw) in props {
         let key = format!("{var_name}.col_{col_id}");
-        map.insert(key, Value::Int64(raw as i64));
+        map.insert(key, decode_raw_val(raw));
     }
     map
 }
@@ -1518,10 +1531,25 @@ fn values_equal(a: &Value, b: &Value) -> bool {
     match (a, b) {
         // Normal same-type comparisons.
         (Value::Int64(x), Value::Int64(y)) => x == y,
-        (Value::String(x), Value::String(y)) => x == y,
+        (Value::String(x), Value::String(y)) => {
+            // First try exact match (short strings, or both full strings).
+            if x == y {
+                return true;
+            }
+            // If the stored value was decoded from the 7-byte inline encoding,
+            // it is truncated.  Compare using the inline-encoded forms so that
+            // a truncated stored value matches the corresponding full literal
+            // (SPA-169).  Two distinct strings that share the same first 7
+            // bytes will incorrectly compare equal — this is an accepted
+            // limitation of the v1 inline encoding (overflow deferred).
+            StoreValue::Bytes(x.as_bytes().to_vec()).to_u64()
+                == StoreValue::Bytes(y.as_bytes().to_vec()).to_u64()
+        }
         (Value::Bool(x), Value::Bool(y)) => x == y,
         (Value::Float64(x), Value::Float64(y)) => x == y,
-        // Mixed: stored raw-int vs string literal — compare via inline encoding.
+        // Mixed: stored raw-int vs string literal — kept for backwards
+        // compatibility; should not be triggered after SPA-169 since string
+        // props are now decoded to Value::String by decode_raw_val.
         (Value::Int64(raw), Value::String(s)) => *raw as u64 == string_to_raw_u64(s),
         (Value::String(s), Value::Int64(raw)) => string_to_raw_u64(s) == *raw as u64,
         // Null is only equal to null.
@@ -1676,7 +1704,7 @@ fn project_row(props: &[(u32, u64)], column_names: &[String], _col_ids: &[u32]) 
             props
                 .iter()
                 .find(|(c, _)| *c == col_id)
-                .map(|(_, v)| Value::Int64(*v as i64))
+                .map(|(_, v)| decode_raw_val(*v))
                 .unwrap_or(Value::Null)
         })
         .collect()
@@ -1698,7 +1726,7 @@ fn project_hop_row(
                 props
                     .iter()
                     .find(|(c, _)| *c == col_id)
-                    .map(|(_, val)| Value::Int64(*val as i64))
+                    .map(|(_, val)| decode_raw_val(*val))
                     .unwrap_or(Value::Null)
             } else {
                 Value::Null
@@ -1724,7 +1752,7 @@ fn project_fof_row(
             fof_props
                 .iter()
                 .find(|(c, _)| *c == col_id)
-                .map(|(_, v)| Value::Int64(*v as i64))
+                .map(|(_, v)| decode_raw_val(*v))
                 .unwrap_or(Value::Null)
         })
         .collect()

--- a/crates/sparrowdb-storage/src/node_store.rs
+++ b/crates/sparrowdb-storage/src/node_store.rs
@@ -46,21 +46,76 @@ pub enum Value {
     Bytes(Vec<u8>),
 }
 
+/// Type tag embedded in the top byte (byte index 7 in LE) of a stored `u64`.
+///
+/// - `0x00` = `Int64`  — lower 7 bytes hold the signed integer (56-bit range).
+/// - `0x01` = `Bytes`  — lower 7 bytes hold up to 7 bytes of inline string data.
+///
+/// This encoding lets `from_u64` reconstruct the original `Value` variant
+/// without needing an out-of-band schema lookup, fixing SPA-169.
+const TAG_INT64: u8 = 0x00;
+const TAG_BYTES: u8 = 0x01;
+
 impl Value {
     /// Encode as a packed `u64` for column storage.
+    ///
+    /// The top byte (byte 7 in little-endian) is a type tag; the remaining
+    /// 7 bytes carry the payload.  This allows `from_u64` to reconstruct the
+    /// correct variant at read time (SPA-169).
+    ///
+    /// # Int64 range
+    /// Only the lower 56 bits of the integer are stored.  This covers all
+    /// practical node IDs and numeric property values; very large i64 values
+    /// (> 2^55 or < -2^55) would be truncated.  Full 64-bit range is deferred
+    /// to a later overflow encoding.
     pub fn to_u64(&self) -> u64 {
         match self {
-            Value::Int64(v) => *v as u64,
+            Value::Int64(v) => {
+                // Top byte = TAG_INT64 (0x00); lower 7 bytes = lower 56 bits of v.
+                // For TAG_INT64 = 0x00 this is just the value masked to 56 bits,
+                // which is a no-op for any i64 whose top byte is already 0x00.
+                let payload = (*v as u64) & 0x00FF_FFFF_FFFF_FFFF;
+                // Tag byte goes into byte 7 (the most significant byte in LE).
+                payload | ((TAG_INT64 as u64) << 56)
+            }
             Value::Bytes(b) => {
                 let mut arr = [0u8; 8];
-                let len = b.len().min(8);
+                arr[7] = TAG_BYTES; // type tag in top byte
+                let len = b.len().min(7);
                 arr[..len].copy_from_slice(&b[..len]);
                 u64::from_le_bytes(arr)
             }
         }
     }
 
+    /// Reconstruct a `Value` from a stored `u64`, using the top byte as a
+    /// type tag (SPA-169).
+    pub fn from_u64(v: u64) -> Self {
+        let bytes = v.to_le_bytes(); // bytes[7] = top byte = tag
+        match bytes[7] {
+            TAG_BYTES => {
+                // Inline string: bytes[0..7] hold the data; strip trailing zeros.
+                let data: Vec<u8> = bytes[..7]
+                    .iter()
+                    .copied()
+                    .take_while(|&b| b != 0)
+                    .collect();
+                Value::Bytes(data)
+            }
+            _ => {
+                // TAG_INT64 (0x00) or any unrecognised tag → Int64.
+                // Sign-extend from 56 bits: shift left 8 to bring bit 55 into
+                // sign position, then arithmetic shift right 8.
+                let shifted = (v << 8) as i64;
+                Value::Int64(shifted >> 8)
+            }
+        }
+    }
+
     /// Reconstruct an `Int64` value from a stored `u64`.
+    ///
+    /// Preserved for callers that know the column type is always Int64 (e.g.
+    /// pre-SPA-169 paths).  New code should prefer `from_u64`.
     pub fn int64_from_u64(v: u64) -> Self {
         Value::Int64(v as i64)
     }
@@ -328,15 +383,17 @@ impl NodeStore {
         Ok(result)
     }
 
-    /// Retrieve the `Int64` property values for a node.
+    /// Retrieve the typed property values for a node.
     ///
-    /// Convenience wrapper over [`get_node_raw`] that interprets every column
-    /// as an `Int64` (two's-complement re-interpretation of the stored `u64`).
+    /// Convenience wrapper over [`get_node_raw`] that uses the type tag
+    /// embedded in the stored `u64` to reconstruct the correct `Value` variant
+    /// (SPA-169).  The returned `Value` will be `Int64` or `Bytes` depending
+    /// on what was written by `create_node`.
     pub fn get_node(&self, node_id: NodeId, col_ids: &[u32]) -> Result<Vec<(u32, Value)>> {
         let raw = self.get_node_raw(node_id, col_ids)?;
         Ok(raw
             .into_iter()
-            .map(|(col_id, v)| (col_id, Value::int64_from_u64(v)))
+            .map(|(col_id, v)| (col_id, Value::from_u64(v)))
             .collect())
     }
 }

--- a/crates/sparrowdb/tests/spa_130_with_clause.rs
+++ b/crates/sparrowdb/tests/spa_130_with_clause.rs
@@ -82,19 +82,12 @@ fn spa130_with_where_string_filter() {
         result.rows.len()
     );
 
-    // Verify the surviving row contains the Alice string (stored as raw u64
-    // little-endian bytes in the current storage encoding).
+    // SPA-169: string properties are now decoded to Value::String, not raw Int64.
     use sparrowdb_execution::types::Value;
-    let alice_raw: u64 = {
-        let b = b"Alice";
-        let mut arr = [0u8; 8];
-        arr[..b.len()].copy_from_slice(b);
-        u64::from_le_bytes(arr)
-    };
     assert_eq!(
         result.rows[0][0],
-        Value::Int64(alice_raw as i64),
-        "surviving row must encode 'Alice' as raw u64"
+        Value::String("Alice".to_string()),
+        "surviving row must return 'Alice' as a String (SPA-169 fix)"
     );
 }
 

--- a/crates/sparrowdb/tests/spa_169_string_props.rs
+++ b/crates/sparrowdb/tests/spa_169_string_props.rs
@@ -1,0 +1,235 @@
+//! End-to-end tests for SPA-169.
+//!
+//! Before this fix, `RETURN n.name` returned a raw `Int64` bit-pattern instead
+//! of the actual string value.  The root cause was that `get_node_raw` returned
+//! `u64` values and `build_row_vals`/`project_row` blindly reinterpreted them
+//! as `Int64`, discarding the type information written by `literal_to_store_value`.
+//!
+//! The fix embeds a type tag in the top byte of every stored `u64`:
+//!   - `0x00` → `Int64`  (7-byte signed payload)
+//!   - `0x01` → `Bytes`  (up to 7 inline bytes of string data)
+//!
+//! `decode_raw_val` now reads the tag and returns `Value::String` or `Value::Int64`
+//! accordingly, so `RETURN n.name` returns the correct string.
+
+use sparrowdb_catalog::catalog::Catalog;
+use sparrowdb_execution::engine::Engine;
+use sparrowdb_execution::types::Value;
+use sparrowdb_storage::csr::CsrForward;
+use sparrowdb_storage::node_store::NodeStore;
+
+/// Build a fresh engine backed by a temp directory.
+fn fresh_engine(dir: &std::path::Path) -> Engine {
+    let store = NodeStore::open(dir).expect("node store");
+    let cat = Catalog::open(dir).expect("catalog");
+    let csr = CsrForward::build(0, &[]);
+    Engine::new(store, cat, csr, dir)
+}
+
+// ── SPA-169: string property round-trips ─────────────────────────────────────
+
+/// CREATE a node with a string property, MATCH and RETURN it — must be a String,
+/// not a garbage Int64.
+#[test]
+fn string_prop_round_trips() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut engine = fresh_engine(dir.path());
+
+    engine
+        .execute("CREATE (n:Person {name: 'Alice'})")
+        .expect("CREATE");
+
+    let result = engine
+        .execute("MATCH (n:Person) RETURN n.name")
+        .expect("MATCH RETURN n.name");
+
+    assert_eq!(result.rows.len(), 1, "expected exactly 1 Person node");
+    assert_eq!(
+        result.rows[0][0],
+        Value::String("Alice".to_string()),
+        "n.name must be String('Alice'), not a raw Int64 (SPA-169)"
+    );
+}
+
+/// CREATE a node with an integer property, MATCH and RETURN it — must be Int64.
+#[test]
+fn int_prop_round_trips() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut engine = fresh_engine(dir.path());
+
+    engine
+        .execute("CREATE (n:Person {age: 30})")
+        .expect("CREATE");
+
+    let result = engine
+        .execute("MATCH (n:Person) RETURN n.age")
+        .expect("MATCH RETURN n.age");
+
+    assert_eq!(result.rows.len(), 1, "expected exactly 1 Person node");
+    assert_eq!(
+        result.rows[0][0],
+        Value::Int64(30),
+        "n.age must be Int64(30)"
+    );
+}
+
+/// CREATE a node with both string and integer properties — both must round-trip
+/// with the correct types.
+#[test]
+fn mixed_props_round_trips() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut engine = fresh_engine(dir.path());
+
+    engine
+        .execute("CREATE (n:Person {name: 'Bob', age: 25})")
+        .expect("CREATE");
+
+    let name_result = engine
+        .execute("MATCH (n:Person) RETURN n.name")
+        .expect("RETURN n.name");
+
+    let age_result = engine
+        .execute("MATCH (n:Person) RETURN n.age")
+        .expect("RETURN n.age");
+
+    assert_eq!(
+        name_result.rows[0][0],
+        Value::String("Bob".to_string()),
+        "n.name must be String('Bob') (SPA-169)"
+    );
+    assert_eq!(
+        age_result.rows[0][0],
+        Value::Int64(25),
+        "n.age must be Int64(25)"
+    );
+}
+
+/// Multiple nodes with the same string property — all return correctly typed values.
+#[test]
+fn multiple_string_nodes_round_trip() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut engine = fresh_engine(dir.path());
+
+    engine
+        .execute("CREATE (n:Person {name: 'Alice'})")
+        .expect("CREATE Alice");
+    engine
+        .execute("CREATE (n:Person {name: 'Bob'})")
+        .expect("CREATE Bob");
+    engine
+        .execute("CREATE (n:Person {name: 'Carol'})")
+        .expect("CREATE Carol");
+
+    let result = engine
+        .execute("MATCH (n:Person) RETURN n.name")
+        .expect("MATCH RETURN n.name");
+
+    assert_eq!(result.rows.len(), 3, "expected 3 rows");
+
+    // Every returned value must be a String, not Int64.
+    for row in &result.rows {
+        assert!(
+            matches!(&row[0], Value::String(_)),
+            "expected Value::String, got {:?} (SPA-169)",
+            row[0]
+        );
+    }
+
+    // The three names should all be present.
+    let mut names: Vec<String> = result
+        .rows
+        .iter()
+        .map(|row| match &row[0] {
+            Value::String(s) => s.clone(),
+            other => panic!("expected String, got {:?}", other),
+        })
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["Alice", "Bob", "Carol"]);
+}
+
+// ── SPA-169: WHERE + RETURN end-to-end ───────────────────────────────────────
+
+/// `WHERE n.name = 'Alice' RETURN n.name` must both filter correctly AND return
+/// the name as a String.
+#[test]
+fn string_prop_where_and_return() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut engine = fresh_engine(dir.path());
+
+    engine
+        .execute("CREATE (n:Person {name: 'Alice'})")
+        .expect("CREATE Alice");
+    engine
+        .execute("CREATE (n:Person {name: 'Bob'})")
+        .expect("CREATE Bob");
+
+    let result = engine
+        .execute("MATCH (n:Person) WHERE n.name = 'Alice' RETURN n.name")
+        .expect("MATCH WHERE RETURN");
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "WHERE n.name = 'Alice' must return exactly 1 row"
+    );
+    assert_eq!(
+        result.rows[0][0],
+        Value::String("Alice".to_string()),
+        "RETURN n.name must be String('Alice') after WHERE filter (SPA-169)"
+    );
+}
+
+/// Confirm Int64 properties are unaffected — existing int storage must not regress.
+#[test]
+fn int_prop_where_and_return() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut engine = fresh_engine(dir.path());
+
+    engine
+        .execute("CREATE (n:Person {age: 42})")
+        .expect("CREATE age=42");
+    engine
+        .execute("CREATE (n:Person {age: 18})")
+        .expect("CREATE age=18");
+
+    let result = engine
+        .execute("MATCH (n:Person) WHERE n.age = 42 RETURN n.age")
+        .expect("MATCH WHERE age = 42 RETURN");
+
+    assert_eq!(result.rows.len(), 1, "WHERE n.age = 42 must return 1 row");
+    assert_eq!(
+        result.rows[0][0],
+        Value::Int64(42),
+        "RETURN n.age must be Int64(42)"
+    );
+}
+
+/// Verify string round-trip survives a DB reopen (persisted encoding is stable).
+#[test]
+fn string_prop_survives_reopen() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Session 1: write.
+    {
+        let mut engine = fresh_engine(dir.path());
+        engine
+            .execute("CREATE (n:Person {name: 'Alice'})")
+            .expect("CREATE");
+    }
+
+    // Session 2: read from disk.
+    {
+        let mut engine = fresh_engine(dir.path());
+        let result = engine
+            .execute("MATCH (n:Person) RETURN n.name")
+            .expect("MATCH after reopen");
+
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(
+            result.rows[0][0],
+            Value::String("Alice".to_string()),
+            "n.name must survive DB reopen as String('Alice') (SPA-169)"
+        );
+    }
+}


### PR DESCRIPTION
## **User description**
## Summary

- `RETURN n.name` was returning a raw `Int64` bit-pattern instead of the actual string value
- Root cause: `build_row_vals`/`project_row` blindly reinterpreted every stored `u64` as `Int64`, discarding type information
- Fix: embed a type tag in the **top byte** of every stored `u64` (`0x00` = Int64, `0x01` = Bytes/String) so the correct type can be recovered at read time without a schema lookup
- A new `decode_raw_val()` helper uses `StoreValue::from_u64()` and maps `Bytes → Value::String`, fixing RETURN
- `values_equal()` updated so WHERE string comparisons work correctly for inline-truncated strings (> 7 bytes): on exact mismatch, both sides are re-encoded via `to_u64()` and compared as bit-patterns

## Files changed

- `crates/sparrowdb-storage/src/node_store.rs` — adds type-tag constants, rewrites `to_u64()` and adds `from_u64()`, updates `get_node()` to use `from_u64()`
- `crates/sparrowdb-execution/src/engine.rs` — adds `decode_raw_val()`, updates `build_row_vals`, `project_row`, `project_hop_row`, `project_fof_row`, `string_to_raw_u64`, `matches_prop_filter_static`, and `values_equal`
- `crates/sparrowdb/tests/spa_130_with_clause.rs` — updates stale assertion from raw-int to `Value::String`
- `crates/sparrowdb/tests/spa_169_string_props.rs` — 7 new e2e tests

## Test plan

- [x] `cargo test --workspace` — all tests pass (0 failures)
- [x] `string_prop_round_trips` — CREATE then RETURN n.name returns `Value::String("Alice")`
- [x] `int_prop_round_trips` — CREATE then RETURN n.age returns `Value::Int64(30)`
- [x] `mixed_props_round_trips` — node with both string and int props returns both correctly typed
- [x] `string_prop_where_and_return` — WHERE n.name = 'Alice' RETURN n.name filters AND returns String
- [x] `int_prop_where_and_return` — WHERE n.age = 42 RETURN n.age works for Int64
- [x] `string_prop_survives_reopen` — encoded format is stable across DB reopen
- [x] All 15 real-world regression tests pass (including `knowledge_graph_where_filter_source` which tests long string WHERE)
- [x] All existing SPA-156, SPA-161, SPA-130 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**String properties now return as strings instead of raw numbers, while integer values keep their normal behavior**

### What Changed
- String properties are decoded back into readable string values when returned from queries
- `WHERE` filters on string properties continue to match correctly, including after reopening the database
- Integer properties still return as integers, with mixed string-and-number records handled correctly
- New end-to-end tests cover string returns, string filters, mixed properties, and persistence after reopen

### Impact
`✅ Correct string values in query results`
`✅ Fewer broken string filters`
`✅ Safer round-trips after database restart`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
