### PR TITLE
feat(cypher): implement IN list operator for WHERE clauses

### DIFF
--- a/crates/sparrowdb-cypher/src/ast.rs
+++ b/crates/sparrowdb-cypher/src/ast.rs
@@ -97,6 +97,12 @@ pub enum Expr {
     FnCall { name: String, args: Vec<Expr> },
     /// A list literal: `[expr, expr, ...]`.
     List(Vec<Expr>),
+    /// `expr IN [val, val, ...]` — membership test.
+    InList {
+        expr: Box<Expr>,
+        list: Vec<Expr>,
+        negated: bool,
+    },
 }
 
 /// An existence pattern used in `NOT (a)-[:R]->(b)`.

--- a/crates/sparrowdb-cypher/src/lexer.rs
+++ b/crates/sparrowdb-cypher/src/lexer.rs
@@ -40,6 +40,7 @@ pub enum Token {
     As,
     With,
     Exists,
+    In,
 
     // Punctuation
     LParen,    // (
@@ -312,6 +313,7 @@ fn keyword_or_ident(word: String) -> Token {
         "AS" => Token::As,
         "WITH" => Token::With,
         "EXISTS" => Token::Exists,
+        "IN" => Token::In,
         _ => Token::Ident(word),
     }
 }

--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -981,6 +981,18 @@ impl Parser {
     fn parse_comparison(&mut self) -> Result<Expr> {
         let left = self.parse_atom()?;
 
+        // Handle `expr IN [...]`
+        if matches!(self.peek(), Token::In) {
+            self.advance(); // consume IN
+            self.expect_tok(&Token::LBracket)?;
+            let list = self.parse_in_list()?;
+            return Ok(Expr::InList {
+                expr: Box::new(left),
+                list,
+                negated: false,
+            });
+        }
+
         let op = match self.peek().clone() {
             Token::Eq => BinOpKind::Eq,
             Token::Neq => BinOpKind::Neq,
@@ -1040,6 +1052,35 @@ impl Parser {
             op,
             right: Box::new(right),
         })
+    }
+
+    /// Parse a comma-separated list of atom expressions up to `]`.
+    /// Assumes `[` has already been consumed.  Returns the list and consumes `]`.
+    fn parse_in_list(&mut self) -> Result<Vec<Expr>> {
+        let mut items = Vec::new();
+        if matches!(self.peek(), Token::RBracket) {
+            self.advance(); // consume `]`
+            return Ok(items); // empty list
+        }
+        loop {
+            items.push(self.parse_atom()?);
+            match self.peek().clone() {
+                Token::Comma => {
+                    self.advance();
+                }
+                Token::RBracket => {
+                    self.advance();
+                    break;
+                }
+                other => {
+                    return Err(Error::InvalidArgument(format!(
+                        "expected ',' or ']' in IN list, got {:?}",
+                        other
+                    )));
+                }
+            }
+        }
+        Ok(items)
     }
 
     fn parse_atom(&mut self) -> Result<Expr> {

--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -1416,6 +1416,12 @@ fn collect_col_ids_from_expr(expr: &Expr, out: &mut Vec<u32>) {
             collect_col_ids_from_expr(r, out);
         }
         Expr::Not(inner) => collect_col_ids_from_expr(inner, out),
+        Expr::InList { expr, list, .. } => {
+            collect_col_ids_from_expr(expr, out);
+            for item in list {
+                collect_col_ids_from_expr(item, out);
+            }
+        }
         _ => {}
     }
 }
@@ -1597,6 +1603,11 @@ fn eval_where(expr: &Expr, vals: &HashMap<String, Value>) -> bool {
         Expr::Not(inner) => !eval_where(inner, vals),
         Expr::Literal(Literal::Bool(b)) => *b,
         Expr::Literal(_) => false,
+        Expr::InList { expr, list, negated } => {
+            let lv = eval_expr(expr, vals);
+            let matched = list.iter().any(|item| values_equal(&lv, &eval_expr(item, vals)));
+            if *negated { !matched } else { matched }
+        }
         _ => false, // unsupported expression — reject row rather than silently pass
     }
 }
@@ -1691,6 +1702,11 @@ fn eval_expr(expr: &Expr, vals: &HashMap<String, Value>) -> Value {
             (Value::Bool(a), Value::Bool(b)) => Value::Bool(a || b),
             _ => Value::Null,
         },
