### PR TITLE
feat(cypher): implement ANY/ALL/NONE/SINGLE list predicates

### DIFF
--- a/crates/sparrowdb-cypher/src/ast.rs
+++ b/crates/sparrowdb-cypher/src/ast.rs
@@ -73,6 +73,15 @@ pub struct PathPattern {
     pub rels: Vec<RelPattern>,
 }
 
+/// Variants for list predicate expressions: ANY, ALL, NONE, SINGLE.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ListPredicateKind {
+    Any,
+    All,
+    None,
+    Single,
+}
+
 /// An expression used in WHERE, RETURN, ORDER BY.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Expr {
@@ -107,6 +116,13 @@ pub enum Expr {
         expr: Box<Expr>,
         list: Vec<Expr>,
         negated: bool,
+    },
+    /// `ANY(x IN list_expr WHERE predicate)` — list predicate.
+    ListPredicate {
+        kind: ListPredicateKind,
+        variable: String,
+        list_expr: Box<Expr>,
+        predicate: Box<Expr>,
     },
 }
 

--- a/crates/sparrowdb-cypher/src/lexer.rs
+++ b/crates/sparrowdb-cypher/src/lexer.rs
@@ -41,6 +41,10 @@ pub enum Token {
     With,
     Exists,
     In,
+    Any,
+    All,
+    NoneKw,
+    Single,
 
     // Punctuation
     LParen,    // (
@@ -316,6 +320,10 @@ fn keyword_or_ident(word: String) -> Token {
         "WITH" => Token::With,
         "EXISTS" => Token::Exists,
         "IN" => Token::In,
+        "ANY" => Token::Any,
+        "ALL" => Token::All,
+        "NONE" => Token::NoneKw,
+        "SINGLE" => Token::Single,
         _ => Token::Ident(word),
     }
 }

--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -6,10 +6,10 @@
 use sparrowdb_common::{Error, Result};
 
 use crate::ast::{
-    BinOpKind, CreateStatement, EdgeDir, ExistsPattern, Expr, Literal, MatchCreateStatement,
-    MatchMutateStatement, MatchOptionalMatchStatement, MatchStatement, MergeStatement, Mutation,
-    NodePattern, OptionalMatchStatement, PathPattern, PropEntry, RelPattern, ReturnClause,
-    ReturnItem, SortDir, Statement, UnionStatement, UnwindStatement,
+    BinOpKind, CreateStatement, EdgeDir, ExistsPattern, Expr, ListPredicateKind, Literal,
+    MatchCreateStatement, MatchMutateStatement, MatchOptionalMatchStatement, MatchStatement,
+    MergeStatement, Mutation, NodePattern, OptionalMatchStatement, PathPattern, PropEntry,
+    RelPattern, ReturnClause, ReturnItem, SortDir, Statement, UnionStatement, UnwindStatement,
 };
 use crate::lexer::{tokenize, Token};
 
