### PR TITLE
fix(db): reject Literal::Null and Literal::Param in CREATE properties

### DIFF
--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -448,12 +448,25 @@ impl GraphDb {
                 .map(|entry| {
                     let col_id = col_id_of(&entry.key);
                     match &entry.value {
+                        sparrowdb_cypher::ast::Expr::Literal(
+                            sparrowdb_cypher::ast::Literal::Null,
+                        ) => Err(sparrowdb_common::Error::InvalidArgument(format!(
+                            "CREATE property '{}' is null; use a concrete value",
+                            entry.key
+                        ))),
+                        sparrowdb_cypher::ast::Expr::Literal(
+                            sparrowdb_cypher::ast::Literal::Param(p),
+                        ) => Err(sparrowdb_common::Error::InvalidArgument(format!(
+                            "CREATE property '{}' references parameter ${p}; runtime parameters are not yet supported in standalone CREATE",
+                            entry.key
+                        ))),
                         sparrowdb_cypher::ast::Expr::Literal(lit) => {
                             Ok((col_id, literal_to_value(lit)))
                         }
-                        _ => Err(sparrowdb_common::Error::InvalidArgument(
-                            "CREATE with relationship edges currently supports only literal node properties".into(),
-                        )),
+                        _ => Err(sparrowdb_common::Error::InvalidArgument(format!(
+                            "CREATE property '{}' must be a literal value (int, float, bool, or string)",
+                            entry.key
+                        ))),
                     }
                 })
                 .collect::<Result<Vec<_>>>()?;


### PR DESCRIPTION
## **User description**
## Summary

CodeAnt flagged that `execute_create_standalone` had an insufficient guard: `Expr::Literal` matched all literal variants, but `literal_to_value` silently coerces `Literal::Null` and `Literal::Param(_)` to `Int64(0)`.

This means:
- `CREATE (a:N {x: null})` → writes `0` instead of rejecting or writing null
- `CREATE (a:N {x: $p})` → writes `0` instead of propagating the parameter

**Fix:** Add explicit match arms for `Literal::Null` and `Literal::Param` before the catch-all `Expr::Literal` arm, returning clear `InvalidArgument` errors.

Follow-up to #64 (SPA-182) — the fix was reviewed post-merge and missed the squash window.

## Test plan
- [ ] CREATE with null literal property returns error
- [ ] CREATE with param literal property returns error
- [ ] CREATE with normal literal properties still works


___

## **CodeAnt-AI Description**
**Reject invalid CREATE property values instead of storing the wrong value**

### What Changed
- CREATE now rejects `null` property values with a clear error message
- CREATE now rejects parameter-based property values and explains that runtime parameters are not supported in standalone CREATE
- Non-literal property values now get a direct message saying only basic literal values are allowed

### Impact
`✅ Fewer incorrect node properties`
`✅ Clearer CREATE validation errors`
`✅ Less silent data corruption`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
