### PR TITLE
fix(engine): evaluate WHERE predicate in 2-hop path matching — SPA-188

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -1389,7 +1389,8 @@ impl Engine {
         tracing::debug!(src_label = %src_label, fof_label = %fof_label, hwm_src = hwm_src, "two-hop traversal start");
 
         // Collect col_ids for fof: projected columns plus any columns referenced by prop filters.
-        // Also include any columns referenced by the WHERE clause.
+        // Also include any columns referenced by the WHERE clause, scoped to the fof variable so
+        // that src-only predicates do not cause spurious column fetches from fof nodes.
         let col_ids_fof = {
             let mut ids = collect_col_ids_for_var(&fof_node_pat.var, column_names, fof_label_id);
             for p in &fof_node_pat.props {
@@ -1399,16 +1400,17 @@ impl Engine {
                 }
             }
             if let Some(ref where_expr) = m.where_clause {
-                collect_col_ids_from_expr(where_expr, &mut ids);
+                collect_col_ids_from_expr_for_var(where_expr, &fof_node_pat.var, &mut ids);
             }
             ids
         };
 
-        // Collect col_ids for src that are referenced by the WHERE clause.
+        // Collect col_ids for src that are referenced by the WHERE clause, scoped to the src
+        // variable so that fof-only predicates do not cause spurious column fetches from src nodes.
         let col_ids_src_where: Vec<u32> = {
             let mut ids = Vec::new();
             if let Some(ref where_expr) = m.where_clause {
-                collect_col_ids_from_expr(where_expr, &mut ids);
+                collect_col_ids_from_expr_for_var(where_expr, &src_node_pat.var, &mut ids);
             }
             ids
         };
@@ -1526,6 +1528,19 @@ impl Engine {
                         row_vals.insert(
                             format!("{}.__labels__", fof_node_pat.var),
                             Value::List(vec![Value::String(fof_label.clone())]),
+                        );
+                    }
+                    // Inject relationship type metadata so type(r) works in WHERE.
+                    if !pat.rels[0].var.is_empty() {
+                        row_vals.insert(
+                            format!("{}.__type__", pat.rels[0].var),
+                            Value::String(pat.rels[0].rel_type.clone()),
+                        );
+                    }
+                    if !pat.rels[1].var.is_empty() {
+                        row_vals.insert(
+                            format!("{}.__type__", pat.rels[1].var),
+                            Value::String(pat.rels[1].rel_type.clone()),
                         );
                     }
                     if !eval_where(where_expr, &row_vals) {
@@ -1968,6 +1983,56 @@ fn extract_return_column_names(items: &[ReturnItem]) -> Vec<String> {
             },
         })
         .collect()
+}
+
+/// Collect all column IDs referenced by property accesses in an expression,
+/// scoped to a specific variable name.
+///
+/// Only `PropAccess` nodes whose `var` field matches `target_var` contribute
+/// column IDs, so callers can separate src-side from fof-side columns without
+/// accidentally fetching unrelated properties from the wrong node.
+fn collect_col_ids_from_expr_for_var(expr: &Expr, target_var: &str, out: &mut Vec<u32>) {
+    match expr {
+        Expr::PropAccess { var, prop } => {
+            if var == target_var {
+                let col_id = prop_name_to_col_id(prop);
+                if !out.contains(&col_id) {
+                    out.push(col_id);
+                }
+            }
+        }
+        Expr::BinOp { left, right, .. } => {
+            collect_col_ids_from_expr_for_var(left, target_var, out);
+            collect_col_ids_from_expr_for_var(right, target_var, out);
+        }
+        Expr::And(l, r) | Expr::Or(l, r) => {
+            collect_col_ids_from_expr_for_var(l, target_var, out);
+            collect_col_ids_from_expr_for_var(r, target_var, out);
+        }
+        Expr::Not(inner) | Expr::IsNull(inner) | Expr::IsNotNull(inner) => {
+            collect_col_ids_from_expr_for_var(inner, target_var, out);
+        }
+        Expr::InList { expr, list, .. } => {
+            collect_col_ids_from_expr_for_var(expr, target_var, out);
+            for item in list {
+                collect_col_ids_from_expr_for_var(item, target_var, out);
+            }
+        }
+        Expr::FnCall { args, .. } | Expr::List(args) => {
+            for arg in args {
+                collect_col_ids_from_expr_for_var(arg, target_var, out);
+            }
+        }
+        Expr::ListPredicate {
+            list_expr,
+            predicate,
+            ..
+        } => {
+            collect_col_ids_from_expr_for_var(list_expr, target_var, out);
+            collect_col_ids_from_expr_for_var(predicate, target_var, out);
+        }
+        _ => {}
+    }
 }
 
 /// Collect all column IDs referenced by property accesses in an expression.

--- a/crates/sparrowdb/tests/spa_188_two_hop_where.rs
+++ b/crates/sparrowdb/tests/spa_188_two_hop_where.rs
@@ -168,3 +168,77 @@ fn two_hop_without_where_returns_all_paths() {
     names.sort();
     assert_eq!(names, vec!["Charlie", "Dave"]);
 }