@@ -26,7 +26,9 @@ pub fn parse(input: &str) -> Result<Statement> {
     // Check for UNION / UNION ALL between two statements.
     let stmt = if matches!(p.peek(), Token::Union) {
         p.advance();
-        let all = if matches!(p.peek(), Token::Ident(ref s) if s.to_uppercase() == "ALL") {
+        let all = if matches!(p.peek(), Token::All)
+            || matches!(p.peek(), Token::Ident(ref s) if s.to_uppercase() == "ALL")
+        {
             p.advance();
             true
         } else {
@@ -1202,6 +1204,31 @@ impl Parser {
                 let e = self.parse_expr()?;
                 self.expect_tok(&Token::RParen)?;
                 Ok(e)
+            }
+            // Inline list literal: [expr, expr, ...]
+            Token::LBracket => self.parse_list_literal(),
+            // List predicate: ANY(x IN list_expr WHERE predicate)
+            Token::Any | Token::All | Token::NoneKw | Token::Single => {
+                let kind = match self.advance().clone() {
+                    Token::Any => ListPredicateKind::Any,
+                    Token::All => ListPredicateKind::All,
+                    Token::NoneKw => ListPredicateKind::None,
+                    Token::Single => ListPredicateKind::Single,
+                    _ => unreachable!(),
+                };
+                self.expect_tok(&Token::LParen)?;
+                let variable = self.expect_ident()?;
+                self.expect_tok(&Token::In)?;
+                let list_expr = self.parse_expr()?;
+                self.expect_tok(&Token::Where)?;
+                let predicate = self.parse_expr()?;
+                self.expect_tok(&Token::RParen)?;
+                Ok(Expr::ListPredicate {
+                    kind,
+                    variable,
+                    list_expr: Box::new(list_expr),
+                    predicate: Box::new(predicate),
+                })
             }
             // Unary minus: -expr (negates a numeric literal or sub-expression).
             Token::Dash => {

--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -11,8 +11,8 @@ use tracing::info_span;
 use sparrowdb_catalog::catalog::Catalog;
 use sparrowdb_common::{col_id_of, NodeId, Result};
 use sparrowdb_cypher::ast::{
-    BinOpKind, CreateStatement, Expr, Literal, MatchCreateStatement, MatchMutateStatement,
-    MatchOptionalMatchStatement, MatchStatement, MatchWithStatement, Mutation,
+    BinOpKind, CreateStatement, Expr, ListPredicateKind, Literal, MatchCreateStatement,
+    MatchMutateStatement, MatchOptionalMatchStatement, MatchStatement, MatchWithStatement, Mutation,
     OptionalMatchStatement, PathPattern, ReturnItem, SortDir, Statement, UnionStatement,
     UnwindStatement, WithClause,
 };
@@ -1808,6 +1808,16 @@ fn collect_col_ids_from_expr(expr: &Expr, out: &mut Vec<u32>) {
                 collect_col_ids_from_expr(arg, out);
             }
         }
+        Expr::ListPredicate { list_expr, predicate, .. } => {
+            collect_col_ids_from_expr(list_expr, out);
+            collect_col_ids_from_expr(predicate, out);
+        }
+        // Inline list literal: recurse into each element so property references are loaded.
+        Expr::List(items) => {
+            for item in items {
+                collect_col_ids_from_expr(item, out);
+            }
+        }
         _ => {}
     }
 }
@@ -2011,6 +2021,13 @@ fn eval_where(expr: &Expr, vals: &HashMap<String, Value>) -> bool {
             let matched = list.iter().any(|item| values_equal(&lv, &eval_expr(item, vals)));
             if *negated { !matched } else { matched }
         }
+        Expr::ListPredicate { .. } => {
+            // Delegate to eval_expr which handles ListPredicate and returns Value::Bool.
+            match eval_expr(expr, vals) {
+                Value::Bool(b) => b,
+                _ => false,
+            }
+        }
         _ => false, // unsupported expression — reject row rather than silently pass
     }
 }
@@ -2126,7 +2143,36 @@ fn eval_expr(expr: &Expr, vals: &HashMap<String, Value>) -> Value {
             let matched = list.iter().any(|item| values_equal(&lv, &eval_expr(item, vals)));
             Value::Bool(if *negated { !matched } else { matched })
         }
-        Expr::List(_) | Expr::NotExists(_) | Expr::CountStar => Value::Null,
+        Expr::List(items) => {
+            let evaluated: Vec<Value> = items.iter().map(|e| eval_expr(e, vals)).collect();
+            Value::List(evaluated)
+        }
+        Expr::ListPredicate { kind, variable, list_expr, predicate } => {
+            let list_val = eval_expr(list_expr, vals);
+            let items = match list_val {
+                Value::List(v) => v,
+                _ => return Value::Null,
+            };
+            let mut satisfied_count = 0usize;
+            // Clone vals once and reuse the same scope map each iteration,
+            // updating only the loop variable binding to avoid O(n * |scope|) clones.
+            let mut scope = vals.clone();
+            for item in &items {
+                scope.insert(variable.clone(), item.clone());
+                let result = eval_expr(predicate, &scope);
+                if result == Value::Bool(true) {
+                    satisfied_count += 1;
+                }
+            }
+            let result = match kind {
+                ListPredicateKind::Any => satisfied_count > 0,
+                ListPredicateKind::All => satisfied_count == items.len(),
+                ListPredicateKind::None => satisfied_count == 0,
+                ListPredicateKind::Single => satisfied_count == 1,
+            };
+            Value::Bool(result)
+        }
+        Expr::NotExists(_) | Expr::CountStar => Value::Null,
     }
 }
 
