### PR TITLE
feat(execution): implement COUNT/SUM/AVG/MIN/MAX grouped aggregation

### DIFF
--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -1172,9 +1172,20 @@ impl Parser {
             Token::Count => {
                 self.advance();
                 self.expect_tok(&Token::LParen)?;
-                self.expect_tok(&Token::Star)?;
-                self.expect_tok(&Token::RParen)?;
-                Ok(Expr::CountStar)
+                if self.peek() == &Token::Star {
+                    // COUNT(*) — the well-known star form.
+                    self.advance();
+                    self.expect_tok(&Token::RParen)?;
+                    Ok(Expr::CountStar)
+                } else {
+                    // COUNT(expr) — treat as a named aggregate FnCall.
+                    let arg = self.parse_expr()?;
+                    self.expect_tok(&Token::RParen)?;
+                    Ok(Expr::FnCall {
+                        name: "count".to_string(),
+                        args: vec![arg],
+                    })
+                }
             }
             Token::Integer(_)
             | Token::Float(_)

--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -904,7 +904,7 @@ impl Engine {
             }
         }
 
-        let use_agg = has_collect_in_return(&m.return_clause.items);
+        let use_agg = has_aggregate_in_return(&m.return_clause.items);
         if use_agg {
             // Aggregate expressions reference properties not captured by
             // column_names (e.g. collect(p.name) -> column "collect(p.name)").
@@ -1007,9 +1007,9 @@ impl Engine {
         let mut col_ids_dst =
             collect_col_ids_for_var(&dst_node_pat.var, column_names, dst_label_id);
 
-        let use_agg = has_collect_in_return(&m.return_clause.items);
+        let use_agg = has_aggregate_in_return(&m.return_clause.items);
         if use_agg {
-            // Collect col_ids referenced inside collect() argument expressions.
+            // Collect col_ids referenced inside aggregate argument expressions.
             for item in &m.return_clause.items {
                 collect_col_ids_from_expr(&item.expr, &mut col_ids_src);
                 collect_col_ids_from_expr(&item.expr, &mut col_ids_dst);
@@ -1646,6 +1646,7 @@ fn extract_return_column_names(items: &[ReturnItem]) -> Vec<String> {
             None => match &item.expr {
                 Expr::PropAccess { var, prop } => format!("{var}.{prop}"),
                 Expr::Var(v) => v.clone(),
+                Expr::CountStar => "count(*)".to_string(),
                 Expr::FnCall { name, args } => {
                     let arg_str = args
                         .first()
@@ -2121,43 +2122,83 @@ fn compare_values(a: &Value, b: &Value) -> std::cmp::Ordering {
     }
 }
 
-// ── collect() aggregation ─────────────────────────────────────────────────────
+// ── aggregation (COUNT/SUM/AVG/MIN/MAX/collect) ───────────────────────────────
 
-/// Returns `true` if any RETURN item contains a `collect()` aggregate call.
-fn has_collect_in_return(items: &[ReturnItem]) -> bool {
-    items.iter().any(|item| expr_has_collect(&item.expr))
+/// Returns `true` if `expr` is any aggregate call.
+fn is_aggregate_expr(expr: &Expr) -> bool {
+    match expr {
+        Expr::CountStar => true,
+        Expr::FnCall { name, .. } => matches!(
+            name.to_lowercase().as_str(),
+            "count" | "sum" | "avg" | "min" | "max" | "collect"
+        ),
+        _ => false,
+    }
 }
 
-fn expr_has_collect(expr: &Expr) -> bool {
-    matches!(expr, Expr::FnCall { name, .. } if name.to_lowercase() == "collect")
+/// Returns `true` if any RETURN item is an aggregate expression.
+fn has_aggregate_in_return(items: &[ReturnItem]) -> bool {
+    items.iter().any(|item| is_aggregate_expr(&item.expr))
+}
+
+/// The aggregation kind for a single RETURN item.
+#[derive(Debug, Clone, PartialEq)]
+enum AggKind {
+    /// Non-aggregate — used as a grouping key.
+    Key,
+    CountStar,
+    Count,
+    Sum,
+    Avg,
+    Min,
+    Max,
+    Collect,
+}
+
+fn agg_kind(expr: &Expr) -> AggKind {
+    match expr {
+        Expr::CountStar => AggKind::CountStar,
+        Expr::FnCall { name, .. } => match name.to_lowercase().as_str() {
+            "count" => AggKind::Count,
+            "sum" => AggKind::Sum,
+            "avg" => AggKind::Avg,
+            "min" => AggKind::Min,
+            "max" => AggKind::Max,
+            "collect" => AggKind::Collect,
+            _ => AggKind::Key,
+        },
+        _ => AggKind::Key,
+    }
 }
 
 /// Aggregate a set of flat `HashMap<String, Value>` rows by evaluating RETURN
-/// items that contain `collect()`.
+/// items that contain aggregate calls (COUNT(*), COUNT, SUM, AVG, MIN, MAX, collect).
 ///
-/// Non-aggregate RETURN items become the group key; `collect()` items accumulate
-/// a `Value::List` per group.  Returns one output `Vec<Value>` per unique key
-/// in the same column order as `return_items`.
+/// Non-aggregate RETURN items become the group key.  Returns one output
+/// `Vec<Value>` per unique key in the same column order as `return_items`.
 fn aggregate_rows(
     rows: &[HashMap<String, Value>],
     return_items: &[ReturnItem],
 ) -> Vec<Vec<Value>> {
-    let key_indices: Vec<usize> = return_items
+    // Classify each return item.
+    let kinds: Vec<AggKind> = return_items.iter().map(|item| agg_kind(&item.expr)).collect();
+
+    let key_indices: Vec<usize> = kinds
         .iter()
         .enumerate()
-        .filter(|(_, item)| !expr_has_collect(&item.expr))
+        .filter(|(_, k)| **k == AggKind::Key)
         .map(|(i, _)| i)
         .collect();
 
-    let collect_indices: Vec<usize> = return_items
+    let agg_indices: Vec<usize> = kinds
         .iter()
         .enumerate()
-        .filter(|(_, item)| expr_has_collect(&item.expr))
+        .filter(|(_, k)| **k != AggKind::Key)
         .map(|(i, _)| i)
         .collect();
 
-    // No collect() items — fall through to plain projection.
-    if collect_indices.is_empty() {
+    // No aggregate items — fall through to plain projection.
+    if agg_indices.is_empty() {
         return rows
             .iter()
             .map(|row_vals| {
@@ -2171,8 +2212,8 @@ fn aggregate_rows(
 
     // Build groups preserving insertion order.
     let mut group_keys: Vec<Vec<Value>> = Vec::new();
-    // [group_idx][collect_col_idx] → accumulated values
-    let mut group_collects: Vec<Vec<Vec<Value>>> = Vec::new();
+    // [group_idx][agg_col_pos] → accumulated raw values
+    let mut group_accum: Vec<Vec<Vec<Value>>> = Vec::new();
 
     for row_vals in rows {
         let key: Vec<Value> = key_indices
@@ -2184,48 +2225,152 @@ fn aggregate_rows(
             pos
         } else {
             group_keys.push(key);
-            group_collects.push(vec![vec![]; collect_indices.len()]);
+            group_accum.push(vec![vec![]; agg_indices.len()]);
             group_keys.len() - 1
         };
 
-        for (ci, &ri) in collect_indices.iter().enumerate() {
-            let collect_arg_val = match &return_items[ri].expr {
-                Expr::FnCall { args, .. } if !args.is_empty() => eval_expr(&args[0], row_vals),
-                _ => Value::Null,
-            };
-            // Standard Cypher: collect() ignores nulls.
-            if !matches!(collect_arg_val, Value::Null) {
-                group_collects[group_idx][ci].push(collect_arg_val);
+        for (ai, &ri) in agg_indices.iter().enumerate() {
+            match &kinds[ri] {
+                AggKind::CountStar => {
+                    // Sentinel: count the number of sentinels after grouping.
+                    group_accum[group_idx][ai].push(Value::Int64(1));
+                }
+                AggKind::Count | AggKind::Sum | AggKind::Avg | AggKind::Min | AggKind::Max
+                | AggKind::Collect => {
+                    let arg_val = match &return_items[ri].expr {
+                        Expr::FnCall { args, .. } if !args.is_empty() => {
+                            eval_expr(&args[0], row_vals)
+                        }
+                        _ => Value::Null,
+                    };
+                    // All aggregates ignore NULLs (standard Cypher semantics).
+                    if !matches!(arg_val, Value::Null) {
+                        group_accum[group_idx][ai].push(arg_val);
+                    }
+                }
+                AggKind::Key => unreachable!(),
             }
         }
     }
 
-    // No rows and only collect() columns → one row with an empty list.
+    // No grouping keys and no rows → one result row of zero/empty aggregates.
     if group_keys.is_empty() && key_indices.is_empty() {
-        return vec![return_items.iter().map(|_| Value::List(vec![])).collect()];
+        let row: Vec<Value> = kinds
+            .iter()
+            .map(|k| match k {
+                AggKind::CountStar | AggKind::Count | AggKind::Sum => Value::Int64(0),
+                AggKind::Avg | AggKind::Min | AggKind::Max => Value::Null,
+                AggKind::Collect => Value::List(vec![]),
+                AggKind::Key => Value::Null,
+            })
+            .collect();
+        return vec![row];
     }
 
-    // No rows and there are grouping keys → no output rows.
+    // There are grouping keys but no rows → no output rows.
     if group_keys.is_empty() {
         return vec![];
     }
 
-    // Assemble output rows — one per group.
+    // Finalize and assemble output rows — one per group.
     let mut out: Vec<Vec<Value>> = Vec::with_capacity(group_keys.len());
     for (gi, key_vals) in group_keys.into_iter().enumerate() {
         let mut output_row: Vec<Value> = Vec::with_capacity(return_items.len());
         let mut ki = 0usize;
-        let mut ci = 0usize;
-        for item in return_items.iter() {
-            if expr_has_collect(&item.expr) {
-                output_row.push(Value::List(group_collects[gi][ci].clone()));
-                ci += 1;
-            } else {
+        let mut ai = 0usize;
+        for col_idx in 0..return_items.len() {
+            if kinds[col_idx] == AggKind::Key {
                 output_row.push(key_vals[ki].clone());
                 ki += 1;
+            } else {
+                let result = finalize_aggregate(&kinds[col_idx], &group_accum[gi][ai]);
+                output_row.push(result);
+                ai += 1;
             }
         }
         out.push(output_row);
     }
     out
+}
+
+/// Reduce accumulated values for a single aggregate column into a final `Value`.
+fn finalize_aggregate(kind: &AggKind, vals: &[Value]) -> Value {
+    match kind {
+        AggKind::CountStar | AggKind::Count => Value::Int64(vals.len() as i64),
+        AggKind::Sum => {
+            let mut sum_i: i64 = 0;
+            let mut sum_f: f64 = 0.0;
+            let mut is_float = false;
+            for v in vals {
+                match v {
+                    Value::Int64(n) => sum_i += n,
+                    Value::Float64(f) => {
+                        is_float = true;
+                        sum_f += f;
+                    }
+                    _ => {}
+                }
+            }
+            if is_float {
+                Value::Float64(sum_f + sum_i as f64)
+            } else {
+                Value::Int64(sum_i)
+            }
+        }
+        AggKind::Avg => {
+            if vals.is_empty() {
+                return Value::Null;
+            }
+            let mut sum: f64 = 0.0;
+            let mut count: i64 = 0;
+            for v in vals {
+                match v {
+                    Value::Int64(n) => {
+                        sum += *n as f64;
+                        count += 1;
+                    }
+                    Value::Float64(f) => {
+                        sum += f;
+                        count += 1;
+                    }
+                    _ => {}
+                }
+            }
+            if count == 0 {
+                Value::Null
+            } else {
+                Value::Float64(sum / count as f64)
+            }
+        }
+        AggKind::Min => vals
+            .iter()
+            .fold(None::<Value>, |acc, v| match (acc, v) {
+                (None, v) => Some(v.clone()),
+                (Some(Value::Int64(a)), Value::Int64(b)) => Some(Value::Int64(a.min(*b))),
+                (Some(Value::Float64(a)), Value::Float64(b)) => {
+                    Some(Value::Float64(a.min(*b)))
+                }
+                (Some(Value::String(a)), Value::String(b)) => {
+                    Some(Value::String(if a <= *b { a } else { b.clone() }))
+                }
+                (Some(a), _) => Some(a),
+            })
+            .unwrap_or(Value::Null),
+        AggKind::Max => vals
+            .iter()
+            .fold(None::<Value>, |acc, v| match (acc, v) {
+                (None, v) => Some(v.clone()),
+                (Some(Value::Int64(a)), Value::Int64(b)) => Some(Value::Int64(a.max(*b))),
+                (Some(Value::Float64(a)), Value::Float64(b)) => {
+                    Some(Value::Float64(a.max(*b)))
+                }
+                (Some(Value::String(a)), Value::String(b)) => {
+                    Some(Value::String(if a >= *b { a } else { b.clone() }))
+                }
+                (Some(a), _) => Some(a),
+            })
+            .unwrap_or(Value::Null),
+        AggKind::Collect => Value::List(vals.to_vec()),
+        AggKind::Key => Value::Null,
+    }
 }

--- a/crates/sparrowdb-execution/src/functions.rs
+++ b/crates/sparrowdb-execution/src/functions.rs
@@ -70,9 +70,9 @@ pub fn dispatch_function(name: &str, args: Vec<Value>) -> Result<Value> {
         "isnull" => fn_is_null(args),
         "isnotnull" => fn_is_not_null(args),
 
-        // collect() is an aggregate — handled by the engine, not as a scalar function.
-        "collect" => Err(Error::InvalidArgument(
-            "collect() is an aggregate function and cannot be used as a scalar expression".into(),
+        // Aggregate functions — handled by the engine's aggregate_rows(), not as scalar functions.
+        "collect" | "count" | "sum" | "avg" | "min" | "max" => Err(Error::InvalidArgument(
+            format!("{name}() is an aggregate function and cannot be used as a scalar expression"),
         )),
 
         // ── Temporal functions ────────────────────────────────────────────────

--- a/crates/sparrowdb/tests/spa_aggregation.rs
+++ b/crates/sparrowdb/tests/spa_aggregation.rs
@@ -1,0 +1,205 @@
+//! E2E tests for grouped aggregation: COUNT(*), COUNT, SUM, AVG, MIN, MAX.
+//!
+//! All tests use a real tempdir-backed GraphDb with no mocks.
+
+use sparrowdb::open;
+use sparrowdb_execution::types::Value;
+
+fn make_db() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+// ── Test 1: count_star ────────────────────────────────────────────────────────
+
+/// `MATCH (n:Person) RETURN COUNT(*) AS total` → total node count.
+#[test]
+fn count_star() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Person {name: 'Alice'})").expect("CREATE Alice");
+    db.execute("CREATE (n:Person {name: 'Bob'})").expect("CREATE Bob");
+    db.execute("CREATE (n:Person {name: 'Charlie'})").expect("CREATE Charlie");
+
+    let result = db
+        .execute("MATCH (n:Person) RETURN COUNT(*) AS total")
+        .expect("COUNT(*) must succeed");
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "COUNT(*) with no grouping key must return 1 row; got: {:?}",
+        result.rows
+    );
+    assert_eq!(
+        result.rows[0][0],
+        Value::Int64(3),
+        "COUNT(*) must return 3; got: {:?}",
+        result.rows[0][0]
+    );
+}
+
+// ── Test 2: count_grouped ─────────────────────────────────────────────────────
+
+/// Per-person friend count via `MATCH (n:Person)-[:KNOWS]->(f) RETURN n.name, COUNT(f) AS cnt`.
+#[test]
+fn count_grouped() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Person {name: 'Alice'})").expect("CREATE Alice");
+    db.execute("CREATE (n:Person {name: 'Bob'})").expect("CREATE Bob");
+    db.execute("CREATE (n:Person {name: 'Carol'})").expect("CREATE Carol");
+
+    // Alice knows Bob and Carol; Bob knows Carol.
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .expect("Alice->Bob");
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (c:Person {name: 'Carol'}) CREATE (a)-[:KNOWS]->(c)",
+    )
+    .expect("Alice->Carol");
+    db.execute(
+        "MATCH (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'}) CREATE (b)-[:KNOWS]->(c)",
+    )
+    .expect("Bob->Carol");
+
+    let result = db
+        .execute("MATCH (n:Person)-[:KNOWS]->(f:Person) RETURN n.name, COUNT(f.name) AS cnt")
+        .expect("COUNT grouped must succeed");
+
+    // Alice: 2 friends, Bob: 1 friend.
+    assert_eq!(
+        result.rows.len(),
+        2,
+        "expected 2 groups (Alice, Bob); got: {:?}",
+        result.rows
+    );
+
+    // Sort rows by name for deterministic assertion.
+    let mut rows = result.rows.clone();
+    rows.sort_by(|a, b| match (&a[0], &b[0]) {
+        (Value::String(x), Value::String(y)) => x.cmp(y),
+        _ => std::cmp::Ordering::Equal,
+    });
+
+    // Alice has 2 friends.
+    assert_eq!(rows[0][0], Value::String("Alice".to_string()));
+    assert_eq!(rows[0][1], Value::Int64(2), "Alice should have 2 friends");
+
+    // Bob has 1 friend.
+    assert_eq!(rows[1][0], Value::String("Bob".to_string()));
+    assert_eq!(rows[1][1], Value::Int64(1), "Bob should have 1 friend");
+}
+
+// ── Test 3: sum_property ──────────────────────────────────────────────────────
+
+/// `MATCH (n:Person) RETURN SUM(n.age) AS total_age`.
+#[test]
+fn sum_property() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Person {age: 30})").expect("age 30");
+    db.execute("CREATE (n:Person {age: 25})").expect("age 25");
+    db.execute("CREATE (n:Person {age: 45})").expect("age 45");
+
+    let result = db
+        .execute("MATCH (n:Person) RETURN SUM(n.age) AS total_age")
+        .expect("SUM must succeed");
+
+    assert_eq!(result.rows.len(), 1, "SUM with no grouping key must return 1 row");
+    assert_eq!(
+        result.rows[0][0],
+        Value::Int64(100),
+        "SUM(age) must be 100; got: {:?}",
+        result.rows[0][0]
+    );
+}
+
+// ── Test 4: avg_property ──────────────────────────────────────────────────────
+
+/// `MATCH (n:Person) RETURN AVG(n.age) AS avg`.
+#[test]
+fn avg_property() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Person {age: 10})").expect("age 10");
+    db.execute("CREATE (n:Person {age: 20})").expect("age 20");
+    db.execute("CREATE (n:Person {age: 30})").expect("age 30");
+
+    let result = db
+        .execute("MATCH (n:Person) RETURN AVG(n.age) AS avg")
+        .expect("AVG must succeed");
+
+    assert_eq!(result.rows.len(), 1, "AVG with no grouping key must return 1 row");
+    match &result.rows[0][0] {
+        Value::Float64(f) => {
+            let diff = (f - 20.0_f64).abs();
+            assert!(
+                diff < 1e-9,
+                "AVG(age) should be 20.0; got: {f}"
+            );
+        }
+        other => panic!("expected Float64 for AVG, got {:?}", other),
+    }
+}
+
+// ── Test 5: min_max ───────────────────────────────────────────────────────────
+
+/// `MATCH (n:Person) RETURN MIN(n.age), MAX(n.age)`.
+#[test]
+fn min_max() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Person {age: 42})").expect("age 42");
+    db.execute("CREATE (n:Person {age: 7})").expect("age 7");
+    db.execute("CREATE (n:Person {age: 99})").expect("age 99");
+    db.execute("CREATE (n:Person {age: 23})").expect("age 23");
+
+    let result = db
+        .execute("MATCH (n:Person) RETURN MIN(n.age), MAX(n.age)")
+        .expect("MIN/MAX must succeed");
+
+    assert_eq!(result.rows.len(), 1, "MIN/MAX must return 1 row");
+    assert_eq!(
+        result.rows[0][0],
+        Value::Int64(7),
+        "MIN(age) must be 7; got: {:?}",
+        result.rows[0][0]
+    );
+    assert_eq!(
+        result.rows[0][1],
+        Value::Int64(99),
+        "MAX(age) must be 99; got: {:?}",
+        result.rows[0][1]
+    );
+}
+
+// ── Test 6: count_star_no_rows ────────────────────────────────────────────────
+
+/// When the label exists but no rows match, COUNT(*) must return 0, not an error.
+#[test]
+fn count_star_no_rows() {
+    let (_dir, db) = make_db();
+
+    // Register the label by creating one node that won't match the filter.
+    db.execute("CREATE (n:Person {name: 'Sentinel'})").expect("CREATE sentinel");
+
+    // Use a filter that matches nobody — label exists but zero rows match.
+    let result = db
+        .execute("MATCH (n:Person {name: 'NOBODY'}) RETURN COUNT(*) AS total")
+        .expect("COUNT(*) over zero-matching-nodes must succeed");
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "COUNT(*) must still return 1 row when zero nodes match"
+    );
+    assert_eq!(
+        result.rows[0][0],
+        Value::Int64(0),
+        "COUNT(*) over zero rows must be 0; got: {:?}",
+        result.rows[0][0]
+    );
+}


### PR DESCRIPTION
## **User description**
## Summary

- Extends the collect() aggregation infrastructure (PR #50) to cover the full Cypher aggregate function set: `COUNT(*)`, `COUNT(expr)`, `SUM`, `AVG`, `MIN`, `MAX`
- Refactors the old `has_collect_in_return` / `expr_has_collect` pair into `has_aggregate_in_return` / `is_aggregate_expr` that handle all six aggregate kinds
- Adds an `AggKind` enum and `finalize_aggregate()` reducer in `engine.rs` for clean per-kind finalization
- Extends the parser to allow `COUNT(expr)` (previously only `COUNT(*)` was legal)
- Registers `count`/`sum`/`avg`/`min`/`max` as engine-handled aggregates in `functions.rs` (preventing scalar dispatch)

## Supported query shapes

```cypher
MATCH (n:Person) RETURN COUNT(*) AS total
MATCH (n:Person) RETURN COUNT(n.age) AS cnt, AVG(n.age) AS avg_age
MATCH (n:Person)-[:KNOWS]->(f:Person) RETURN n.name, COUNT(f.name) AS friends_count
MATCH (n:Person) RETURN MIN(n.age), MAX(n.age), SUM(n.age)
```

## Test plan

- [ ] `count_star` — `COUNT(*)` returns total node count
- [ ] `count_grouped` — per-source friend count via one-hop traversal + `COUNT(f.name)`
- [ ] `sum_property` — `SUM(n.age)` returns correct integer sum
- [ ] `avg_property` — `AVG(n.age)` returns correct `Float64`
- [ ] `min_max` — `MIN` and `MAX` return extreme integer values
- [ ] `count_star_no_rows` — `COUNT(*)` returns `0` (not error) when no rows match
- [ ] Full `cargo test` — all existing tests still pass (zero regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Support grouped COUNT, SUM, AVG, MIN, and MAX in query results**

### What Changed
- Queries can now return `COUNT(expr)` as well as `SUM`, `AVG`, `MIN`, and `MAX`, including grouped results like `n.name, COUNT(f.name)`
- `COUNT(*)` now returns `0` when no rows match instead of failing
- `MIN` and `MAX` return the lowest and highest matching values in a group, while `AVG` returns a decimal result
- These aggregate functions are no longer treated like plain values in query output

### Impact
`✅ More complete aggregation results`
`✅ Fewer failures on empty matches`
`✅ Clearer friend counts and totals in grouped queries`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
