### PR TITLE
feat(cypher): implement variable-length path matching [:R*], [:R*N], [:R*M..N]

### DIFF
--- a/crates/sparrowdb-cypher/src/ast.rs
+++ b/crates/sparrowdb-cypher/src/ast.rs
@@ -59,6 +59,11 @@ pub struct RelPattern {
     pub rel_type: String,
     /// Direction from the perspective of the path order.
     pub dir: EdgeDir,
+    /// Minimum hops for variable-length paths (None = exactly 1 hop, i.e. not variable-length).
+    pub min_hops: Option<u32>,
+    /// Maximum hops for variable-length paths (None = unbounded, capped at 10 internally).
+    /// Only meaningful when `min_hops` is `Some`.
+    pub max_hops: Option<u32>,
 }
 
 /// A path pattern: a sequence of alternating nodes and relationships.

--- a/crates/sparrowdb-cypher/src/lexer.rs
+++ b/crates/sparrowdb-cypher/src/lexer.rs
@@ -238,7 +238,9 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>> {
                 while i < n && chars[i].is_ascii_digit() {
                     i += 1;
                 }
-                let is_float = i < n && chars[i] == '.';
+                // Only treat `1.x` as a float when the char after '.' is a digit,
+                // not when it's another '.' (which would form a `..` DotDot token).
+                let is_float = i < n && chars[i] == '.' && i + 1 < n && chars[i + 1] != '.';
                 if is_float {
                     i += 1;
                     while i < n && chars[i].is_ascii_digit() {

--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -818,12 +818,12 @@ impl Parser {
             _ => String::new(),
         };
 
-        // Check for variable-length syntax: *n..m or *n or *
+        // Parse optional colon before rel type (or error on bare star).
         if matches!(self.peek(), Token::Colon) {
             self.advance();
         } else if matches!(self.peek(), Token::Star) {
             return Err(Error::InvalidArgument(
-                "variable-length paths are not supported".into(),
+                "variable-length paths require a relationship type: use [:R*] not [*]".into(),
             ));
         }
 
@@ -837,12 +837,52 @@ impl Parser {
             }
         };
 
-        // Check for variable-length after rel type: [:REL*1..3]
-        if matches!(self.peek(), Token::Star) {
-            return Err(Error::InvalidArgument(
-                "variable-length paths are not supported".into(),
-            ));
-        }
+        // Parse optional variable-length hop spec after rel type:
+        //   [:R*]      -> min=1, max=unbounded (capped at 10 in engine)
+        //   [:R*N]     -> min=N, max=N
+        //   [:R*M..N]  -> min=M, max=N
+        //   [:R*M..]   -> min=M, max=unbounded
+        //   [:R*..N]   -> min=1, max=N
+        let (min_hops, max_hops) = if matches!(self.peek(), Token::Star) {
+            self.advance(); // consume '*'
+            if matches!(self.peek(), Token::DotDot) {
+                // [:R*..N]
+                self.advance(); // consume '..'
+                let max = match self.advance().clone() {
+                    Token::Integer(n) if n >= 0 => n as u32,
+                    other => {
+                        return Err(Error::InvalidArgument(format!(
+                            "expected integer after '..', got {:?}",
+                            other
+                        )))
+                    }
+                };
+                (Some(1u32), Some(max))
+            } else if let Token::Integer(n) = self.peek().clone() {
+                let first = n as u32;
+                self.advance(); // consume first integer
+                if matches!(self.peek(), Token::DotDot) {
+                    self.advance(); // consume '..'
+                    if let Token::Integer(m) = self.peek().clone() {
+                        let second = m as u32;
+                        self.advance(); // consume second integer
+                        // [:R*M..N]
+                        (Some(first), Some(second))
+                    } else {
+                        // [:R*M..] -> min=M, max=unbounded
+                        (Some(first), None)
+                    }
+                } else {
+                    // [:R*N] -> min=N, max=N
+                    (Some(first), Some(first))
+                }
+            } else {
+                // [:R*] -> min=1, max=unbounded
+                (Some(1u32), None)
+            }
+        } else {
+            (None, None)
+        };
 
         self.expect_tok(&Token::RBracket)?;
 
@@ -874,7 +914,13 @@ impl Parser {
             }
         };
 
-        Ok(RelPattern { var, rel_type, dir })
+        Ok(RelPattern {
+            var,
+            rel_type,
+            dir,
+            min_hops,
+            max_hops,
+        })
     }
 
     // ── Property map ──────────────────────────────────────────────────────────