@@ -2304,7 +2350,65 @@ fn is_aggregate_expr(expr: &Expr) -> bool {
             name.to_lowercase().as_str(),
             "count" | "sum" | "avg" | "min" | "max" | "collect"
         ),
+        // ANY/ALL/NONE/SINGLE(x IN collect(...) WHERE pred) is an aggregate.
+        Expr::ListPredicate { list_expr, .. } => expr_has_collect(list_expr),
         _ => false,
+    }
+}
+
+/// Returns `true` if the expression contains a `collect()` call (directly or nested).
+fn expr_has_collect(expr: &Expr) -> bool {
+    match expr {
+        Expr::FnCall { name, .. } => name.to_lowercase() == "collect",
+        Expr::ListPredicate { list_expr, .. } => expr_has_collect(list_expr),
+        _ => false,
+    }
+}
+
+/// Extract the `collect()` argument from an expression that contains `collect()`.
+///
+/// Handles two forms:
+/// - Direct: `collect(expr)` → evaluates `expr` against `row_vals`
+/// - Nested: `ANY(x IN collect(expr) WHERE pred)` → evaluates `expr` against `row_vals`
+fn extract_collect_arg(expr: &Expr, row_vals: &HashMap<String, Value>) -> Value {
+    match expr {
+        Expr::FnCall { args, .. } if !args.is_empty() => eval_expr(&args[0], row_vals),
+        Expr::ListPredicate { list_expr, .. } => extract_collect_arg(list_expr, row_vals),
+        _ => Value::Null,
+    }
+}
+
+/// Evaluate an aggregate expression given the already-accumulated list.
+///
+/// For a bare `collect(...)`, returns the list itself.
+/// For `ANY/ALL/NONE/SINGLE(x IN collect(...) WHERE pred)`, substitutes the
+/// accumulated list and evaluates the predicate.
+fn evaluate_aggregate_expr(expr: &Expr, accumulated_list: &Value, outer_vals: &HashMap<String, Value>) -> Value {
+    match expr {
+        Expr::FnCall { name, .. } if name.to_lowercase() == "collect" => accumulated_list.clone(),
+        Expr::ListPredicate { kind, variable, predicate, .. } => {
+            let items = match accumulated_list {
+                Value::List(v) => v,
+                _ => return Value::Null,
+            };
+            let mut satisfied_count = 0usize;
+            for item in items {
+                let mut scope = outer_vals.clone();
+                scope.insert(variable.clone(), item.clone());
+                let result = eval_expr(predicate, &scope);
+                if result == Value::Bool(true) {
+                    satisfied_count += 1;
+                }
+            }
+            let result = match kind {
+                ListPredicateKind::Any => satisfied_count > 0,
+                ListPredicateKind::All => satisfied_count == items.len(),
+                ListPredicateKind::None => satisfied_count == 0,
+                ListPredicateKind::Single => satisfied_count == 1,
+            };
+            Value::Bool(result)
+        }
+        _ => Value::Null,
     }
 }
 
@@ -2339,6 +2443,8 @@ fn agg_kind(expr: &Expr) -> AggKind {
             "collect" => AggKind::Collect,
             _ => AggKind::Key,
         },
+        // ANY/ALL/NONE/SINGLE(x IN collect(...) WHERE pred) treated as Collect-kind aggregate.
+        Expr::ListPredicate { list_expr, .. } if expr_has_collect(list_expr) => AggKind::Collect,
         _ => AggKind::Key,
     }
 }
@@ -2407,8 +2513,7 @@ fn aggregate_rows(
                     // Sentinel: count the number of sentinels after grouping.
                     group_accum[group_idx][ai].push(Value::Int64(1));
                 }