+        Expr::InList { expr, list, negated } => {
+            let lv = eval_expr(expr, vals);
+            let matched = list.iter().any(|item| values_equal(&lv, &eval_expr(item, vals)));
+            Value::Bool(if *negated { !matched } else { matched })
+        }
         Expr::List(_) | Expr::NotExists(_) | Expr::CountStar => Value::Null,
     }
 }

--- a/crates/sparrowdb/tests/spa_in_operator.rs
+++ b/crates/sparrowdb/tests/spa_in_operator.rs
@@ -1,0 +1,168 @@
+//! End-to-end tests for IN list operator support in Cypher WHERE clauses.
+//!
+//! `WHERE x IN ['a', 'b', 'c']` — membership test against a literal list.
+//!
+//! Covers: string matching, integer matching, single-element list, empty list,
+//! and no-match cases.
+
+use sparrowdb_catalog::catalog::Catalog;
+use sparrowdb_execution::engine::Engine;
+use sparrowdb_execution::types::Value;
+use sparrowdb_storage::csr::CsrForward;
+use sparrowdb_storage::node_store::NodeStore;
+
+/// Build a fresh engine backed by a temp directory.
+fn fresh_engine(dir: &std::path::Path) -> Engine {
+    let store = NodeStore::open(dir).expect("node store");
+    let cat = Catalog::open(dir).expect("catalog");
+    let csr = CsrForward::build(0, &[]);
+    Engine::new(store, cat, csr, dir)
+}
+
+// ── IN operator: string matching ─────────────────────────────────────────────
+
+/// `WHERE n.name IN ['Alice', 'Bob']` — returns nodes whose name is in the list.
+#[test]
+fn in_operator_string_match() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut engine = fresh_engine(dir.path());
+
+    engine
+        .execute("CREATE (n:Person {name: 'Alice'})")
+        .expect("CREATE Alice");
+    engine
+        .execute("CREATE (n:Person {name: 'Bob'})")
+        .expect("CREATE Bob");
+    engine
+        .execute("CREATE (n:Person {name: 'Charlie'})")
+        .expect("CREATE Charlie");
+
+    let result = engine
+        .execute("MATCH (n:Person) WHERE n.name IN ['Alice', 'Bob'] RETURN n.name")
+        .expect("MATCH WHERE IN");
+
+    assert_eq!(result.rows.len(), 2, "expected 2 rows (Alice and Bob)");
+    let names: Vec<&Value> = result.rows.iter().map(|r| &r[0]).collect();
+    assert!(
+        names.contains(&&Value::String("Alice".to_string())),
+        "Alice should be in results"
+    );
+    assert!(
+        names.contains(&&Value::String("Bob".to_string())),
+        "Bob should be in results"
+    );
+}
+
+// ── IN operator: no match ────────────────────────────────────────────────────
+
+/// `WHERE n.name IN ['Ghost', 'Nobody']` — returns empty when no node matches.
+#[test]
+fn in_operator_no_match() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut engine = fresh_engine(dir.path());
+
+    engine
+        .execute("CREATE (n:Person {name: 'Alice'})")
+        .expect("CREATE Alice");
+    engine
+        .execute("CREATE (n:Person {name: 'Bob'})")
+        .expect("CREATE Bob");
+
+    let result = engine
+        .execute("MATCH (n:Person) WHERE n.name IN ['Ghost', 'Nobody'] RETURN n.name")
+        .expect("MATCH WHERE IN no match");
+
+    assert_eq!(
+        result.rows.len(),
+        0,
+        "expected 0 rows — no node with those names"
+    );
+}
+
+// ── IN operator: integer values ───────────────────────────────────────────────
+
+/// `WHERE n.age IN [25, 30, 35]` — membership test with integers.
+#[test]
+fn in_operator_integer() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut engine = fresh_engine(dir.path());
+
+    engine
+        .execute("CREATE (n:Person {age: 25})")
+        .expect("CREATE age 25");
+    engine
+        .execute("CREATE (n:Person {age: 30})")
+        .expect("CREATE age 30");
+    engine
+        .execute("CREATE (n:Person {age: 40})")
+        .expect("CREATE age 40");
+
+    let result = engine
+        .execute("MATCH (n:Person) WHERE n.age IN [25, 30, 35] RETURN n.age")
+        .expect("MATCH WHERE IN integers");
+
+    assert_eq!(
+        result.rows.len(),
+        2,
+        "expected 2 rows (age 25 and age 30 match)"
+    );
+    let ages: Vec<&Value> = result.rows.iter().map(|r| &r[0]).collect();
+    assert!(
+        ages.contains(&&Value::Int64(25)),
+        "age 25 should be in results"
+    );
+    assert!(
+        ages.contains(&&Value::Int64(30)),
+        "age 30 should be in results"
+    );
+}
+
+// ── IN operator: single-element list ─────────────────────────────────────────
+
+/// `WHERE n.name IN ['Alice']` — single-element list works correctly.
+#[test]
+fn in_operator_single_value() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut engine = fresh_engine(dir.path());
+
+    engine
+        .execute("CREATE (n:Person {name: 'Alice'})")
+        .expect("CREATE Alice");
+    engine
+        .execute("CREATE (n:Person {name: 'Bob'})")
+        .expect("CREATE Bob");
+
+    let result = engine
+        .execute("MATCH (n:Person) WHERE n.name IN ['Alice'] RETURN n.name")
+        .expect("MATCH WHERE IN single");
+
+    assert_eq!(result.rows.len(), 1, "expected 1 row (Alice only)");
+    assert_eq!(
+        result.rows[0][0],
+        Value::String("Alice".to_string()),
+        "result must be Alice"
+    );
+}
+
+// ── IN operator: empty list ───────────────────────────────────────────────────
+
+/// `WHERE n.name IN []` — empty list returns nothing, no error.
+#[test]
+fn in_operator_empty_list() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut engine = fresh_engine(dir.path());
+
+    engine
+        .execute("CREATE (n:Person {name: 'Alice'})")
+        .expect("CREATE Alice");
+
+    let result = engine
+        .execute("MATCH (n:Person) WHERE n.name IN [] RETURN n.name")
+        .expect("MATCH WHERE IN empty list — must not error");
+
+    assert_eq!(
+        result.rows.len(),
+        0,
+        "empty IN list should match nothing"
+    );
+}