--- a/crates/sparrowdb-cypher/tests/parser_tests.rs
+++ b/crates/sparrowdb-cypher/tests/parser_tests.rs
@@ -200,8 +200,13 @@ fn parse_detach_delete_rejected() {
 }
 
 #[test]
-fn parse_variable_length_path_rejected() {
-    assert!(parse("MATCH (a)-[:KNOWS*1..3]->(b) RETURN b").is_err());
+fn parse_variable_length_path_supported() {
+    // Variable-length paths are now supported (SPA-168+).
+    // Verify each syntax variant parses without error.
+    assert!(parse("MATCH (a:Person)-[:KNOWS*]->(b:Person) RETURN b.name").is_ok(), "[:R*] must parse");
+    assert!(parse("MATCH (a:Person)-[:KNOWS*2]->(b:Person) RETURN b.name").is_ok(), "[:R*N] must parse");
+    assert!(parse("MATCH (a:Person)-[:KNOWS*1..3]->(b:Person) RETURN b.name").is_ok(), "[:R*M..N] must parse");
+    assert!(parse("MATCH (a:Person)-[:KNOWS*..5]->(b:Person) RETURN b.name").is_ok(), "[:R*..N] must parse");
 }
 
 #[test]

--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -542,10 +542,16 @@ impl Engine {
         // Determine if this is a 2-hop query.
         let is_two_hop = m.pattern.len() == 1 && m.pattern[0].rels.len() == 2;
         let is_one_hop = m.pattern.len() == 1 && m.pattern[0].rels.len() == 1;
+        // Detect variable-length path: single pattern with exactly 1 rel that has min_hops set.
+        let is_var_len = m.pattern.len() == 1
+            && m.pattern[0].rels.len() == 1
+            && m.pattern[0].rels[0].min_hops.is_some();
 
         let column_names = extract_return_column_names(&m.return_clause.items);
 
-        if is_two_hop {
+        if is_var_len {
+            self.execute_variable_length(m, &column_names)
+        } else if is_two_hop {
             self.execute_two_hop(m, &column_names)
         } else if is_one_hop {
             self.execute_one_hop(m, &column_names)
@@ -1237,7 +1243,207 @@ impl Engine {
         })
     }
 
-    // ── Property filter helpers ───────────────────────────────────────────────
+    // ── Variable-length path traversal: (a)-[:R*M..N]->(b) ──────────────────
+
+    /// Collect all neighbor slot-ids reachable from `src_slot` via the delta
+    /// log and CSR adjacency.  src_label_id is used to filter delta records.
+    fn get_node_neighbors_by_slot(
+        &self,
+        src_slot: u64,
+        src_label_id: u32,
+    ) -> Vec<u64> {
+        let csr_neighbors: Vec<u64> = self.csr.neighbors(src_slot).to_vec();
+        let delta_neighbors: Vec<u64> = {
+            let edge_store = sparrowdb_storage::edge_store::EdgeStore::open(
+                &self.db_root,
+                sparrowdb_storage::edge_store::RelTableId(0),
+            );
+            match edge_store.and_then(|s| s.read_delta()) {
+                Ok(records) => records
+                    .into_iter()
+                    .filter(|r| {
+                        let r_src_label = (r.src.0 >> 32) as u32;
+                        let r_src_slot = r.src.0 & 0xFFFF_FFFF;
+                        r_src_label == src_label_id && r_src_slot == src_slot
+                    })
+                    .map(|r| r.dst.0 & 0xFFFF_FFFF)
+                    .collect(),
+                Err(_) => vec![],
+            }
+        };
+        let mut all: std::collections::HashSet<u64> = csr_neighbors.into_iter().collect();
+        all.extend(delta_neighbors);
+        all.into_iter().collect()
+    }
+
+    /// BFS traversal for variable-length path patterns `(src)-[:R*min..max]->(dst)`.
+    ///
+    /// Returns the set of destination slot-ids reachable from `src_slot` in
+    /// `[min_hops, max_hops]` hops.  Max is capped at 10 to prevent runaway
+    /// traversals on dense graphs.
+    fn execute_variable_hops(
+        &self,
+        src_slot: u64,
+        src_label_id: u32,
+        min_hops: u32,
+        max_hops: u32,
+    ) -> Vec<u64> {
+        const SAFETY_CAP: u32 = 10;
+        let max_hops = max_hops.min(SAFETY_CAP);
+
+        // BFS: frontier = nodes at the current depth.
+        // visited = all nodes ever enqueued (for cycle-avoidance).
+        // results = nodes at depth >= min_hops.
+        let mut visited: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        visited.insert(src_slot);
+        let mut frontier: Vec<u64> = vec![src_slot];
+        let mut results: std::collections::HashSet<u64> = std::collections::HashSet::new();
+
+        for depth in 1..=max_hops {
+            let mut next_frontier: Vec<u64> = Vec::new();
+            for &node_slot in &frontier {
+                let neighbors = self.get_node_neighbors_by_slot(node_slot, src_label_id);
+                for nb in neighbors {
+                    if visited.insert(nb) {
+                        next_frontier.push(nb);
+                    }
+                    if depth >= min_hops {
+                        results.insert(nb);
+                    }
+                }
+            }
+            if next_frontier.is_empty() {
+                break;
+            }
+            frontier = next_frontier;
+        }
+
+        results.into_iter().collect()
+    }
+
+    /// Execute a variable-length path query: `MATCH (a:L1)-[:R*M..N]->(b:L2) RETURN …`.
+    fn execute_variable_length(
+        &self,
+        m: &MatchStatement,
+        column_names: &[String],
+    ) -> Result<QueryResult> {
+        let pat = &m.pattern[0];
+        let src_node_pat = &pat.nodes[0];
+        let dst_node_pat = &pat.nodes[1];
+        let rel_pat = &pat.rels[0];
+
+        if rel_pat.dir != sparrowdb_cypher::ast::EdgeDir::Outgoing {
+            return Err(sparrowdb_common::Error::Unimplemented);
+        }
+
+        let min_hops = rel_pat.min_hops.unwrap_or(1);
+        let max_hops = rel_pat.max_hops.unwrap_or(10); // unbounded → cap at 10
+
+        let src_label = src_node_pat.labels.first().cloned().unwrap_or_default();
+        let dst_label = dst_node_pat.labels.first().cloned().unwrap_or_default();
+
+        let src_label_id = self
+            .catalog
+            .get_label(&src_label)?
+            .ok_or(sparrowdb_common::Error::NotFound)? as u32;
+        let dst_label_id = self
+            .catalog
+            .get_label(&dst_label)?
+            .ok_or(sparrowdb_common::Error::NotFound)? as u32;
+
+        let hwm_src = self.store.hwm_for_label(src_label_id)?;
+
+        let col_ids_src = collect_col_ids_for_var(&src_node_pat.var, column_names, src_label_id);
+        let col_ids_dst = collect_col_ids_for_var(&dst_node_pat.var, column_names, dst_label_id);
+
+        let mut rows: Vec<Vec<Value>> = Vec::new();
+        let mut seen_pairs: std::collections::HashSet<(u64, u64)> = std::collections::HashSet::new();
+
+        for src_slot in 0..hwm_src {
+            let src_node = NodeId(((src_label_id as u64) << 32) | src_slot);
+
+            // Fetch source props (for filter + projection).
+            let src_all_col_ids: Vec<u32> = {
+                let mut v = col_ids_src.clone();
+                for p in &src_node_pat.props {
+                    let col_id = prop_name_to_col_id(&p.key);
+                    if !v.contains(&col_id) {
+                        v.push(col_id);
+                    }
+                }
+                v
+            };
+            let src_props = if !src_all_col_ids.is_empty() {
+                self.store.get_node_raw(src_node, &src_all_col_ids)?
+            } else {
+                vec![]
+            };
+
+            if !self.matches_prop_filter(&src_props, &src_node_pat.props) {
+                continue;
+            }
+
+            // BFS to find all reachable dst slots within [min_hops, max_hops].
+            let dst_slots = self.execute_variable_hops(src_slot, src_label_id, min_hops, max_hops);
+
+            for dst_slot in dst_slots {
+                if !seen_pairs.insert((src_slot, dst_slot)) {
+                    continue;
+                }
+
+                let dst_node = NodeId(((dst_label_id as u64) << 32) | dst_slot);
+                let dst_props = if !col_ids_dst.is_empty() {
+                    self.store.get_node_raw(dst_node, &col_ids_dst)?
+                } else {
+                    vec![]
+                };
+
+                if !self.matches_prop_filter(&dst_props, &dst_node_pat.props) {
+                    continue;
+                }
+
+                // Apply WHERE clause.
+                if let Some(ref where_expr) = m.where_clause {
+                    let mut row_vals =
+                        build_row_vals(&src_props, &src_node_pat.var, &col_ids_src);
+                    row_vals.extend(build_row_vals(&dst_props, &dst_node_pat.var, &col_ids_dst));
+                    if !eval_where(where_expr, &row_vals) {
+                        continue;
+                    }
+                }
+
+                let row = project_hop_row(
+                    &src_props,
+                    &dst_props,
+                    column_names,
+                    &src_node_pat.var,
+                    &dst_node_pat.var,
+                );
+                rows.push(row);
+            }
+        }
+
+        // DISTINCT
+        if m.distinct {
+            deduplicate_rows(&mut rows);
+        }
+
+        // ORDER BY
+        apply_order_by(&mut rows, m, column_names);
+
+        // LIMIT
+        if let Some(lim) = m.limit {
+            rows.truncate(lim as usize);
+        }
+
+        tracing::debug!(rows = rows.len(), min_hops, max_hops, "variable-length traversal complete");
+        Ok(QueryResult {
+            columns: column_names.to_vec(),
+            rows,
+        })
+    }
+
+        // ── Property filter helpers ───────────────────────────────────────────────
 
     fn matches_prop_filter(
         &self,

--- a/crates/sparrowdb/tests/spa_variable_paths.rs
+++ b/crates/sparrowdb/tests/spa_variable_paths.rs
@@ -1,0 +1,217 @@
+//! Variable-length path matching tests.
+//!
+//! Covers `[:R*]`, `[:R*N]`, and `[:R*M..N]` syntax in MATCH patterns.
+//! Each test builds a real graph on disk via Cypher CREATE and MATCH…CREATE,
+//! then verifies BFS traversal correctness.
+
+use sparrowdb::open;
+
+fn make_db() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+/// Helper: collect a single column of strings from a query result.
+fn col_strings(result: &sparrowdb_execution::types::QueryResult, col: usize) -> Vec<String> {
+    result
+        .rows
+        .iter()
+        .filter_map(|row| match &row[col] {
+            sparrowdb_execution::types::Value::String(s) => Some(s.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+// ── Test 1: [:KNOWS*1] behaves exactly like [:KNOWS] (direct neighbors) ───────
+
+/// A→B: `[:KNOWS*1]` must return B (depth-1 only, same as plain `[:KNOWS]`).
+#[test]
+fn var_path_star_one_hop() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Person {name: 'Alice'})").unwrap();
+    db.execute("CREATE (n:Person {name: 'Bob'})").unwrap();
+
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+
+    let result = db
+        .execute("MATCH (a:Person)-[:KNOWS*1]->(b:Person) RETURN a.name, b.name")
+        .expect("[:KNOWS*1] query must succeed");
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "[:KNOWS*1] must return exactly 1 row (direct hop); got: {:?}",
+        result.rows
+    );
+
+    let src_names = col_strings(&result, 0);
+    let dst_names = col_strings(&result, 1);
+    assert!(src_names.contains(&"Alice".to_string()), "src should be Alice");
+    assert!(dst_names.contains(&"Bob".to_string()), "dst should be Bob");
+}
+
+// ── Test 2: [:KNOWS*2] returns friends-of-friends ─────────────────────────────
+
+/// Chain: A→B→C.  `[:KNOWS*2]` from A must return C (depth-2 only, not B).
+#[test]
+fn var_path_star_two_hops() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Person {name: 'Alice'})").unwrap();
+    db.execute("CREATE (n:Person {name: 'Bob'})").unwrap();
+    db.execute("CREATE (n:Person {name: 'Carol'})").unwrap();
+
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+    db.execute(
+        "MATCH (a:Person {name: 'Bob'}), (b:Person {name: 'Carol'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+
+    let result = db
+        .execute("MATCH (a:Person {name: 'Alice'})-[:KNOWS*2]->(b:Person) RETURN b.name")
+        .expect("[:KNOWS*2] query must succeed");
+
+    let dst_names = col_strings(&result, 0);
+    assert!(
+        dst_names.contains(&"Carol".to_string()),
+        "[:KNOWS*2] must reach Carol (depth 2); got: {:?}",
+        dst_names
+    );
+    assert!(
+        !dst_names.contains(&"Bob".to_string()),
+        "[:KNOWS*2] must NOT include Bob (depth 1); got: {:?}",
+        dst_names
+    );
+}
+
+// ── Test 3: [:KNOWS*1..2] returns both depth-1 and depth-2 nodes ───────────────
+
+/// Chain: A→B→C.  `[:KNOWS*1..2]` must return both B and C.
+#[test]
+fn var_path_range() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Person {name: 'Alice'})").unwrap();
+    db.execute("CREATE (n:Person {name: 'Bob'})").unwrap();
+    db.execute("CREATE (n:Person {name: 'Carol'})").unwrap();
+
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+    db.execute(
+        "MATCH (a:Person {name: 'Bob'}), (b:Person {name: 'Carol'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+
+    let result = db
+        .execute("MATCH (a:Person {name: 'Alice'})-[:KNOWS*1..2]->(b:Person) RETURN b.name")
+        .expect("[:KNOWS*1..2] query must succeed");
+
+    let dst_names = col_strings(&result, 0);
+    assert!(
+        dst_names.contains(&"Bob".to_string()),
+        "[:KNOWS*1..2] must include Bob (depth 1); got: {:?}",
+        dst_names
+    );
+    assert!(
+        dst_names.contains(&"Carol".to_string()),
+        "[:KNOWS*1..2] must include Carol (depth 2); got: {:?}",
+        dst_names
+    );
+}
+
+// ── Test 4: [:KNOWS*2] does NOT return depth-1 nodes ─────────────────────────
+
+/// Chain: A→B→C.  `[:KNOWS*2]` from A must include C but NOT B.
+#[test]
+fn var_path_exact() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Person {name: 'Alice'})").unwrap();
+    db.execute("CREATE (n:Person {name: 'Bob'})").unwrap();
+    db.execute("CREATE (n:Person {name: 'Carol'})").unwrap();
+
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+    db.execute(
+        "MATCH (a:Person {name: 'Bob'}), (b:Person {name: 'Carol'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+
+    let result = db
+        .execute("MATCH (a:Person {name: 'Alice'})-[:KNOWS*2]->(b:Person) RETURN b.name")
+        .expect("[:KNOWS*2] query must succeed");
+
+    let dst_names = col_strings(&result, 0);
+
+    assert!(
+        !dst_names.contains(&"Bob".to_string()),
+        "[:KNOWS*2] (exact 2 hops) must NOT return Bob (depth 1); got: {:?}",
+        dst_names
+    );
+    assert!(
+        dst_names.contains(&"Carol".to_string()),
+        "[:KNOWS*2] must return Carol (depth 2); got: {:?}",
+        dst_names
+    );
+}
+
+// ── Test 5: [:KNOWS*] traverses full chain ────────────────────────────────────
+
+/// Chain: A→B→C→D.  `[:KNOWS*]` from A must return B, C, and D.
+#[test]
+fn var_path_unbounded() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Person {name: 'Alice'})").unwrap();
+    db.execute("CREATE (n:Person {name: 'Bob'})").unwrap();
+    db.execute("CREATE (n:Person {name: 'Carol'})").unwrap();
+    db.execute("CREATE (n:Person {name: 'Dave'})").unwrap();
+
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+    db.execute(
+        "MATCH (a:Person {name: 'Bob'}), (b:Person {name: 'Carol'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+    db.execute(
+        "MATCH (a:Person {name: 'Carol'}), (b:Person {name: 'Dave'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+
+    let result = db
+        .execute("MATCH (a:Person {name: 'Alice'})-[:KNOWS*]->(b:Person) RETURN b.name")
+        .expect("[:KNOWS*] query must succeed");
+
+    let dst_names = col_strings(&result, 0);
+
+    assert!(
+        dst_names.contains(&"Bob".to_string()),
+        "[:KNOWS*] must include Bob (depth 1); got: {:?}",
+        dst_names
+    );
+    assert!(
+        dst_names.contains(&"Carol".to_string()),
+        "[:KNOWS*] must include Carol (depth 2); got: {:?}",
+        dst_names
+    );
+    assert!(
+        dst_names.contains(&"Dave".to_string()),
+        "[:KNOWS*] must include Dave (depth 3); got: {:?}",
+        dst_names
+    );
+}