-                AggKind::Count | AggKind::Sum | AggKind::Avg | AggKind::Min | AggKind::Max
-                | AggKind::Collect => {
+                AggKind::Count | AggKind::Sum | AggKind::Avg | AggKind::Min | AggKind::Max => {
                     let arg_val = match &return_items[ri].expr {
                         Expr::FnCall { args, .. } if !args.is_empty() => {
                             eval_expr(&args[0], row_vals)
@@ -2420,6 +2525,15 @@ fn aggregate_rows(
                         group_accum[group_idx][ai].push(arg_val);
                     }
                 }
+                AggKind::Collect => {
+                    // For collect() or ListPredicate(x IN collect(...) WHERE ...), extract the
+                    // collect() argument (handles both direct and nested forms).
+                    let arg_val = extract_collect_arg(&return_items[ri].expr, row_vals);
+                    // Standard Cypher: collect() ignores nulls.
+                    if !matches!(arg_val, Value::Null) {
+                        group_accum[group_idx][ai].push(arg_val);
+                    }
+                }
                 AggKind::Key => unreachable!(),
             }
         }
@@ -2427,12 +2541,16 @@ fn aggregate_rows(
 
     // No grouping keys and no rows → one result row of zero/empty aggregates.
     if group_keys.is_empty() && key_indices.is_empty() {
-        let row: Vec<Value> = kinds
+        let empty_vals: HashMap<String, Value> = HashMap::new();
+        let row: Vec<Value> = return_items
             .iter()
-            .map(|k| match k {
+            .zip(kinds.iter())
+            .map(|(item, k)| match k {
                 AggKind::CountStar | AggKind::Count | AggKind::Sum => Value::Int64(0),
                 AggKind::Avg | AggKind::Min | AggKind::Max => Value::Null,
-                AggKind::Collect => Value::List(vec![]),
+                AggKind::Collect => {
+                    evaluate_aggregate_expr(&item.expr, &Value::List(vec![]), &empty_vals)
+                }
                 AggKind::Key => Value::Null,
             })
             .collect();
@@ -2450,12 +2568,26 @@ fn aggregate_rows(
         let mut output_row: Vec<Value> = Vec::with_capacity(return_items.len());
         let mut ki = 0usize;
         let mut ai = 0usize;
+        // Build outer scope from key columns for ListPredicate predicate evaluation.
+        let outer_vals: HashMap<String, Value> = key_indices
+            .iter()
+            .enumerate()
+            .map(|(pos, &i)| {
+                let name = return_items[i].alias.clone().unwrap_or_else(|| format!("_k{i}"));
+                (name, key_vals[pos].clone())
+            })
+            .collect();
         for col_idx in 0..return_items.len() {
             if kinds[col_idx] == AggKind::Key {
                 output_row.push(key_vals[ki].clone());
                 ki += 1;
             } else {
-                let result = finalize_aggregate(&kinds[col_idx], &group_accum[gi][ai]);
+                let accumulated = Value::List(group_accum[gi][ai].clone());
+                let result = if kinds[col_idx] == AggKind::Collect {
+                    evaluate_aggregate_expr(&return_items[col_idx].expr, &accumulated, &outer_vals)
+                } else {
+                    finalize_aggregate(&kinds[col_idx], &group_accum[gi][ai])
+                };
                 output_row.push(result);
                 ai += 1;
             }

--- a/crates/sparrowdb-execution/src/json.rs
+++ b/crates/sparrowdb-execution/src/json.rs
@@ -35,6 +35,7 @@ pub fn value_to_json(v: &Value) -> serde_json::Value {
         // Serialize as strings so precision is preserved across the JSON boundary.
         Value::NodeRef(n) => serde_json::json!({"$type": "node", "id": n.0.to_string()}),
         Value::EdgeRef(e) => serde_json::json!({"$type": "edge", "id": e.0.to_string()}),
+        Value::List(items) => serde_json::Value::Array(items.iter().map(value_to_json).collect()),
     }
 }
 

--- a/crates/sparrowdb/tests/spa_list_predicates.rs
+++ b/crates/sparrowdb/tests/spa_list_predicates.rs
@@ -1,0 +1,361 @@
+//! E2E tests for ANY/ALL/NONE/SINGLE list predicate functions.
+//!
+//! These predicates iterate over a list value and apply a filter predicate,
+//! returning a boolean result:
+//!
+//!   ANY(x IN list WHERE predicate)    — true if at least one element matches
+//!   ALL(x IN list WHERE predicate)    — true if every element matches
+//!   NONE(x IN list WHERE predicate)   — true if no element matches
+//!   SINGLE(x IN list WHERE predicate) — true if exactly one element matches
+//!
+//! Tests exercise two patterns:
+//!   1. Inline list literals: RETURN ANY(x IN ['a','b','c'] WHERE x = 'a')
+//!   2. collect() aggregation: MATCH … RETURN ANY(x IN collect(t.name) WHERE x = 'graph')
+
+use sparrowdb::open;
+use sparrowdb_execution::types::Value;
+
+fn make_db() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+// ── Test 1: any_matches — collect() ───────────────────────────────────────────
+
+/// ANY wrapping collect() returns true when at least one element satisfies the predicate.
+#[test]
+fn any_matches() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Tag {name: 'graph'})").expect("CREATE graph");
+    db.execute("CREATE (n:Tag {name: 'database'})").expect("CREATE database");
+    db.execute("CREATE (n:Tag {name: 'rust'})").expect("CREATE rust");
+
+    let result = db
+        .execute(
+            "MATCH (t:Tag) RETURN ANY(x IN collect(t.name) WHERE x = 'graph') AS has_graph",
+        )
+        .expect("ANY predicate must succeed");
+
+    assert_eq!(result.rows.len(), 1, "expected 1 row; got: {:?}", result.rows);
+    assert_eq!(
+        result.rows[0][0],
+        Value::Bool(true),
+        "ANY(x IN collect(t.name) WHERE x = 'graph') must be true; got: {:?}",
+        result.rows[0][0]
+    );
+}
+
+// ── Test 1b: any_inline_list — inline list literal ────────────────────────────
+
+/// ANY on an inline list literal returns true when at least one element matches.
+#[test]
+fn any_inline_list() {
+    let (_dir, db) = make_db();
+
+    let result = db
+        .execute("RETURN ANY(x IN ['a', 'b', 'c'] WHERE x = 'b') AS found")
+        .expect("ANY with inline list must succeed");
+
+    assert_eq!(result.rows.len(), 1, "expected 1 row; got: {:?}", result.rows);
+    assert_eq!(
+        result.rows[0][0],
+        Value::Bool(true),
+        "ANY(x IN ['a','b','c'] WHERE x = 'b') must be true; got: {:?}",
+        result.rows[0][0]
+    );
+}
+
+// ── Test 1c: all_inline_list — inline list literal ────────────────────────────
+
+/// ALL on an inline list literal returns true when every element satisfies predicate.
+#[test]
+fn all_inline_list() {
+    let (_dir, db) = make_db();
+
+    let result = db
+        .execute("RETURN ALL(x IN [2, 4, 6] WHERE x > 1) AS all_positive")
+        .expect("ALL with inline list must succeed");
+
+    assert_eq!(result.rows.len(), 1, "expected 1 row; got: {:?}", result.rows);
+    assert_eq!(
+        result.rows[0][0],
+        Value::Bool(true),
+        "ALL(x IN [2,4,6] WHERE x > 1) must be true; got: {:?}",
+        result.rows[0][0]
+    );
+}
+
+// ── Test 1d: none_inline_list — inline list literal ───────────────────────────
+
+/// NONE on an inline list literal returns true when no element matches.
+#[test]
+fn none_inline_list() {
+    let (_dir, db) = make_db();
+
+    let result = db
+        .execute("RETURN NONE(x IN [1, 2, 3] WHERE x = 99) AS none_99")
+        .expect("NONE with inline list must succeed");
+
+    assert_eq!(result.rows.len(), 1, "expected 1 row; got: {:?}", result.rows);
+    assert_eq!(
+        result.rows[0][0],
+        Value::Bool(true),
+        "NONE(x IN [1,2,3] WHERE x = 99) must be true; got: {:?}",
+        result.rows[0][0]
+    );
+}
+
+// ── Test 1e: single_inline_list — inline list literal ─────────────────────────
+
+/// SINGLE on an inline list literal returns true when exactly one element matches.
+#[test]
+fn single_inline_list() {
+    let (_dir, db) = make_db();
+
+    let result = db
+        .execute("RETURN SINGLE(x IN [1, 2, 3] WHERE x = 2) AS exactly_one")
+        .expect("SINGLE with inline list must succeed");
+
+    assert_eq!(result.rows.len(), 1, "expected 1 row; got: {:?}", result.rows);
+    assert_eq!(
+        result.rows[0][0],
+        Value::Bool(true),
+        "SINGLE(x IN [1,2,3] WHERE x = 2) must be true; got: {:?}",
+        result.rows[0][0]
+    );
+}
+
+// ── Test 2: any_no_match — collect() ──────────────────────────────────────────
+
+/// ANY returns false when no element satisfies the predicate.
+#[test]
+fn any_no_match() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Tag {name: 'graph'})").expect("CREATE graph");
+    db.execute("CREATE (n:Tag {name: 'database'})").expect("CREATE database");
+
+    let result = db
+        .execute(
+            "MATCH (t:Tag) RETURN ANY(x IN collect(t.name) WHERE x = 'missing') AS found",
+        )
+        .expect("ANY predicate (no match) must succeed");
+
+    assert_eq!(result.rows.len(), 1, "expected 1 row");
+    assert_eq!(
+        result.rows[0][0],
+        Value::Bool(false),
+        "ANY on no-match must be false; got: {:?}",
+        result.rows[0][0]
+    );
+}
+
+// ── Test 3: all_matches — collect() ───────────────────────────────────────────
+
+/// ALL returns true when every element satisfies the predicate.
+#[test]
+fn all_matches() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Score {value: 90})").expect("CREATE 90");
+    db.execute("CREATE (n:Score {value: 85})").expect("CREATE 85");
+    db.execute("CREATE (n:Score {value: 95})").expect("CREATE 95");
+
+    let result = db
+        .execute(
+            "MATCH (s:Score) RETURN ALL(x IN collect(s.value) WHERE x > 80) AS all_above_80",
+        )
+        .expect("ALL predicate must succeed");
+
+    assert_eq!(result.rows.len(), 1, "expected 1 row");
+    assert_eq!(
+        result.rows[0][0],
+        Value::Bool(true),
+        "ALL(x IN scores WHERE x > 80) must be true; got: {:?}",
+        result.rows[0][0]
+    );
+}
+
+// ── Test 4: all_fails — collect() ─────────────────────────────────────────────
+
+/// ALL returns false when at least one element does not satisfy the predicate.
+#[test]
+fn all_fails() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Score {value: 90})").expect("CREATE 90");
+    db.execute("CREATE (n:Score {value: 70})").expect("CREATE 70 (below threshold)");
+    db.execute("CREATE (n:Score {value: 95})").expect("CREATE 95");
+
+    let result = db
+        .execute(
+            "MATCH (s:Score) RETURN ALL(x IN collect(s.value) WHERE x > 80) AS all_above_80",
+        )
+        .expect("ALL predicate (fail case) must succeed");
+
+    assert_eq!(result.rows.len(), 1, "expected 1 row");
+    assert_eq!(
+        result.rows[0][0],
+        Value::Bool(false),
+        "ALL(x > 80) must be false when 70 is in list; got: {:?}",
+        result.rows[0][0]
+    );
+}
+
+// ── Test 5: none_matches — collect() ─────────────────────────────────────────
+
+/// NONE returns true when no element satisfies the predicate.
+#[test]
+fn none_matches() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Item {name: 'alpha'})").expect("CREATE alpha");
+    db.execute("CREATE (n:Item {name: 'beta'})").expect("CREATE beta");
+    db.execute("CREATE (n:Item {name: 'gamma'})").expect("CREATE gamma");
+
+    let result = db
+        .execute(
+            "MATCH (i:Item) RETURN NONE(x IN collect(i.name) WHERE x = 'deleted') AS none_deleted",
+        )
+        .expect("NONE predicate must succeed");
+
+    assert_eq!(result.rows.len(), 1, "expected 1 row");
+    assert_eq!(
+        result.rows[0][0],
+        Value::Bool(true),
+        "NONE(x = 'deleted') must be true when no item is named 'deleted'; got: {:?}",
+        result.rows[0][0]
+    );
+}
+
+// ── Test 6: none_fails — collect() ───────────────────────────────────────────
+
+/// NONE returns false when at least one element satisfies the predicate.
+#[test]
+fn none_fails() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Item {name: 'alpha'})").expect("CREATE alpha");
+    db.execute("CREATE (n:Item {name: 'deleted'})").expect("CREATE deleted");
+
+    let result = db
+        .execute(
+            "MATCH (i:Item) RETURN NONE(x IN collect(i.name) WHERE x = 'deleted') AS none_deleted",
+        )
+        .expect("NONE predicate (fail case) must succeed");
+
+    assert_eq!(result.rows.len(), 1, "expected 1 row");
+    assert_eq!(
+        result.rows[0][0],
+        Value::Bool(false),
+        "NONE(x = 'deleted') must be false when 'deleted' is in list; got: {:?}",
+        result.rows[0][0]
+    );
+}
+
+// ── Test 7: any_on_empty_list ─────────────────────────────────────────────────
+
+/// ANY on an empty list returns false (no element can satisfy the predicate).
+///
+/// Uses a prop filter that matches nothing so collect() produces an empty list.
+#[test]
+fn any_on_empty_list() {
+    let (_dir, db) = make_db();
+
+    // Create a node so the label exists, but use a prop filter that matches nothing.
+    db.execute("CREATE (n:Empty {val: 999})").expect("CREATE dummy");
+
+    // Prop filter {val: 0} matches nothing → collect() produces [] → ANY = false.
+    let result = db
+        .execute(
+            "MATCH (e:Empty {val: 0}) RETURN ANY(x IN collect(e.val) WHERE x = 0) AS found",
+        )
+        .expect("ANY on empty list must succeed");
+
+    // With no rows matching the prop filter, aggregate_rows returns one row with empty list.
+    assert_eq!(result.rows.len(), 1, "expected 1 row; got: {:?}", result.rows);
+    assert_eq!(
+        result.rows[0][0],
+        Value::Bool(false),
+        "ANY on empty list must be false; got: {:?}",
+        result.rows[0][0]
+    );
+}
+
+// ── Test 8: all_on_empty_list ─────────────────────────────────────────────────
+
+/// ALL on an empty list returns true (vacuous truth: no element fails the predicate).
+#[test]
+fn all_on_empty_list() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Empty {val: 999})").expect("CREATE dummy");
+
+    let result = db
+        .execute(
+            "MATCH (e:Empty {val: 0}) RETURN ALL(x IN collect(e.val) WHERE x > 100) AS all_big",
+        )
+        .expect("ALL on empty list must succeed");
+
+    assert_eq!(result.rows.len(), 1, "expected 1 row; got: {:?}", result.rows);
+    assert_eq!(
+        result.rows[0][0],
+        Value::Bool(true),
+        "ALL on empty list must be true (vacuous truth); got: {:?}",
+        result.rows[0][0]
+    );
+}
+
+// ── Test 9: single_matches — collect() ───────────────────────────────────────
+
+/// SINGLE returns true when exactly one element satisfies the predicate.
+#[test]
+fn single_matches() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Person {name: 'Alice'})").expect("CREATE Alice");
+    db.execute("CREATE (n:Person {name: 'Bob'})").expect("CREATE Bob");
+    db.execute("CREATE (n:Person {name: 'Charlie'})").expect("CREATE Charlie");
+
+    let result = db
+        .execute(
+            "MATCH (p:Person) RETURN SINGLE(x IN collect(p.name) WHERE x = 'Alice') AS one_alice",
+        )
+        .expect("SINGLE predicate must succeed");
+
+    assert_eq!(result.rows.len(), 1, "expected 1 row");
+    assert_eq!(
+        result.rows[0][0],
+        Value::Bool(true),
+        "SINGLE(x = 'Alice') must be true when exactly one Alice exists; got: {:?}",
+        result.rows[0][0]
+    );
+}
+
+// ── Test 10: single_fails_multiple ────────────────────────────────────────────
+
+/// SINGLE returns false when more than one element satisfies the predicate.
+#[test]
+fn single_fails_multiple() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Person {name: 'Alice'})").expect("CREATE Alice 1");
+    db.execute("CREATE (n:Person {name: 'Alice'})").expect("CREATE Alice 2");
+    db.execute("CREATE (n:Person {name: 'Bob'})").expect("CREATE Bob");
+
+    let result = db
+        .execute(
+            "MATCH (p:Person) RETURN SINGLE(x IN collect(p.name) WHERE x = 'Alice') AS one_alice",
+        )
+        .expect("SINGLE predicate (multiple matches) must succeed");
+
+    assert_eq!(result.rows.len(), 1, "expected 1 row");
+    assert_eq!(
+        result.rows[0][0],
+        Value::Bool(false),
+        "SINGLE(x = 'Alice') must be false when two Alices exist; got: {:?}",
+        result.rows[0][0]
+    );
+}


