### PR TITLE
fix(storage): missing property returns null not 0 (SPA-197)

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -280,11 +280,7 @@ impl Engine {
 
         for slot in 0..hwm {
             let node_id = NodeId(((label_id as u64) << 32) | slot);
-            let props = if !all_col_ids.is_empty() {
-                self.store.get_node_raw(node_id, &all_col_ids)?
-            } else {
-                vec![]
-            };
+            let props = read_node_props(&self.store, node_id, &all_col_ids)?;
 
             if !matches_prop_filter_static(&props, &node_pat.props) {
                 continue;
@@ -632,7 +628,7 @@ impl Engine {
                 if col0_check.iter().any(|&(c, v)| c == 0 && v == u64::MAX) {
                     continue;
                 }
-                let props = self.store.get_node_raw(node_id, &all_col_ids)?;
+                let props = read_node_props(&self.store, node_id, &all_col_ids)?;
                 if !self.matches_prop_filter(&props, &node.props) {
                     continue;
                 }
@@ -814,7 +810,7 @@ impl Engine {
             if col0_check.iter().any(|&(c, v)| c == 0 && v == u64::MAX) {
                 continue;
             }
-            let props = self.store.get_node_raw(node_id, &lead_all_col_ids)?;
+            let props = read_node_props(&self.store, node_id, &lead_all_col_ids)?;
             if !self.matches_prop_filter(&props, &lead_node_pat.props) {
                 continue;
             }
@@ -991,11 +987,7 @@ impl Engine {
                 continue;
             }
             let dst_node = NodeId(((dst_label_id as u64) << 32) | dst_slot);
-            let dst_props = if !col_ids_dst.is_empty() {
-                self.store.get_node_raw(dst_node, &col_ids_dst)?
-            } else {
-                vec![]
-            };
+            let dst_props = read_node_props(&self.store, dst_node, &col_ids_dst)?;
             if !self.matches_prop_filter(&dst_props, &dst_node_pat.props) {
                 continue;
             }
@@ -1184,7 +1176,7 @@ impl Engine {
         // Scan source nodes.
         for src_slot in 0..hwm_src {
             let src_node = NodeId(((src_label_id as u64) << 32) | src_slot);
-            let src_props = if !col_ids_src.is_empty() || !src_node_pat.props.is_empty() {
+            let src_props = {
                 let all_needed: Vec<u32> = {
                     let mut v = col_ids_src.clone();
                     // Add prop filter cols
@@ -1196,9 +1188,7 @@ impl Engine {
                     }
                     v
                 };
-                self.store.get_node_raw(src_node, &all_needed)?
-            } else {
-                vec![]
+                read_node_props(&self.store, src_node, &all_needed)?
             };
 
             // Apply src inline prop filter.
@@ -1237,11 +1227,7 @@ impl Engine {
                     continue;
                 }
                 let dst_node = NodeId(((dst_label_id as u64) << 32) | dst_slot);
-                let dst_props = if !col_ids_dst.is_empty() {
-                    self.store.get_node_raw(dst_node, &col_ids_dst)?
-                } else {
-                    vec![]
-                };
+                let dst_props = read_node_props(&self.store, dst_node, &col_ids_dst)?;
 
                 // Apply dst inline prop filter.
                 if !self.matches_prop_filter(&dst_props, &dst_node_pat.props) {
@@ -1438,11 +1424,7 @@ impl Engine {
                 v
             };
 
-            let src_props = if !src_needed.is_empty() {
-                self.store.get_node_raw(src_node, &src_needed)?
-            } else {
-                vec![]
-            };
+            let src_props = read_node_props(&self.store, src_node, &src_needed)?;
 
             // Apply src inline prop filter.
             if !self.matches_prop_filter(&src_props, &src_node_pat.props) {
@@ -1481,11 +1463,7 @@ impl Engine {
 
             for fof_slot in fof_slots {
                 let fof_node = NodeId(((fof_label_id as u64) << 32) | fof_slot);
-                let fof_props = if !col_ids_fof.is_empty() {
-                    self.store.get_node_raw(fof_node, &col_ids_fof)?
-                } else {
-                    vec![]
-                };
+                let fof_props = read_node_props(&self.store, fof_node, &col_ids_fof)?;
 
                 // Apply fof inline prop filter.
                 if !self.matches_prop_filter(&fof_props, &fof_node_pat.props) {
@@ -1644,11 +1622,7 @@ impl Engine {
                 }
                 v
             };
-            let src_props = if !src_all_col_ids.is_empty() {
-                self.store.get_node_raw(src_node, &src_all_col_ids)?
-            } else {
-                vec![]
-            };
+            let src_props = read_node_props(&self.store, src_node, &src_all_col_ids)?;
 
             if !self.matches_prop_filter(&src_props, &src_node_pat.props) {
                 continue;
@@ -1663,11 +1637,7 @@ impl Engine {
                 }
 
                 let dst_node = NodeId(((dst_label_id as u64) << 32) | dst_slot);
-                let dst_props = if !col_ids_dst.is_empty() {
-                    self.store.get_node_raw(dst_node, &col_ids_dst)?
-                } else {
-                    vec![]
-                };
+                let dst_props = read_node_props(&self.store, dst_node, &col_ids_dst)?;
 
                 if !self.matches_prop_filter(&dst_props, &dst_node_pat.props) {
                     continue;
@@ -2073,6 +2043,32 @@ fn collect_col_ids_for_var(var: &str, column_names: &[String], _label_id: u32) -
         ids.push(0);
     }
     ids
+}
+
+/// Read node properties using the nullable store path (SPA-197).
+///
+/// Calls `get_node_raw_nullable` so that columns that were never written for
+/// this node are returned as `None` (absent) rather than `0u64`.  The result
+/// is a `Vec<(col_id, raw_u64)>` containing only the columns that have a real
+/// stored value; callers that iterate over `col_ids` but don't find a column
+/// in the result will receive `Value::Null` (e.g. via `project_row`).
+///
+/// This is the correct read path for any code that eventually projects
+/// property values into query results.  Use `get_node_raw` only for
+/// tombstone checks (col 0 == u64::MAX) where the raw sentinel is meaningful.
+fn read_node_props(
+    store: &NodeStore,
+    node_id: NodeId,
+    col_ids: &[u32],
+) -> sparrowdb_common::Result<Vec<(u32, u64)>> {
+    if col_ids.is_empty() {
+        return Ok(vec![]);
+    }
+    let nullable = store.get_node_raw_nullable(node_id, col_ids)?;
+    Ok(nullable
+        .into_iter()
+        .filter_map(|(col_id, opt): (u32, Option<u64>)| opt.map(|v| (col_id, v)))
+        .collect())
 }
 
 /// Decode a raw `u64` column value (as returned by `get_node_raw`) into the
@@ -2922,8 +2918,7 @@ fn eval_call_expr(expr: &Expr, env: &HashMap<String, Value>, store: &NodeStore) 
         Expr::PropAccess { var, prop } => match env.get(var.as_str()) {
             Some(Value::NodeRef(node_id)) => {
                 let col_id = prop_name_to_col_id(prop);
-                store
-                    .get_node_raw(*node_id, &[col_id])
+                read_node_props(store, *node_id, &[col_id])
                     .ok()
                     .and_then(|pairs| pairs.into_iter().find(|(c, _)| *c == col_id))
                     .map(|(_, raw)| decode_raw_val(raw))

--- a/crates/sparrowdb/tests/spa_197_missing_prop_null.rs
+++ b/crates/sparrowdb/tests/spa_197_missing_prop_null.rs
@@ -1,0 +1,121 @@
+//! End-to-end regression test for SPA-197.
+//!
+//! When a node is created without a particular property (e.g. no `name` field),
+//! a subsequent `MATCH (n) RETURN n.name` used to return `Int64(0)` because
+//! `get_node_raw` returned `0u64` for absent column slots and `decode_raw_val(0)`
+//! produced `Value::Int64(0)` (type tag 0x00 = Int64).
+//!
+//! The fix (SPA-197) routes all property reads through `get_node_raw_nullable`
+//! via the new `read_node_props` helper, which treats absent/zero slots as
+//! `None` and allows `project_row` / `build_row_vals` to return `Value::Null`
+//! instead.
+
+use sparrowdb_catalog::catalog::Catalog;
+use sparrowdb_execution::engine::Engine;
+use sparrowdb_execution::types::Value;
+use sparrowdb_storage::csr::CsrForward;
+use sparrowdb_storage::node_store::NodeStore;
+
+fn fresh_engine(dir: &std::path::Path) -> Engine {
+    let store = NodeStore::open(dir).expect("node store");
+    let cat = Catalog::open(dir).expect("catalog");
+    let csr = CsrForward::build(0, &[]);
+    Engine::new(store, cat, csr, dir)
+}
+
+/// CREATE a node with only `content` property (no `name`).
+/// RETURN n.name must be `Value::Null`, not `Value::Int64(0)`.
+#[test]
+fn missing_string_property_returns_null() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut engine = fresh_engine(dir.path());
+
+    // Use a short string (≤7 bytes) to stay within the inline-bytes encoding
+    // limit (SPA-169) — longer strings are truncated by the storage layer.
+    engine
+        .execute("CREATE (n:Know {body: 'Fact'})")
+        .expect("CREATE");
+
+    let result = engine
+        .execute("MATCH (n:Know) RETURN n.name, n.body")
+        .expect("MATCH RETURN");
+
+    assert_eq!(result.rows.len(), 1, "expected exactly 1 Know node");
+
+    // n.name was never set — must be null, not integer 0 (SPA-197).
+    assert_eq!(
+        result.rows[0][0],
+        Value::Null,
+        "n.name was never set; expected Value::Null but got {:?} (SPA-197)",
+        result.rows[0][0]
+    );
+
+    // n.body was set — must be the correct string.
+    assert_eq!(
+        result.rows[0][1],
+        Value::String("Fact".to_string()),
+        "n.body must be String('Fact')"
+    );
+}
+
+/// Variation: multiple nodes, only some have a property.
+/// Nodes that don't have it must return null; nodes that do must return the value.
+///
+/// Uses short strings (≤7 bytes) to stay within the inline-bytes storage limit.
+#[test]
+fn partial_property_coverage_returns_null_for_absent_nodes() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut engine = fresh_engine(dir.path());
+
+    // Node 1 has both properties; node 2 has only body.
+    engine
+        .execute("CREATE (n:Item {name: 'Widget', body: 'small'})")
+        .expect("CREATE 1");
+    engine
+        .execute("CREATE (n:Item {body: 'anon'})")
+        .expect("CREATE 2");
+
+    let result = engine
+        .execute("MATCH (n:Item) RETURN n.name, n.body ORDER BY n.body")
+        .expect("MATCH RETURN");
+
+    assert_eq!(result.rows.len(), 2, "expected 2 Item nodes");
+
+    // After ORDER BY n.body: "anon" < "small".
+    let (nameless_name, _nameless_body) = (&result.rows[0][0], &result.rows[0][1]);
+    let (widget_name, _widget_body) = (&result.rows[1][0], &result.rows[1][1]);
+
+    assert_eq!(
+        *nameless_name,
+        Value::Null,
+        "Node without name must return Value::Null (SPA-197)"
+    );
+    assert_eq!(
+        *widget_name,
+        Value::String("Widget".to_string()),
+        "Node with name='Widget' must return Value::String('Widget')"
+    );
+}
+
+/// Regression: missing integer property must also return null, not 0.
+/// Note: avoid `n.count` which conflicts with the COUNT aggregate keyword.
+#[test]
+fn missing_integer_property_returns_null() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut engine = fresh_engine(dir.path());
+
+    engine
+        .execute("CREATE (n:Item {body: 'hello'})")
+        .expect("CREATE");
+
+    let result = engine
+        .execute("MATCH (n:Item) RETURN n.score")
+        .expect("MATCH RETURN");
+
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(
+        result.rows[0][0],
+        Value::Null,
+        "missing integer property must be Null, not Int64(0) (SPA-197)"
+    );
+}


### PR DESCRIPTION
## **User description**
## Summary

- `MATCH (n:Know) RETURN n.name` where `n` was created without a `name` property was returning `Int64(0)` instead of `null`
- Root cause: `get_node_raw` returns `Ok(0u64)` for absent column slots (file-not-found path), and `decode_raw_val(0)` produces `Value::Int64(0)` because type-tag `0x00` = Int64
- The fix for IS NULL (SPA-168) introduced `get_node_raw_nullable` but it was only used in `execute_scan`; all other execution paths (one-hop, two-hop, variable-length, MATCH/WITH, OPTIONAL MATCH, CALL prop access) still used the non-nullable path

## Fix

Introduces `read_node_props()` — a free function wrapping `get_node_raw_nullable` that filters out `None` (absent) entries before returning `Vec<(u32, u64)>`. All property-projection call sites in `engine.rs` now go through this helper:

- `scan_for_ids` (MATCH WHERE filter path)
- `execute_with_match` scan loop
- `execute_match_optional_match` lead rows
- `fetch_neighbor_rows` (OPTIONAL MATCH sub-pattern dst)
- `execute_one_hop` src + dst props
- `execute_two_hop` src + fof props
- `execute_variable_length` src + dst props
- `eval_call_expr` PropAccess (CALL procedure results)

Tombstone checks (`col_0 == u64::MAX`) continue to use `get_node_raw` — that is correct.

## Test plan

- [x] 3 new e2e regression tests in `crates/sparrowdb/tests/spa_197_missing_prop_null.rs`
  - `missing_string_property_returns_null` — node with no `name`, RETURN `n.name` = null
  - `partial_property_coverage_returns_null_for_absent_nodes` — 2 nodes, one with name one without
  - `missing_integer_property_returns_null` — node with no `score`, RETURN `n.score` = null
- [x] Full `cargo test -p sparrowdb` suite passes (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Missing node properties now return null in query results**

### What Changed
- Queries now return `null` when a node does not have a requested property, instead of showing `0`
- This applies across node lookups, path queries, optional matches, and property access inside calls
- Added regression tests for missing string and integer properties, including mixed cases where only some nodes have the field

### Impact
`✅ Correct nulls for missing fields`
`✅ Fewer false 0 values in query results`
`✅ Safer property reads across graph queries`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