### PR DESCRIPTION
## **User description**
## Summary

- **AST**: Added `min_hops: Option<u32>` and `max_hops: Option<u32>` to `RelPattern` — `None/None` = existing single-hop behavior, no breaking change
- **Lexer**: Fixed float disambiguation bug: `1..3` now tokenizes as `Integer(1) DotDot Integer(3)` instead of `Float(1.) Integer(3)` — required for `*1..3` syntax to work
- **Parser**: Full variable-length syntax support: `[:R*]`, `[:R*N]`, `[:R*M..N]`, `[:R*..N]`, `[:R*M..]`
- **Engine**: BFS traversal (`execute_variable_hops`) with cycle-avoidance and a 10-hop safety cap for unbounded `[:R*]`; wired into `execute_match` dispatch before existing 1-hop/2-hop paths

## Syntax supported

```cypher
MATCH (a:Person)-[:KNOWS*]->(b:Person) RETURN b.name      -- min=1, max=10 (capped)
MATCH (a:Person)-[:KNOWS*3]->(b:Person) RETURN b.name     -- exactly 3 hops
MATCH (a:Person)-[:KNOWS*1..3]->(b:Person) RETURN b.name  -- 1, 2, or 3 hops
MATCH (a:Person)-[:KNOWS*..5]->(b:Person) RETURN b.name   -- up to 5 hops
```