### PR DESCRIPTION
## **User description**
## Summary

- Implements the four Cypher list predicate functions: `ANY`, `ALL`, `NONE`, `SINGLE`
- Syntax: `ANY(x IN list WHERE predicate)` — iterate a list, apply a predicate per element
- Correctly handles empty-list semantics: `ANY([]) = false`, `ALL([]) = true` (vacuous truth)
- Supports `ANY(x IN collect(p.name) WHERE x = 'Alice')` — predicates wrapping `collect()` aggregate

## Changes

**Lexer** (`lexer.rs`): Added `Token::Any`, `Token::All`, `Token::NoneKw`, `Token::Single`; `UNION ALL` regression fixed by accepting `Token::All` as the ALL keyword there too.

**AST** (`ast.rs`): Added `ListPredicateKind` enum and `Expr::ListPredicate { kind, variable, list_expr, predicate }` variant.

**Parser** (`parser.rs`): `parse_atom` recognises the four new tokens and parses `KEYWORD(var IN list_expr WHERE pred)` form.

**Engine** (`engine.rs`):
- `eval_expr` handles `Expr::ListPredicate` by binding the loop variable in a cloned scope per element
- `eval_where` delegates `ListPredicate` to `eval_expr`
- `collect_col_ids_from_expr` recurses into `list_expr` and `predicate`
- `expr_has_collect` recursively detects `collect()` inside `ListPredicate`
- New helpers `extract_collect_arg` and `evaluate_aggregate_expr` allow `ANY/ALL/NONE/SINGLE(x IN collect(...) WHERE pred)` to work correctly in the aggregation path

