### PR TITLE
feat(execution): implement type(r) and labels(n) metadata functions

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -941,7 +941,14 @@ impl Engine {
             // Apply WHERE clause.
             let var_name = node.var.as_str();
             if let Some(ref where_expr) = m.where_clause {
-                let row_vals = build_row_vals(&props, var_name, &all_col_ids);
+                let mut row_vals = build_row_vals(&props, var_name, &all_col_ids);
+                // Inject label metadata so labels(n) works in WHERE.
+                if !var_name.is_empty() && !label.is_empty() {
+                    row_vals.insert(
+                        format!("{}.__labels__", var_name),
+                        Value::List(vec![Value::String(label.clone())]),
+                    );
+                }
                 if !eval_where(where_expr, &row_vals) {
                     continue;
                 }
@@ -949,11 +956,18 @@ impl Engine {
 
             if use_agg {
                 // Build eval_expr-compatible map for aggregation path.
-                let row_vals = build_row_vals(&props, var_name, &all_col_ids);
+                let mut row_vals = build_row_vals(&props, var_name, &all_col_ids);
+                // Inject label metadata for aggregation.
+                if !var_name.is_empty() && !label.is_empty() {
+                    row_vals.insert(
+                        format!("{}.__labels__", var_name),
+                        Value::List(vec![Value::String(label.clone())]),
+                    );
+                }
                 raw_rows.push(row_vals);
             } else {
                 // Project RETURN columns directly (fast path).
-                let row = project_row(&props, column_names, &all_col_ids);
+                let row = project_row(&props, column_names, &all_col_ids, var_name, &label);
                 rows.push(row);
             }
         }
@@ -1089,6 +1103,26 @@ impl Engine {
                 if let Some(ref where_expr) = m.where_clause {
                     let mut row_vals = build_row_vals(&src_props, &src_node_pat.var, &col_ids_src);
                     row_vals.extend(build_row_vals(&dst_props, &dst_node_pat.var, &col_ids_dst));
+                    // Inject relationship metadata so type(r) works in WHERE.
+                    if !rel_pat.var.is_empty() {
+                        row_vals.insert(
+                            format!("{}.__type__", rel_pat.var),
+                            Value::String(rel_pat.rel_type.clone()),
+                        );
+                    }
+                    // Inject node label metadata so labels(n) works in WHERE.
+                    if !src_node_pat.var.is_empty() && !src_label.is_empty() {
+                        row_vals.insert(
+                            format!("{}.__labels__", src_node_pat.var),
+                            Value::List(vec![Value::String(src_label.clone())]),
+                        );
+                    }
+                    if !dst_node_pat.var.is_empty() && !dst_label.is_empty() {
+                        row_vals.insert(
+                            format!("{}.__labels__", dst_node_pat.var),
+                            Value::List(vec![Value::String(dst_label.clone())]),
+                        );
+                    }
                     if !eval_where(where_expr, &row_vals) {
                         continue;
                     }
@@ -1099,15 +1133,54 @@ impl Engine {
                         build_row_vals(&src_props, &src_node_pat.var, &col_ids_src);
                     row_vals
                         .extend(build_row_vals(&dst_props, &dst_node_pat.var, &col_ids_dst));
+                    // Inject relationship and label metadata for aggregate path.
+                    if !rel_pat.var.is_empty() {
+                        row_vals.insert(
+                            format!("{}.__type__", rel_pat.var),
+                            Value::String(rel_pat.rel_type.clone()),
+                        );
+                    }
+                    if !src_node_pat.var.is_empty() && !src_label.is_empty() {
+                        row_vals.insert(
+                            format!("{}.__labels__", src_node_pat.var),
+                            Value::List(vec![Value::String(src_label.clone())]),
+                        );
+                    }
+                    if !dst_node_pat.var.is_empty() && !dst_label.is_empty() {
+                        row_vals.insert(
+                            format!("{}.__labels__", dst_node_pat.var),
+                            Value::List(vec![Value::String(dst_label.clone())]),
+                        );
+                    }
                     raw_rows.push(row_vals);
                 } else {
                     // Build result row.
+                    // For the fast-path projection, pass rel type and node labels
+                    // so columns like type(r) and labels(n) can be resolved.
+                    let rel_var_type = if !rel_pat.var.is_empty() {
+                        Some((rel_pat.var.as_str(), rel_pat.rel_type.as_str()))
+                    } else {
+                        None
+                    };
+                    let src_label_meta = if !src_node_pat.var.is_empty() && !src_label.is_empty() {
+                        Some((src_node_pat.var.as_str(), src_label.as_str()))
+                    } else {
+                        None
+                    };
+                    let dst_label_meta = if !dst_node_pat.var.is_empty() && !dst_label.is_empty() {
+                        Some((dst_node_pat.var.as_str(), dst_label.as_str()))
+                    } else {
+                        None
+                    };
                     let row = project_hop_row(
                         &src_props,
                         &dst_props,
                         column_names,
                         &src_node_pat.var,
                         &dst_node_pat.var,
+                        rel_var_type,
+                        src_label_meta,
+                        dst_label_meta,
                     );
                     rows.push(row);
                 }
@@ -1455,17 +1528,55 @@ impl Engine {
                     let mut row_vals =
                         build_row_vals(&src_props, &src_node_pat.var, &col_ids_src);
                     row_vals.extend(build_row_vals(&dst_props, &dst_node_pat.var, &col_ids_dst));
+                    // Inject relationship metadata so type(r) works in WHERE.
+                    if !rel_pat.var.is_empty() {
+                        row_vals.insert(
+                            format!("{}.__type__", rel_pat.var),
+                            Value::String(rel_pat.rel_type.clone()),
+                        );
+                    }
+                    // Inject node label metadata so labels(n) works in WHERE.
+                    if !src_node_pat.var.is_empty() && !src_label.is_empty() {
+                        row_vals.insert(
+                            format!("{}.__labels__", src_node_pat.var),
+                            Value::List(vec![Value::String(src_label.clone())]),
+                        );
+                    }
+                    if !dst_node_pat.var.is_empty() && !dst_label.is_empty() {
+                        row_vals.insert(
+                            format!("{}.__labels__", dst_node_pat.var),
+                            Value::List(vec![Value::String(dst_label.clone())]),
+                        );
+                    }
                     if !eval_where(where_expr, &row_vals) {
                         continue;
                     }
                 }
 
+                let rel_var_type = if !rel_pat.var.is_empty() {
+                    Some((rel_pat.var.as_str(), rel_pat.rel_type.as_str()))
+                } else {
+                    None
+                };
+                let src_label_meta = if !src_node_pat.var.is_empty() && !src_label.is_empty() {
+                    Some((src_node_pat.var.as_str(), src_label.as_str()))
+                } else {
+                    None
+                };
+                let dst_label_meta = if !dst_node_pat.var.is_empty() && !dst_label.is_empty() {
+                    Some((dst_node_pat.var.as_str(), dst_label.as_str()))
+                } else {
+                    None
+                };
                 let row = project_hop_row(
                     &src_props,
                     &dst_props,
                     column_names,
                     &src_node_pat.var,
                     &dst_node_pat.var,
+                    rel_var_type,
+                    src_label_meta,
+                    dst_label_meta,
                 );
                 rows.push(row);
             }
@@ -1928,6 +2039,22 @@ fn eval_expr(expr: &Expr, vals: &HashMap<String, Value>) -> Value {
             Literal::Null => Value::Null,
         },
         Expr::FnCall { name, args } => {
+            // Special-case metadata functions that need direct row-map access.
+            // type(r) and labels(n) look up pre-inserted metadata keys rather
+            // than dispatching through the function library with evaluated args.
+            let name_lc = name.to_lowercase();
+            if name_lc == "type" {
+                if let Some(Expr::Var(var_name)) = args.first() {
+                    let meta_key = format!("{}.__type__", var_name);
+                    return vals.get(&meta_key).cloned().unwrap_or(Value::Null);
+                }
+            }
+            if name_lc == "labels" {
+                if let Some(Expr::Var(var_name)) = args.first() {
+                    let meta_key = format!("{}.__labels__", var_name);
+                    return vals.get(&meta_key).cloned().unwrap_or(Value::Null);
+                }
+            }
             // Evaluate each argument recursively, then dispatch to the function library.
             let evaluated: Vec<Value> = args.iter().map(|a| eval_expr(a, vals)).collect();
             crate::functions::dispatch_function(name, evaluated).unwrap_or(Value::Null)
@@ -2002,10 +2129,25 @@ fn eval_expr(expr: &Expr, vals: &HashMap<String, Value>) -> Value {
     }
 }
 
-fn project_row(props: &[(u32, u64)], column_names: &[String], _col_ids: &[u32]) -> Vec<Value> {
+fn project_row(
+    props: &[(u32, u64)],
+    column_names: &[String],
+    _col_ids: &[u32],
+    // Variable name for the scanned node (e.g. "n"), used for labels(n) columns.
+    var_name: &str,
+    // Primary label for the scanned node, used for labels(n) columns.
+    node_label: &str,
+) -> Vec<Value> {
     column_names
         .iter()
         .map(|col_name| {
+            // Handle labels(var) column.
+            if let Some(inner) = col_name.strip_prefix("labels(").and_then(|s| s.strip_suffix(')')) {
+                if inner == var_name && !node_label.is_empty() {
+                    return Value::List(vec![Value::String(node_label.to_string())]);
+                }
+                return Value::Null;
+            }
             let prop = col_name.split('.').next_back().unwrap_or(col_name.as_str());
             let col_id = prop_name_to_col_id(prop);
             props
@@ -2023,10 +2165,40 @@ fn project_hop_row(
     column_names: &[String],
     src_var: &str,
     _dst_var: &str,
+    // Optional (rel_var, rel_type) for resolving `type(rel_var)` columns.
+    rel_var_type: Option<(&str, &str)>,
+    // Optional (src_var, src_label) for resolving `labels(src_var)` columns.
+    src_label_meta: Option<(&str, &str)>,
+    // Optional (dst_var, dst_label) for resolving `labels(dst_var)` columns.
+    dst_label_meta: Option<(&str, &str)>,
 ) -> Vec<Value> {
     column_names
         .iter()
         .map(|col_name| {
+            // Handle metadata function calls: type(r) → "type(r)" column name.
+            if let Some(inner) = col_name.strip_prefix("type(").and_then(|s| s.strip_suffix(')')) {
+                // inner is the variable name, e.g. "r"
+                if let Some((rel_var, rel_type)) = rel_var_type {
+                    if inner == rel_var {
+                        return Value::String(rel_type.to_string());
+                    }
+                }
+                return Value::Null;
+            }
+            // Handle labels(n) → "labels(n)" column name.
+            if let Some(inner) = col_name.strip_prefix("labels(").and_then(|s| s.strip_suffix(')')) {
+                if let Some((meta_var, label)) = src_label_meta {
+                    if inner == meta_var {
+                        return Value::List(vec![Value::String(label.to_string())]);
+                    }
+                }
+                if let Some((meta_var, label)) = dst_label_meta {
+                    if inner == meta_var {
+                        return Value::List(vec![Value::String(label.to_string())]);
+                    }
+                }
+                return Value::Null;
+            }
             if let Some((v, prop)) = col_name.split_once('.') {
                 let col_id = prop_name_to_col_id(prop);
                 let props = if v == src_var { src_props } else { dst_props };

--- a/crates/sparrowdb/tests/spa_type_labels.rs
+++ b/crates/sparrowdb/tests/spa_type_labels.rs
@@ -1,0 +1,182 @@
+//! E2E tests for `type(r)` and `labels(n)` metadata functions.
+//!
+//! `type(r)` returns the relationship type name as a string:
+//!   MATCH (a)-[r:KNOWS]->(b) RETURN type(r)  -- returns "KNOWS"
+//!
+//! `labels(n)` returns the node label(s) as a list:
+//!   MATCH (n:Person) RETURN labels(n)         -- returns ["Person"]
+//!
+//! Both functions require the engine to inject metadata into the row map
+//! during traversal so that eval_expr can resolve them without a catalog
+//! round-trip per row.
+
+use sparrowdb::open;
+use sparrowdb_execution::types::Value;
+
+fn make_db() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+// ── Test 1: type(r) returns the relationship type name ───────────────────────
+
+/// MATCH (a:Person)-[r:KNOWS]->(b:Person) RETURN type(r)
+/// must return the string "KNOWS" for each matched edge.
+#[test]
+fn type_fn_returns_rel_type() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Person {name: 'Alice'})").expect("CREATE Alice");
+    db.execute("CREATE (n:Person {name: 'Bob'})").expect("CREATE Bob");
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .expect("CREATE edge");
+
+    let result = db
+        .execute("MATCH (a:Person)-[r:KNOWS]->(b:Person) RETURN type(r)")
+        .expect("MATCH with type(r) must succeed");
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "expected 1 row; got: {:?}",
+        result.rows
+    );
+    assert_eq!(
+        result.rows[0][0],
+        Value::String("KNOWS".to_string()),
+        "type(r) must return 'KNOWS'; got: {:?}",
+        result.rows[0][0]
+    );
+}
+
+// ── Test 2: type(r) in WHERE filters correctly ───────────────────────────────
+
+/// WHERE type(r) = 'KNOWS' should pass for KNOWS edges and filter out others.
+#[test]
+fn type_fn_in_where() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Person {name: 'Alice'})").expect("CREATE Alice");
+    db.execute("CREATE (n:Person {name: 'Bob'})").expect("CREATE Bob");
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .expect("CREATE KNOWS edge");
+
+    // Filter that matches — should return 1 row.
+    let result = db
+        .execute(
+            "MATCH (a:Person)-[r:KNOWS]->(b:Person) WHERE type(r) = 'KNOWS' RETURN a.name",
+        )
+        .expect("MATCH with WHERE type(r) must succeed");
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "WHERE type(r) = 'KNOWS' must return 1 row; got: {:?}",
+        result.rows
+    );
+    assert_eq!(
+        result.rows[0][0],
+        Value::String("Alice".to_string()),
+        "a.name must be 'Alice'; got: {:?}",
+        result.rows[0][0]
+    );
+
+    // Filter that does NOT match — should return 0 rows.
+    let result_no_match = db
+        .execute(
+            "MATCH (a:Person)-[r:KNOWS]->(b:Person) WHERE type(r) = 'FOLLOWS' RETURN a.name",
+        )
+        .expect("MATCH with WHERE type(r) = 'FOLLOWS' must succeed");
+
+    assert_eq!(
+        result_no_match.rows.len(),
+        0,
+        "WHERE type(r) = 'FOLLOWS' must return 0 rows; got: {:?}",
+        result_no_match.rows
+    );
+}
+
+// ── Test 3: labels(n) returns the node label ─────────────────────────────────
+
+/// MATCH (n:Person) RETURN labels(n)
+/// must return a list containing "Person" for each matched node.
+#[test]
+fn labels_fn_returns_label() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Person {name: 'Alice'})").expect("CREATE Alice");
+    db.execute("CREATE (n:Person {name: 'Bob'})").expect("CREATE Bob");
+
+    let result = db
+        .execute("MATCH (n:Person) RETURN labels(n)")
+        .expect("MATCH with labels(n) must succeed");
+
+    assert_eq!(
+        result.rows.len(),
+        2,
+        "expected 2 rows; got: {:?}",
+        result.rows
+    );
+
+    for row in &result.rows {
+        match &row[0] {
+            Value::List(items) => {
+                assert!(
+                    items.contains(&Value::String("Person".to_string())),
+                    "labels(n) must contain 'Person'; got: {:?}",
+                    items
+                );
+            }
+            other => panic!("expected Value::List from labels(n), got: {:?}", other),
+        }
+    }
+}
+
+// ── Test 4: type(r) works on variable-length paths ───────────────────────────
+
+/// MATCH (a:Person)-[r:KNOWS*1..2]->(b:Person) RETURN type(r)
+/// should return "KNOWS" for each path found within 1..2 hops.
+#[test]
+fn type_fn_variable_path() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Person {name: 'Alice'})").expect("CREATE Alice");
+    db.execute("CREATE (n:Person {name: 'Bob'})").expect("CREATE Bob");
+    db.execute("CREATE (n:Person {name: 'Charlie'})").expect("CREATE Charlie");
+
+    // Alice→Bob, Bob→Charlie
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .expect("CREATE Alice→Bob");
+    db.execute(
+        "MATCH (a:Person {name: 'Bob'}), (b:Person {name: 'Charlie'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .expect("CREATE Bob→Charlie");
+
+    let result = db
+        .execute("MATCH (a:Person)-[r:KNOWS*1..2]->(b:Person) RETURN type(r)")
+        .expect("variable-length MATCH with type(r) must succeed");
+
+    // Should return at least 1 row (direct 1-hop paths).
+    assert!(
+        !result.rows.is_empty(),
+        "variable-length path must return rows; got: {:?}",
+        result.rows
+    );
+
+    // Every row should have type "KNOWS".
+    for row in &result.rows {
+        assert_eq!(
+            row[0],
+            Value::String("KNOWS".to_string()),
+            "type(r) must be 'KNOWS' for variable-length path; got: {:?}",
+            row[0]
+        );
+    }
+}


### PR DESCRIPTION
## **User description**
## Summary

- Inject relationship type metadata (`r.__type__`) and node label metadata (`n.__labels__`) into the row HashMap during traversal so `type(r)` and `labels(n)` can be resolved without catalog round-trips
- Special-case `type(var)` and `labels(var)` in `eval_expr` before the general function dispatch, looking up pre-inserted metadata keys in the row map
- Extend `project_hop_row` and `project_row` (fast-path projection) to handle column names like `"type(r)"` and `"labels(n)"` so `RETURN type(r)` works without falling back to the aggregate path
- All three execution paths are covered: WHERE clause evaluation, aggregation raw_rows path, and the fast-path projection

## Queries now supported

```cypher
MATCH (a:Person)-[r:KNOWS]->(b:Person) RETURN type(r)
-- returns "KNOWS"

MATCH (n:Person) RETURN labels(n)
-- returns ["Person"]

MATCH (a)-[r]->(b) WHERE type(r) = 'KNOWS' RETURN a.name
-- filters on rel type

MATCH (a:Person)-[r:KNOWS*1..2]->(b:Person) RETURN type(r)
-- works on variable-length paths
```

## Test plan

- [x] `type_fn_returns_rel_type` — RETURN type(r) returns "KNOWS"
- [x] `type_fn_in_where` — WHERE type(r) = 'KNOWS' filters correctly; WHERE type(r) = 'FOLLOWS' returns 0 rows
- [x] `labels_fn_returns_label` — RETURN labels(n) returns a list containing "Person"
- [x] `type_fn_variable_path` — type(r) works with `[:KNOWS*1..2]` variable-length paths
- [x] Full `cargo test` — all existing tests continue to pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Support `type(r)` and `labels(n)` in queries**

### What Changed
- `RETURN type(r)` now shows the relationship type name, including on variable-length paths
- `RETURN labels(n)` now returns the node’s label list
- `WHERE type(r) = ...` and `WHERE labels(n) ...` now work when filtering matched rows
- Added end-to-end coverage for returning, filtering, and variable-length path cases

### Impact
`✅ Clearer relationship type lookups`
`✅ Node labels available in query results`
`✅ Fewer failed filters on typed paths`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