## Test plan

- [x] `var_path_star_one_hop` — `[:KNOWS*1]` returns only direct neighbors (same as `[:KNOWS]`)
- [x] `var_path_star_two_hops` — `[:KNOWS*2]` returns friends-of-friends (A→B→C chain, returns C)
- [x] `var_path_range` — `[:KNOWS*1..2]` returns both B and C from a 3-node chain
- [x] `var_path_exact` — `[:KNOWS*2]` does NOT return depth-1 nodes (B excluded)
- [x] `var_path_unbounded` — `[:KNOWS*]` traverses full 4-node chain A→B→C→D, returns B, C, D
- [x] All existing tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Support variable-length relationship paths in Cypher MATCH queries**

### What Changed
- MATCH patterns can now follow relationships across multiple hops, including exact lengths, ranges, and unbounded paths such as `*`, `*2`, `*1..3`, and `*..5`
- Queries now return all nodes reached at the allowed hop counts, while excluding nodes that are too close or beyond the requested range
- Bare `[*]` patterns now produce a clear error telling users to include a relationship type
- Numbers followed by `..` are now read correctly, so range paths like `*1..3` parse as intended

### Impact
`✅ Multi-hop graph searches`
`✅ Fewer failed MATCH queries for range paths`
`✅ Clearer syntax errors for invalid path patterns`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