### PR DESCRIPTION
## **User description**
## Summary

- Add `WHERE x IN ['a', 'b', 'c']` membership test operator end-to-end through lexer, AST, parser, and engine
- `NOT IN` is handled naturally: `NOT n.name IN [...]` wraps the `InList` node in an `Expr::Not` via the existing `parse_not_expr` path
- Empty list `IN []` correctly returns no rows without error

## Changes

| Layer | Change |
|-------|--------|
| **Lexer** | `Token::In` + `"IN" => Token::In` in `keyword_or_ident` |
| **AST** | `Expr::InList { expr: Box<Expr>, list: Vec<Expr>, negated: bool }` |
| **Parser** | `parse_comparison` checks for `Token::In` after lhs, delegates to new `parse_in_list` helper |
| **Engine `eval_where`** | `Expr::InList` arm: evaluate lhs, check any list item via `values_equal` |
| **Engine `eval_expr`** | Same arm returning `Value::Bool` for use in RETURN expressions |
| **Engine `collect_col_ids_from_expr`** | Recurse into `InList.expr` and list items so columns are loaded before predicate eval |

## Test plan

- [x] `in_operator_string_match` — `WHERE n.name IN ['Alice', 'Bob']` returns matching nodes
- [x] `in_operator_no_match` — `WHERE n.name IN ['Ghost', 'Nobody']` returns empty
- [x] `in_operator_integer` — `WHERE n.age IN [25, 30, 35]` returns correct nodes
- [x] `in_operator_single_value` — `WHERE n.name IN ['Alice']` single-element list
- [x] `in_operator_empty_list` — `WHERE n.name IN []` returns nothing, no error
- [x] Full `cargo test` — all 200+ existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Support `IN` list checks in Cypher queries**

### What Changed
- Queries can now match values against a list with `WHERE x IN [...]`
- `IN` works for strings and numbers, including single-item lists
- Empty lists return no results instead of failing
- `NOT IN` is also supported through the same query form

### Impact
`✅ Easier list-based filtering`
`✅ Fewer empty-list query failures`
`✅ Clearer membership checks in MATCH filters`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