## Test plan

- [x] `any_matches` — ANY with a matching element returns true
- [x] `any_no_match` — ANY with no matching element returns false
- [x] `all_matches` — ALL when every element satisfies predicate returns true
- [x] `all_fails` — ALL when one element fails returns false
- [x] `none_matches` — NONE when no element matches returns true
- [x] `none_fails` — NONE when one element matches returns false
- [x] `any_on_empty_list` — ANY on empty list returns false
- [x] `all_on_empty_list` — ALL on empty list returns true (vacuous truth)
- [x] `single_matches` — SINGLE with exactly one match returns true
- [x] `single_fails_multiple` — SINGLE with two matches returns false
- [x] Full test suite — all pre-existing tests continue to pass (UNION ALL regression fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Support Cypher list predicates in queries, and keep `UNION ALL` working**

### What Changed
- Queries can now use `ANY`, `ALL`, `NONE`, and `SINGLE` with list expressions to return a true/false result
- These predicates work with both list literals and `collect(...)` results, including empty-list cases such as `ANY([]) = false` and `ALL([]) = true`
- `UNION ALL` continues to parse correctly instead of treating `ALL` as a list predicate keyword

### Impact
`✅ Can filter query results with ANY/ALL/NONE/SINGLE`
`✅ Correct empty-list results in list checks`
`✅ Fewer UNION ALL query failures`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
