### PR TITLE
fix(engine): col_-prefixed property names no longer map to col_0 (SPA-165)

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -3376,16 +3376,28 @@ fn string_to_raw_u64(s: &str) -> u64 {
     StoreValue::Bytes(s.as_bytes().to_vec()).to_u64()
 }
 
-/// Map a property name like "col_0" or "name" to a col_id.
+/// Map a property name to a col_id via the canonical FNV-1a hash.
 ///
-/// Uses the canonical [`sparrowdb_common::col_id_of`] FNV-1a hash so that
-/// this always agrees with what the storage layer wrote to disk (SPA-160).
+/// All property names — including those that start with `col_` (e.g. `col_id`,
+/// `col_name`, `col_0`) — are hashed with [`col_id_of`] so that the col_id
+/// computed here always agrees with what the storage layer wrote to disk
+/// (SPA-160).  The Cypher write path (`create_node_named`,
+/// `execute_create_standalone`) consistently uses `col_id_of`, so the read
+/// path must too.
+///
+/// ## SPA-165 bug fix
+///
+/// The previous implementation special-cased names matching `col_N`:
+/// - If the suffix parsed as a `u32` the numeric value was returned directly.
+/// - If it did not parse, `unwrap_or(0)` silently mapped to column 0.
+///
+/// Both behaviours were wrong for user-defined property names.  A name like
+/// `col_id` resolved to column 0 (the tombstone sentinel), and even `col_0`
+/// was inconsistent because `create_node_named` writes it at `col_id_of("col_0")`
+/// while the old read path returned column 0.  The fix removes the `col_`
+/// prefix shorthand entirely; every name goes through `col_id_of`.
 fn prop_name_to_col_id(name: &str) -> u32 {
-    if let Some(suffix) = name.strip_prefix("col_") {
-        suffix.parse().unwrap_or(0)
-    } else {
-        col_id_of(name)
-    }
+    col_id_of(name)
 }
 
 fn collect_col_ids_from_columns(column_names: &[String]) -> Vec<u32> {

--- a/crates/sparrowdb/tests/spa_165_col_prefix_property.rs
+++ b/crates/sparrowdb/tests/spa_165_col_prefix_property.rs
@@ -1,0 +1,115 @@
+//! Regression tests for SPA-165: property names starting with `col_` must not
+//! collide with the internal column-file naming scheme.
+//!
+//! The storage engine persists each property column as `col_{col_id}.bin` where
+//! `col_id` is the FNV-1a hash of the property name.  A previous bug in the
+//! execution engine's `prop_name_to_col_id` helper caused any property name
+//! that started with `col_` but whose suffix did not parse as a `u32` (e.g.
+//! `col_id`, `col_name`) to silently resolve to column 0 instead of the
+//! correct FNV-1a hash, resulting in the wrong value being read back.
+
+use sparrowdb::open;
+use sparrowdb_execution::types::Value;
+
+fn make_db() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+// ── Test 1: `col_id` property round-trip ─────────────────────────────────────
+
+/// A property literally named `col_id` must store and retrieve its value
+/// correctly.  Before SPA-165 was fixed, reading `n.col_id` would silently
+/// resolve to column 0 (the tombstone sentinel column) and return `Null`.
+#[test]
+fn col_prefixed_prop_stores_and_retrieves() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Thing {col_id: 42})").unwrap();
+
+    let result = db
+        .execute("MATCH (n:Thing) RETURN n.col_id")
+        .expect("MATCH with col_id property must not error");
+
+    assert_eq!(result.rows.len(), 1, "expected one matching node");
+    assert_eq!(
+        result.rows[0][0],
+        Value::Int64(42),
+        "n.col_id must return 42, not Null or 0"
+    );
+}
+
+// ── Test 2: `col_0` property round-trip ──────────────────────────────────────
+
+/// A property literally named `col_0` must be stored via its FNV-1a hash and
+/// retrieved correctly.  The name `col_0` looks like an internal column
+/// reference but is a valid user property key with its own hash distinct from
+/// column 0.
+#[test]
+fn col_zero_prop_roundtrip() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Slot {col_0: 99})").unwrap();
+
+    let result = db
+        .execute("MATCH (n:Slot) RETURN n.col_0")
+        .expect("MATCH with col_0 property must not error");
+
+    assert_eq!(result.rows.len(), 1, "expected one matching node");
+    assert_eq!(
+        result.rows[0][0],
+        Value::Int64(99),
+        "n.col_0 must return 99"
+    );
+}
+
+// ── Test 3: multiple `col_`-prefixed properties ───────────────────────────────
+
+/// Multiple properties with `col_`-prefixed names must all be independently
+/// stored and retrieved without cross-contamination.
+#[test]
+fn multiple_col_props() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Widget {col_id: 1, col_name: 'test'})")
+        .unwrap();
+
+    let result = db
+        .execute("MATCH (n:Widget) RETURN n.col_id, n.col_name")
+        .expect("MATCH with multiple col_ properties must not error");
+
+    assert_eq!(result.rows.len(), 1, "expected one matching node");
+    assert_eq!(result.rows[0][0], Value::Int64(1), "n.col_id must return 1");
+    assert_eq!(
+        result.rows[0][1],
+        Value::String("test".to_string()),
+        "n.col_name must return 'test'"
+    );
+}
+
+// ── Test 4: `col_`-prefixed name in WHERE clause ──────────────────────────────
+
+/// A WHERE predicate on a `col_`-prefixed property must filter correctly.
+#[test]
+fn col_prefixed_prop_in_where() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Item {col_id: 10})").unwrap();
+    db.execute("CREATE (n:Item {col_id: 20})").unwrap();
+
+    let result = db
+        .execute("MATCH (n:Item) WHERE n.col_id = 10 RETURN n.col_id")
+        .expect("WHERE on col_id must not error");
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "WHERE n.col_id = 10 must match exactly one node"
+    );
+    assert_eq!(
+        result.rows[0][0],
+        Value::Int64(10),
+        "returned n.col_id must be 10"
+    );
+}

