### PR TITLE
feat(cypher): CONTAINS string predicate for WHERE clauses — SPA-206

### DIFF
--- a/crates/sparrowdb/tests/spa_206_contains_predicate.rs
+++ b/crates/sparrowdb/tests/spa_206_contains_predicate.rs
@@ -52,7 +52,11 @@ fn contains_basic_match() {
         .execute("MATCH (n:Doc) WHERE n.body CONTAINS 'hi' RETURN n.title")
         .expect("MATCH WHERE CONTAINS");
 
-    assert_eq!(result.rows.len(), 2, "expected 2 rows — A and B contain 'hi'");
+    assert_eq!(
+        result.rows.len(),
+        2,
+        "expected 2 rows — A and B contain 'hi'"
+    );
     let titles: Vec<&Value> = result.rows.iter().map(|r| &r[0]).collect();
     assert!(
         titles.contains(&&Value::String("A".to_string())),
@@ -83,7 +87,11 @@ fn contains_no_match() {
         .execute("MATCH (n:Doc) WHERE n.body CONTAINS 'zzz' RETURN n.title")
         .expect("MATCH WHERE CONTAINS no match — must not error");
 
-    assert_eq!(result.rows.len(), 0, "expected 0 rows — no body contains 'zzz'");
+    assert_eq!(
+        result.rows.len(),
+        0,
+        "expected 0 rows — no body contains 'zzz'"
+    );
 }
 
 // ── CONTAINS: missing property → no match (not error) ────────────────────────


### PR DESCRIPTION
## **User description**
## Summary

- Verifies `WHERE n.prop CONTAINS 'substr'` is parsed as a `BinOpKind::Contains` binary expression (lexer, AST, and parser already had this wired up)
- Confirms evaluation via `String::contains()` in both `eval_where` (predicate path) and `eval_expr` (return-expression path) in the execution engine
- Adds 6 end-to-end integration tests covering all required behaviours
- Required for KMS GAP-5 fulltext search bridge

## What already existed vs. what this PR adds

| Layer | Status before this PR |
|-------|----------------------|
| Lexer (`Token::Contains`) | Already present |
| AST (`BinOpKind::Contains`) | Already present |
| Parser (maps `Token::Contains` → `BinOpKind::Contains`) | Already present |
| Evaluator (`eval_where` + `eval_expr`) | Already present |
| **Tests** | **Missing — added by this PR** |

The implementation was complete but entirely untested. This PR closes that gap.

## Storage constraint documented

The v1 inline encoding stores at most 7 bytes of string data per property slot. Test strings are kept within this limit; a comment in the test file documents the constraint for future contributors.

## Test plan

- [x] Basic CONTAINS match returns correct rows (2 of 3 nodes)
- [x] Non-matching value returns empty result set
- [x] Missing property does not error — node is silently excluded
- [x] CONTAINS is case-sensitive (`'Hi'` ≠ `'hi mom'`)
- [x] Full string equal to substring still matches
- [x] Non-string (integer) property returns no match, no error
- [x] Full `cargo test -p sparrowdb` suite passes (one pre-existing `spa191` failure unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add end-to-end coverage for Cypher `CONTAINS` filtering**

### What Changed
- Added integration tests for `WHERE n.prop CONTAINS 'substring'` to verify basic matches, no-match results, and exact-string matches
- Confirmed missing properties and non-string values do not error and are simply excluded from results
- Verified the match is case-sensitive

### Impact
`✅ Safer CONTAINS queries`
`✅ Fewer unexpected query errors`
`✅ Clearer search behavior for users`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
