### PR TITLE
hotfix(engine): restore dst_all_col_ids in execute_variable_length (SPA-224)

### DIFF
--- a/crates/sparrowdb/tests/spa_224_regression_no_so_label.rs
+++ b/crates/sparrowdb/tests/spa_224_regression_no_so_label.rs
@@ -1,0 +1,38 @@
+//! Regression test: SPA-224 dst_all_col_ids fix must survive future PRs.
+//! Uses non-__SO__ labels and a dst prop filter (the case PR #100 broke).
+
+use sparrowdb::open;
+use sparrowdb_execution::types::Value;
+
+fn make_db() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+/// MATCH (a:Person)-[:KNOWS*1..2]->(b:Person {name: 'Bob'}) RETURN b.name
+/// Without dst_all_col_ids, the dst prop filter {name: 'Bob'} silently rejects
+/// all candidates (the column isn't in col_ids_dst when b isn't in RETURN).
+#[test]
+fn varpath_dst_prop_filter_non_so_label() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (n:Person {name: 'Alice'})").unwrap();
+    db.execute("CREATE (n:Person {name: 'Bob'})").unwrap();
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+
+    let result = db
+        .execute("MATCH (a:Person)-[:KNOWS*1..2]->(b:Person {name: 'Bob'}) RETURN b.name")
+        .expect("var-path with dst prop filter must not error");
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "expected 1 row; got {:?}",
+        result.rows
+    );
+    assert_eq!(result.rows[0][0], Value::String("Bob".to_string()));
+}


### PR DESCRIPTION
## **User description**
## Summary
- Restores `dst_all_col_ids` block accidentally removed by PR #100 (commit 6549930)
- SPA-224 fix ensured dst nodes in variable-length paths are read with the full column set (projection + inline-filter + WHERE cols)
- Without this fix, `MATCH (a)-[:R*1..N]->(b {prop: 'x'}) RETURN ...` silently returns 0 rows when `b` is not in RETURN
- SparrowOntology is blocked until this lands on main

## Test plan
- [ ] spa_224_regression_no_so_label passes (new test covering the exact broken case)
- [ ] CI ubuntu + macos pass
- [ ] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Restore variable-length path matches when the destination node has a property filter**

### What Changed
- Fixed a case where variable-length path queries could return no rows when the destination node had a property filter but was not included in the returned fields.
- Added a regression test using regular labels to cover this failed match scenario and prevent it from coming back.

### Impact
`✅ Fewer empty results in path queries`
`✅ Correct matches when filtering the destination node`
`✅ Lower risk of regressions in graph lookups`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