--- a/crates/sparrowdb/tests/spa_fulltext.rs
+++ b/crates/sparrowdb/tests/spa_fulltext.rs
@@ -182,14 +182,21 @@ fn call_yield_node_usable_in_return() {
     db.create_fulltext_index("propIndex")
         .expect("create fulltext index");
 
-    // Create a node with a known integer col_0 value.
+    // Create a node with a known integer property value.
+    // SPA-165: use create_node_named so the property is stored under its
+    // FNV-1a col_id (derived from the name "score"), not at bare col_id 0.
+    // Querying via node.score then round-trips correctly regardless of whether
+    // the name starts with "col_".
     let expected_val: i64 = 42;
     {
         let mut tx = db.begin_write().expect("begin_write");
         let label_id = tx.create_label("Doc").expect("create_label") as u32;
         let node_id = tx
-            .create_node(label_id, &[(0, StoreValue::Int64(expected_val))])
-            .expect("create_node");
+            .create_node_named(
+                label_id,
+                &[("score".to_string(), StoreValue::Int64(expected_val))],
+            )
+            .expect("create_node_named");
         tx.add_to_fulltext_index("propIndex", node_id, "knowledge graph")
             .expect("index node");
         tx.commit().expect("commit");
@@ -210,19 +217,19 @@ fn call_yield_node_usable_in_return() {
         &result.rows[0][0]
     );
 
-    // CALL with RETURN node.col_0 — verifies property projection from yielded NodeRef.
+    // CALL with RETURN node.score — verifies property projection from yielded NodeRef.
     let result2 = db
         .execute(
             "CALL db.index.fulltext.queryNodes('propIndex', 'knowledge') YIELD node \
-             RETURN node.col_0",
+             RETURN node.score",
         )
-        .expect("CALL with RETURN node.col_0");
+        .expect("CALL with RETURN node.score");
 
     assert_eq!(result2.rows.len(), 1, "one node should match");
     assert_eq!(
         result2.rows[0][0],
         Value::Int64(expected_val),
-        "RETURN node.col_0 should project the stored property value, got {:?}",
+        "RETURN node.score should project the stored property value, got {:?}",
         &result2.rows[0][0]
     );
 }


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause**: `prop_name_to_col_id` in the execution engine special-cased any name starting with `col_`. If the suffix after `col_` did not parse as a `u32`, it fell back to `unwrap_or(0)`, silently mapping user property names like `col_id` and `col_name` to column 0 (the tombstone sentinel). Even `col_0` as a user property was broken because `create_node_named` (the Cypher write path) writes it via `col_id_of("col_0")` while the old read path returned literal column 0 — a silent write/read inconsistency.
- **Fix**: Remove the `col_` prefix shorthand entirely from `prop_name_to_col_id`. All property names now go through `col_id_of` (FNV-1a), consistent with how `create_node_named` and `set_property` derive column IDs at write time.
- **Collateral fix**: Updated `spa_fulltext.rs::call_yield_node_usable_in_return` which relied on the internal `col_0` = numeric-column-0 shorthand via the low-level `create_node` API. Replaced with `create_node_named` + a real property name (`score`).

## Test plan

- [x] `spa_165_col_prefix_property.rs` — 4 new regression tests: `col_id` round-trip, `col_0` round-trip, multiple `col_`-prefixed properties, WHERE clause filtering on `col_id`
- [x] All existing `spa_*` tests pass (pre-existing failures in `spa_185`, `spa_193` unaffected)
- [x] `spa_fulltext` — updated test now passes with idiomatic named property API

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix col_-prefixed property names so they round-trip correctly**

### What Changed
- Property names like `col_id`, `col_name`, and `col_0` now read back the values they were written with instead of being mistaken for internal column 0.
- A full-text query test now uses a normal property name and confirms `node.score` is returned correctly.
- New regression tests cover reading, filtering, and using multiple `col_`-prefixed properties together.

### Impact
`✅ Correct values for col_-named fields`
`✅ Fewer missing property reads`
`✅ Safer full-text query results`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed inconsistent handling of properties starting with "col_" to ensure uniform hashing behavior across all property names, eliminating read-path inconsistencies.

* **Tests**
  * Added comprehensive regression tests for property name handling scenarios.
  * Updated existing tests to align with consistent property behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->