+
+/// Source-side WHERE binding test.
+///
+/// Graph:
+///   Alice -[:KNOWS]-> Bob -[:KNOWS]-> Charlie
+///   Alice -[:KNOWS]-> Bob -[:KNOWS]-> Dave
+///   Eve   -[:KNOWS]-> Bob -[:KNOWS]-> Charlie
+///   Eve   -[:KNOWS]-> Bob -[:KNOWS]-> Dave
+///
+/// Query:
+///   MATCH (a:Person)-[:KNOWS]->(b:Person)-[:KNOWS]->(c:Person)
+///   WHERE a.name = 'Alice' AND c.name = 'Charlie' RETURN c.name
+///
+/// Expected: exactly one row containing String("Charlie").
+/// A bug that ignores src-side WHERE bindings would return 2 rows (Alice and Eve paths).
+#[test]
+fn two_hop_where_filters_by_src_and_fof() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (:Person {name: 'Alice'})")
+        .expect("CREATE Alice");
+    db.execute("CREATE (:Person {name: 'Bob'})")
+        .expect("CREATE Bob");
+    db.execute("CREATE (:Person {name: 'Charlie'})")
+        .expect("CREATE Charlie");
+    db.execute("CREATE (:Person {name: 'Dave'})")
+        .expect("CREATE Dave");
+    db.execute("CREATE (:Person {name: 'Eve'})")
+        .expect("CREATE Eve");
+
+    // Alice -> Bob
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .expect("edge Alice->Bob");
+
+    // Eve -> Bob (second source so src-side filtering is load-bearing)
+    db.execute("MATCH (e:Person {name: 'Eve'}), (b:Person {name: 'Bob'}) CREATE (e)-[:KNOWS]->(b)")
+        .expect("edge Eve->Bob");
+
+    // Bob -> Charlie
+    db.execute(
+        "MATCH (b:Person {name: 'Bob'}), (c:Person {name: 'Charlie'}) CREATE (b)-[:KNOWS]->(c)",
+    )
+    .expect("edge Bob->Charlie");
+
+    // Bob -> Dave
+    db.execute(
+        "MATCH (b:Person {name: 'Bob'}), (d:Person {name: 'Dave'}) CREATE (b)-[:KNOWS]->(d)",
+    )
+    .expect("edge Bob->Dave");
+
+    let result = db
+        .execute(
+            "MATCH (a:Person)-[:KNOWS]->(b:Person)-[:KNOWS]->(c:Person) \
+             WHERE a.name = 'Alice' AND c.name = 'Charlie' RETURN c.name",
+        )
+        .expect("two-hop WHERE src+fof query");
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "WHERE a.name='Alice' AND c.name='Charlie' must return exactly 1 row; got {} row(s): {:?}",
+        result.rows.len(),
+        result.rows
+    );
+
+    assert_eq!(
+        result.rows[0][0],
+        Value::String("Charlie".to_string()),
+        "returned value must be String('Charlie'), got {:?}",
+        result.rows[0][0]
+    );
+}


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause**: `execute_two_hop` in `engine.rs` collected all 2-hop candidate paths via ASP-Join but never applied `m.where_clause`. Every path was returned regardless of the WHERE condition.
- **Fix**: After resolving the fof (friend-of-friend) node and applying inline prop filters, build a combined binding map from both src and fof node properties and call `eval_where`. Also ensure the WHERE-referenced column IDs are read from disk before the scan loop.
- **Tests**: Three new e2e integration tests in `crates/sparrowdb/tests/spa_188_two_hop_where.rs` confirm the fix and guard against regression.

## Changes

- `crates/sparrowdb-execution/src/engine.rs`: Collect WHERE-clause col_ids for src and fof nodes; call `eval_where` per candidate path in `execute_two_hop`.
- `crates/sparrowdb/tests/spa_188_two_hop_where.rs`: New regression test file with three tests.

## Test plan

- [ ] `cargo test --test spa_188_two_hop_where` — 3 tests pass
- [ ] `cargo test -p sparrowdb` — full suite (162 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Apply WHERE filters to 2-hop path queries**

### What Changed
- 2-hop graph queries now respect the WHERE clause and return only paths that match it.
- When a WHERE condition does not match, the query returns no rows instead of unrelated paths.
- Queries without a WHERE clause still return all matching 2-hop paths.
- Added regression tests covering a matching filter, a no-match case, and the no-WHERE case.

### Impact
`✅ Correct 2-hop query results`
`✅ Fewer unexpected rows in graph searches`
`✅ Safer regression coverage for path filtering`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WHERE clause filtering in two-hop MATCH queries. WHERE predicates now correctly evaluate and filter results when traversing multiple relationship hops.

* **Tests**
  * Added regression tests to validate WHERE clause behavior in two-hop traversals, including matching, non-matching, and unfiltered query scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->