### PR TITLE
fix(engine): multiple rel-type persistence (SPA-191)

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -2237,7 +2237,7 @@ impl Engine {
                 // type's checkpointed edges are found under its own key.
                 let csr_neighbors: &[u64] = self
                     .csrs
-                    .get(&(*catalog_rel_id as u32))
+                    .get(&u32::try_from(*catalog_rel_id).expect("rel_table_id overflowed u32"))
                     .map(|c| c.neighbors(src_slot))
                     .unwrap_or(&[]);
                 let all_neighbors: Vec<u64> = csr_neighbors


### PR DESCRIPTION
## **User description**
## Summary

- Fixes pre-existing test failure: `spa191_multiple_rel_types_all_persist`
- Root cause: `execute_one_hop()` was hardcoded to only look up the CSR for rel-table 0. For any other catalog `rel_id` (e.g. a FOLLOWS relationship assigned id=1), the checkpointed CSR was silently skipped and only the delta log was read. After a checkpoint the delta log is empty, so those edges returned 0 rows.
- Fix: replace the hardcoded `if *catalog_rel_id == 0 { self.csrs.get(&0) }` guard with `self.csrs.get(&(*catalog_rel_id as u32))`, correctly looking up the per-type CsrForward that `open_csr_map` already loaded for every registered rel table.

## Test plan
- [x] `spa191_rel_type_persistence` — all 4 tests pass (including the previously failing `spa191_multiple_rel_types_all_persist`)
- [x] Full workspace test suite — no regressions introduced (pre-existing `undirected_returns_both_directions` failure is unrelated and pre-dates this branch)
- [x] Clippy clean (`cargo clippy --all-targets -- -D warnings`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Load saved edges for every relationship type during one-hop traversal**

### What Changed
- One-hop lookups now include saved edges for the requested relationship type, not just the first one.
- Relationships that were already checkpointed no longer disappear after a checkpoint when they use a different type ID.
- Results still combine saved edges and new edges, while removing duplicates.

### Impact
`✅ Correct results after checkpoint`
`✅ Fewer missing relationships in multi-type queries`
`✅ More reliable graph traversal across edge types`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
