### PR TITLE
fix(engine): count(expr) routes through aggregation — SPA-194

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -1202,8 +1202,7 @@ impl Engine {
                     continue;
                 }
 
-                let nullable_props =
-                    self.store.get_node_raw_nullable(node_id, &all_col_ids)?;
+                let nullable_props = self.store.get_node_raw_nullable(node_id, &all_col_ids)?;
                 let props: Vec<(u32, u64)> = nullable_props
                     .iter()
                     .filter_map(|&(col_id, opt)| opt.map(|v| (col_id, v)))
@@ -1239,8 +1238,7 @@ impl Engine {
                     }
                     raw_rows.push(row_vals);
                 } else {
-                    let row =
-                        project_row(&props, column_names, &all_col_ids, var_name, label_name);
+                    let row = project_row(&props, column_names, &all_col_ids, var_name, label_name);
                     rows.push(row);
                 }
             }

--- a/crates/sparrowdb/tests/spa_194_count_node_var.rs
+++ b/crates/sparrowdb/tests/spa_194_count_node_var.rs
@@ -101,8 +101,7 @@ fn count_node_var_grouped_by_property() {
     );
 
     // Build a map of name → count for order-independent checking.
-    let mut name_counts: std::collections::HashMap<String, i64> =
-        std::collections::HashMap::new();
+    let mut name_counts: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
     for row in &result.rows {
         let name = match &row[0] {
             Value::String(s) => s.clone(),


### PR DESCRIPTION
## **User description**
## Summary

- `MATCH (n) RETURN count(n)` was failing with `NotFound` because `execute_scan()` attempted `get_label("")` when no node label was specified, returning `None` → `NotFound`
- Fix: add `execute_scan_all_labels()` that iterates all registered catalog labels and unions their nodes, then applies aggregation/ORDER BY/LIMIT after the union
- Wire the new method as an early-return in `execute_scan()` when `node.labels` is empty
- The labeled case `MATCH (n:Person) RETURN count(n)` already worked correctly via the existing `AggKind::Count` path (variable `n` evaluates to `Value::NodeRef` which is non-null and counted)

## Test plan

- [ ] `count_node_var_lowercase_with_label` — `MATCH (n:Person) RETURN count(n) as cnt` returns `Int64(3)` for 3 nodes
- [ ] `count_node_var_no_label_full_scan` — `MATCH (n) RETURN count(n) as cnt` counts across all labels
- [ ] `count_node_var_grouped_by_property` — `MATCH (n:Person) RETURN n.name, count(n)` produces correct grouped counts
- [ ] Full `cargo test -p sparrowdb` suite passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Count node queries now work with and without a label**

### What Changed
- `MATCH (n) RETURN count(n)` now counts nodes across all labels instead of failing when no label is provided
- Count queries keep working with labels and grouped results, including `MATCH (n:Person) RETURN n.name, count(n)`
- Added regression tests for labeled counts, unlabeled full scans, and grouped counts

### Impact
`✅ Unlabeled count queries no longer fail`
`✅ Accurate counts across all node labels`
`✅ Fewer regressions in count-based queries`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
