### PR TITLE
fix(python): update sparrowdb-python to use WriteTx without 'static lifetime (SPA-181)

### DIFF
--- a/crates/sparrowdb-python/src/lib.rs
+++ b/crates/sparrowdb-python/src/lib.rs
@@ -95,21 +95,13 @@ impl PyGraphDb {
     /// Raises ``RuntimeError`` if another write transaction is already active
     /// (single-writer semantics).
     fn begin_write(&self) -> PyResult<PyWriteTx> {
-        // Safety: we transmute WriteTx<'_> to WriteTx<'static> so it can be
-        // stored in a PyO3 class.  This is safe because:
-        // 1. The `'db` lifetime on WriteTx only constrains the MutexGuard,
-        //    which holds the write-lock on `inner.write_lock`.
-        // 2. `PyGraphDb` holds `inner: GraphDb` which contains the Arc<DbInner>
-        //    keeping the Mutex alive for the whole program lifetime of the db.
-        // 3. PyWriteTx will be dropped (releasing the guard) before `inner`
-        //    is dropped, enforced by Python's GC reference counting.
-        let tx: ::sparrowdb::WriteTx<'static> = unsafe {
-            std::mem::transmute(
-                self.inner
-                    .begin_write()
-                    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?,
-            )
-        };
+        // SPA-181: WriteTx no longer carries a lifetime parameter — the write
+        // lock is managed internally by an AtomicBool WriteGuard, so no unsafe
+        // transmute is required here.
+        let tx = self
+            .inner
+            .begin_write()
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
         Ok(PyWriteTx { inner: Some(tx) })
     }
 
@@ -187,7 +179,7 @@ impl PyReadTx {
 #[pyclass(unsendable, name = "WriteTx")]
 struct PyWriteTx {
     /// `None` after commit/rollback so use-after-commit is detected.
-    inner: Option<::sparrowdb::WriteTx<'static>>,
+    inner: Option<::sparrowdb::WriteTx>,
 }
 
 #[cfg(feature = "python")]


### PR DESCRIPTION
## **User description**
## Summary

- SPA-181 (PR #63) removed the lifetime parameter from `WriteTx` by replacing `Mutex<()>` + `unsafe transmute` with an `AtomicBool` `WriteGuard`
- `sparrowdb-python` stored `WriteTx<'static>` and used `unsafe transmute` in `begin_write` — now invalid since `WriteTx` takes 0 lifetime arguments
- Removes `WriteTx<'static>` annotation and unsafe transmute, replacing with a direct `begin_write()` call

## Test plan

- [ ] Python bindings CI passes (`maturin develop` + pytest)
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Update Python write transactions to match the new transaction API**

### What Changed
- Python write transactions now open with the updated transaction type, restoring compatibility with the latest database core changes
- Removed the unsafe conversion step when starting a write transaction
- Write transactions still commit and roll back the same way for Python users

### Impact
`✅ Python write transactions work with the latest core release`
`✅ Fewer binding breakages after upgrades`
`✅ Safer transaction startup`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
