### PR TITLE
fix(db): node-only CREATE routes through WriteTx; reject non-literal props in edge CREATE (SPA-182 followup)

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -220,9 +220,10 @@ impl Engine {
     pub fn is_mutation(stmt: &Statement) -> bool {
         match stmt {
             Statement::Merge(_) | Statement::MatchMutate(_) | Statement::MatchCreate(_) => true,
-            // A standalone CREATE that contains edges must go through the
-            // write-transaction path so the executor can call create_edge.
-            Statement::Create(c) => !c.edges.is_empty(),
+            // All standalone CREATE statements must go through the
+            // write-transaction path to ensure WAL durability and correct
+            // single-writer semantics, regardless of whether edges are present.
+            Statement::Create(_) => true,
             _ => false,
         }
     }

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -395,10 +395,16 @@ impl GraphDb {
                 .iter()
                 .map(|entry| {
                     let col_id = col_id_of(&entry.key);
-                    let val = expr_to_value(&entry.value);
-                    (col_id, val)
+                    match &entry.value {
+                        sparrowdb_cypher::ast::Expr::Literal(lit) => {
+                            Ok((col_id, literal_to_value(lit)))
+                        }
+                        _ => Err(sparrowdb_common::Error::InvalidArgument(
+                            "CREATE with relationship edges currently supports only literal node properties".into(),
+                        )),
+                    }
                 })
-                .collect();
+                .collect::<Result<Vec<_>>>()?;
 
             let node_id = tx.create_node(label_id, &props)?;
 


### PR DESCRIPTION
## **User description**
## Summary

Two critical bugs caught by PR #60 reviewers after merge:

1. **Race condition**: `is_mutation()` returned `false` for node-only CREATE statements, bypassing the WriteTx path (no WAL durability, no writer-lock exclusion). Fixed: all `Statement::Create` are now mutations.

2. **Silent data corruption**: `execute_create_standalone` used `expr_to_value` for node properties in edge-bearing CREATEs, silently coercing `datetime()` and other expressions to `Value::Int64(0)`. Fixed: now uses `literal_to_value` with explicit error for non-literal expressions.

These fixes were prepared in the SPA-182 review loop but the PR was merged before they could be pushed.

## Test plan
- [ ] `cargo test -p sparrowdb` passes
- [ ] All CI checks green


___

## **CodeAnt-AI Description**
**Prevent standalone CREATE from bypassing the write path and reject non-literal node properties in edge-bearing CREATE**

### What Changed
- All standalone CREATE statements now use the write path, so node-only creates get the same durability and single-writer protection as other writes.
- CREATE statements that also define edges now fail when a node property uses anything other than a literal value, instead of quietly turning it into the wrong stored value.

### Impact
`✅ Fewer race conditions during concurrent creates`
`✅ Durable node-only writes`
`✅ Clearer errors for invalid CREATE statements`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
