### PR TITLE
feat: CALL db.schema() + named columns in QueryResult (SPA-209)

### DIFF
--- a/crates/sparrowdb-catalog/src/catalog.rs
+++ b/crates/sparrowdb-catalog/src/catalog.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 use sparrowdb_common::{Error, Result};
 
-use crate::tlv::{encode_entries, LabelEntry, RelTableEntry, TlvEntry};
+use crate::tlv::{encode_entries, ColumnEntry, LabelEntry, RelTableEntry, TlvEntry};
 
 /// Label identifier (u16 matches the TLV label_id field).
 pub type LabelId = u16;
@@ -26,6 +26,11 @@ pub struct Catalog {
     labels: Vec<LabelEntry>,
     /// In-memory relationship table entries.
     rel_tables: Vec<RelTableEntry>,
+    /// In-memory column entries: tracks observed property key names per owner.
+    ///
+    /// Keyed by `(owner_kind, owner_id)` → set of `(field_id, name)` pairs.
+    /// `owner_kind = 0` means a node label; `owner_id` is the `label_id as u64`.
+    column_entries: Vec<ColumnEntry>,
     /// Next label_id to assign.
     next_label_id: u16,
     /// Next rel_table_id to assign.
@@ -43,6 +48,7 @@ impl Catalog {
             path,
             labels: Vec::new(),
             rel_tables: Vec::new(),
+            column_entries: Vec::new(),
             next_label_id: 0,
             next_rel_table_id: 0,
         };
@@ -228,6 +234,54 @@ impl Catalog {
             .collect()
     }
 
+    // --- Property key tracking ---
+
+    /// Register an observed property key name for a node label.
+    ///
+    /// If the `(label_id, field_id)` pair is already registered, this is a
+    /// no-op (idempotent).  Otherwise, the column entry is persisted to the
+    /// catalog file and added to the in-memory set.
+    ///
+    /// `field_id` should be the FNV-1a hash derived from `name` via
+    /// `sparrowdb_common::col_id_of`.
+    pub fn register_property_key(
+        &mut self,
+        label_id: u16,
+        field_id: u32,
+        name: &str,
+    ) -> Result<()> {
+        // Check idempotency — already registered?
+        let already = self
+            .column_entries
+            .iter()
+            .any(|e| e.owner_kind == 0 && e.owner_id == label_id as u64 && e.field_id == field_id);
+        if already {
+            return Ok(());
+        }
+        let entry = ColumnEntry {
+            owner_kind: 0,
+            owner_id: label_id as u64,
+            field_id,
+            name: name.to_string(),
+            type_tag: 0,
+            nullable: 1,
+            has_default: 0,
+            default_bytes: Vec::new(),
+        };
+        self.append_entry(TlvEntry::Column(entry.clone()))?;
+        self.column_entries.push(entry);
+        Ok(())
+    }
+
+    /// Return all observed property key names for a given node label.
+    pub fn list_property_keys(&self, label_id: u16) -> Vec<String> {
+        self.column_entries
+            .iter()
+            .filter(|e| e.owner_kind == 0 && e.owner_id == label_id as u64)
+            .map(|e| e.name.clone())
+            .collect()
+    }
+
     // --- Private helpers ---
 
     /// Load all TLV entries from the catalog file into memory.
@@ -268,6 +322,18 @@ impl Catalog {
                         self.next_rel_table_id = e.rel_table_id + 1;
                     }
                     self.rel_tables.push(e);
+                }
+                TlvEntry::Column(e) => {
+                    // Load column (property key) entries into memory.
+                    // Duplicates are silently skipped (idempotent on re-open).
+                    let already = self.column_entries.iter().any(|x| {
+                        x.owner_kind == e.owner_kind
+                            && x.owner_id == e.owner_id
+                            && x.field_id == e.field_id
+                    });
+                    if !already {
+                        self.column_entries.push(e);
+                    }
                 }
                 _ => {} // other entry types are not processed in Phase 1
             }

--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -231,13 +231,61 @@ impl Engine {
     ///
     /// Currently implemented procedures:
     /// - `db.index.fulltext.queryNodes(indexName, query)` — full-text search
+    /// - `db.schema()` — return graph schema (labels, rel types, property keys)
     fn execute_call(&self, c: &CallStatement) -> Result<QueryResult> {
         match c.procedure.as_str() {
             "db.index.fulltext.queryNodes" => self.call_fulltext_query_nodes(c),
+            "db.schema" => self.call_db_schema(c),
             other => Err(sparrowdb_common::Error::InvalidArgument(format!(
                 "unknown procedure: {other}"
             ))),
         }
+    }
+
+    /// Implementation of `CALL db.schema()`.
+    ///
+    /// Returns one row per node label with columns:
+    ///   - `label`            — String: the label name
+    ///   - `properties`       — List of String: property key names observed for this label
+    ///   - `relationship_types` — List of String: relationship type names in the graph
+    ///
+    /// Relationship types are listed at the graph level (not per-label) for simplicity.
+    fn call_db_schema(&self, _c: &CallStatement) -> Result<QueryResult> {
+        // Collect all labels from the catalog.
+        let labels = self.catalog.list_labels()?;
+
+        // Collect all distinct relationship type names.
+        let rel_tables = self.catalog.list_rel_tables()?;
+        let mut rel_type_set: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for (_, _, rel_type) in &rel_tables {
+            rel_type_set.insert(rel_type.clone());
+        }
+        let mut rel_type_names: Vec<String> = rel_type_set.into_iter().collect();
+        rel_type_names.sort();
+        let rel_types_value = Value::List(rel_type_names.into_iter().map(Value::String).collect());
+
+        // Build one row per label.
+        let mut rows: Vec<Vec<Value>> = Vec::new();
+        for (label_id, label_name) in labels {
+            let prop_keys = self.catalog.list_property_keys(label_id);
+            let mut sorted_keys = prop_keys;
+            sorted_keys.sort();
+            let props_value = Value::List(sorted_keys.into_iter().map(Value::String).collect());
+            rows.push(vec![
+                Value::String(label_name),
+                props_value,
+                rel_types_value.clone(),
+            ]);
+        }
+
+        Ok(QueryResult {
+            columns: vec![
+                "label".to_owned(),
+                "properties".to_owned(),
+                "relationship_types".to_owned(),
+            ],
+            rows,
+        })
     }
 
     /// Implementation of `CALL db.index.fulltext.queryNodes(indexName, query)`.

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -489,6 +489,14 @@ impl GraphDb {
 
             let node_id = tx.create_node(label_id, &props)?;
 
+            // Register property key names in the catalog for db.schema() introspection.
+            for entry in &node.props {
+                let col_id = col_id_of(&entry.key);
+                let _ = tx
+                    .catalog
+                    .register_property_key(label_id as u16, col_id, &entry.key);
+            }
+
             // Record the binding so edge patterns can resolve (src_var, dst_var).
             if !node.var.is_empty() {
                 var_to_node.insert(node.var.clone(), node_id);
@@ -1026,6 +1034,14 @@ impl WriteTx {
             }
         }
 
+        // Register property keys in the catalog (idempotent) for db.schema().
+        for (key, col_id, _) in &col_kv {
+            // Ignore errors — catalog registration is best-effort metadata.
+            let _ = self
+                .catalog
+                .register_property_key(label_id as u16, *col_id, key);
+        }
+
         // Not found — create a new node (buffered, same as create_node).
         let disk_props: Vec<(u32, Value)> = col_kv
             .iter()
@@ -1056,6 +1072,10 @@ impl WriteTx {
     pub fn set_property(&mut self, node_id: NodeId, key: &str, val: Value) -> Result<()> {
         let col_id = fnv1a_col_id(key);
         self.dirty_nodes.insert(node_id.0);
+
+        // Register the property key in the catalog (idempotent) for db.schema().
+        let label_id = (node_id.0 >> 32) as u16;
+        let _ = self.catalog.register_property_key(label_id, col_id, key);
 
         // Stage the update through the write buffer (records before-image for
         // WAL and MVCC). WAL emission happens exactly once at commit time via

--- a/crates/sparrowdb/tests/spa_209_schema_introspection.rs
+++ b/crates/sparrowdb/tests/spa_209_schema_introspection.rs
@@ -1,0 +1,218 @@
+//! SPA-209 acceptance tests — CALL db.schema() + named columns in QueryResult.
+//!
+//! Covers:
+//!   1. `call_db_schema_returns_labels` — create nodes with two labels,
+//!      call db.schema(), verify both labels appear.
+//!   2. `query_result_has_named_columns` — execute `MATCH (n:Person) RETURN n.name`,
+//!      verify `result.columns == ["n.name"]`.
+//!   3. `schema_includes_rel_types` — create nodes + edges, call db.schema(),
+//!      verify the relationship type appears.
+
+use sparrowdb::{open, GraphDb};
+use sparrowdb_execution::Value;
+
+/// Open a fresh database in a temp directory.
+fn make_db() -> (tempfile::TempDir, GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 1: create nodes with two labels; CALL db.schema() returns both labels.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn call_db_schema_returns_labels() {
+    let (_dir, db) = make_db();
+
+    // Create nodes using Cypher (which registers properties via merge_node).
+    db.execute("CREATE (p:Person {name: 'Alice'})")
+        .expect("create person");
+    db.execute("CREATE (c:Company {name: 'Acme'})")
+        .expect("create company");
+
+    let result = db
+        .execute("CALL db.schema()")
+        .expect("CALL db.schema() must succeed");
+
+    assert_eq!(
+        result.columns,
+        vec!["label", "properties", "relationship_types"],
+        "schema columns should be [label, properties, relationship_types]"
+    );
+
+    // Extract the label strings from the rows.
+    let mut label_names: Vec<String> = result
+        .rows
+        .iter()
+        .filter_map(|row| {
+            if let Some(Value::String(name)) = row.first() {
+                Some(name.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+    label_names.sort();
+
+    assert!(
+        label_names.contains(&"Person".to_owned()),
+        "schema should include Person label; got: {label_names:?}"
+    );
+    assert!(
+        label_names.contains(&"Company".to_owned()),
+        "schema should include Company label; got: {label_names:?}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 2: MATCH … RETURN produces correctly named columns.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn query_result_has_named_columns() {
+    let (_dir, db) = make_db();
+
+    // Insert a Person node.
+    db.execute("CREATE (p:Person {name: 'Bob', age: 30})")
+        .expect("create person");
+
+    // Query with a single RETURN projection.
+    let result = db
+        .execute("MATCH (n:Person) RETURN n.name")
+        .expect("query must succeed");
+
+    assert_eq!(
+        result.columns,
+        vec!["n.name"],
+        "column name for 'n.name' projection should be 'n.name'"
+    );
+    assert_eq!(result.rows.len(), 1, "should return one row");
+
+    // Query with multiple projections.
+    let result2 = db
+        .execute("MATCH (n:Person) RETURN n.name, n.age")
+        .expect("query must succeed");
+
+    assert_eq!(
+        result2.columns,
+        vec!["n.name", "n.age"],
+        "columns should match the RETURN projection order"
+    );
+
+    // Query with an AS alias.
+    let result3 = db
+        .execute("MATCH (n:Person) RETURN n.name AS fullName")
+        .expect("query must succeed");
+
+    assert_eq!(
+        result3.columns,
+        vec!["fullName"],
+        "AS alias should be reflected in columns"
+    );
+
+    // Query with count(*).
+    let result4 = db
+        .execute("MATCH (n:Person) RETURN count(*)")
+        .expect("query must succeed");
+
+    assert_eq!(
+        result4.columns,
+        vec!["count(*)"],
+        "count(*) column name should be 'count(*)'"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 3: create nodes + edges; CALL db.schema() reports the rel type.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn schema_includes_rel_types() {
+    let (_dir, db) = make_db();
+
+    // Create two nodes and connect them with a KNOWS relationship.
+    db.execute("CREATE (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'})")
+        .expect("create nodes");
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .expect("create edge");
+
+    let result = db
+        .execute("CALL db.schema()")
+        .expect("CALL db.schema() must succeed");
+
+    // Every row's third column should be a List of rel types.
+    // We only need to find at least one row where KNOWS appears.
+    let mut found_knows = false;
+    for row in &result.rows {
+        if let Some(Value::List(rel_types)) = row.get(2) {
+            for rt in rel_types {
+                if let Value::String(s) = rt {
+                    if s == "KNOWS" {
+                        found_knows = true;
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        found_knows,
+        "CALL db.schema() should report KNOWS relationship type; rows: {result:?}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 4: property keys registered via merge_node appear in schema.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn schema_includes_property_keys() {
+    let (_dir, db) = make_db();
+
+    // Create a node with named properties via Cypher CREATE.
+    db.execute("CREATE (p:Person {name: 'Carol', age: 42})")
+        .expect("create person");
+
+    let result = db
+        .execute("CALL db.schema()")
+        .expect("CALL db.schema() must succeed");
+
+    // Find the Person row and check its properties list.
+    let person_row = result
+        .rows
+        .iter()
+        .find(|row| matches!(row.first(), Some(Value::String(s)) if s == "Person"));
+
+    assert!(person_row.is_some(), "Person label should appear in schema");
+
+    let person_row = person_row.unwrap();
+    if let Some(Value::List(props)) = person_row.get(1) {
+        let prop_names: Vec<&str> = props
+            .iter()
+            .filter_map(|v| {
+                if let Value::String(s) = v {
+                    Some(s.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert!(
+            prop_names.contains(&"name"),
+            "Person properties should include 'name'; got: {prop_names:?}"
+        );
+        assert!(
+            prop_names.contains(&"age"),
+            "Person properties should include 'age'; got: {prop_names:?}"
+        );
+    } else {
+        panic!(
+            "Expected Value::List for properties column, got: {:?}",
+            person_row.get(1)
+        );
+    }
+}


### PR DESCRIPTION
## **User description**
## Summary

- **`CALL db.schema()` procedure**: Returns one row per node label with columns `label` (String), `properties` (List\<String\>), and `relationship_types` (List\<String\>). Follows the same CALL dispatch pattern as `db.index.fulltext.queryNodes`.
- **Property key tracking in Catalog**: Added `register_property_key` / `list_property_keys` to `Catalog`, persisting entries via the existing `TAG_COLUMN` TLV format. Keys are registered automatically in `execute_create_standalone`, `WriteTx::merge_node`, and `WriteTx::set_property`.
- **Named columns already present**: `QueryResult.columns: Vec<String>` was already populated by the engine for all RETURN projections (`n.name`, AS aliases, `count(*)`). Tests verify this behavior.

## Files changed

- `crates/sparrowdb-catalog/src/catalog.rs` — `ColumnEntry` loading on open + `register_property_key` / `list_property_keys`
- `crates/sparrowdb-execution/src/engine.rs` — `call_db_schema` implementation + dispatch wiring
- `crates/sparrowdb/src/lib.rs` — property key registration in `execute_create_standalone`, `merge_node`, `set_property`
- `crates/sparrowdb/tests/spa_209_schema_introspection.rs` — 4 integration tests (all pass)

## Test plan

- [ ] `call_db_schema_returns_labels` — two-label graph, both appear in schema
- [ ] `query_result_has_named_columns` — `n.name`, multi-projection, AS alias, `count(*)` all produce correct column names
- [ ] `schema_includes_rel_types` — KNOWS relationship appears in schema
- [ ] `schema_includes_property_keys` — `name` and `age` appear for Person label

Run: `cargo test -p sparrowdb --test spa_209_schema_introspection`

Note: `spa191_multiple_rel_types_all_persist` is a pre-existing failure unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add schema introspection and property key reporting**

### What Changed
- `CALL db.schema()` now returns one row per label with the label name, the properties seen for that label, and the relationship types in the graph
- Property names written through create or update operations are recorded so they appear in schema results later
- Added coverage for schema output, relationship types, and returned column names

### Impact
`✅ Easier graph schema discovery`
`✅ Property names visible in schema results`
`✅ Clearer database introspection for users` 
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
