### PR TITLE
test(cypher): multi-clause Cypher integration test suite (SPA-134)

### DIFF
--- a/crates/sparrowdb/tests/spa_134_multi_clause.rs
+++ b/crates/sparrowdb/tests/spa_134_multi_clause.rs
@@ -305,7 +305,11 @@ fn spa134_match_with_collect_unwind_return() {
 
     // Should fan-out the 3 collected names back into 3 rows.
     assert_eq!(result.columns, vec!["item"]);
-    assert_eq!(result.rows.len(), 3, "collect then unwind should yield 3 rows");
+    assert_eq!(
+        result.rows.len(),
+        3,
+        "collect then unwind should yield 3 rows"
+    );
 
     let mut items: Vec<String> = result
         .rows
@@ -462,10 +466,7 @@ fn spa134_exists_subquery_where_in_with_clause() {
         })
         .collect();
     names.sort_unstable();
-    assert_eq!(
-        names,
-        vec!["Alice".to_string(), "Bob".to_string()],
-    );
+    assert_eq!(names, vec!["Alice".to_string(), "Bob".to_string()],);
 }
 
 // ── Additional covered patterns ────────────────────────────────────────────────
@@ -559,10 +560,10 @@ fn spa134_match_with_count_no_filter_return() {
         )
         .expect("MATCH … WITH count(*) AS c RETURN c must succeed");
 
-    assert_eq!(result.rows.len(), 1, "aggregate always returns exactly 1 row");
     assert_eq!(
-        result.rows[0][0],
-        Value::Int64(3),
-        "3 persons in the graph"
+        result.rows.len(),
+        1,
+        "aggregate always returns exactly 1 row"
     );
+    assert_eq!(result.rows[0][0], Value::Int64(3), "3 persons in the graph");
 }


### PR DESCRIPTION
## Summary

- Adds 13 integration tests covering the 8 multi-clause Cypher pipeline patterns specified in SPA-134
- 3 tests pass immediately; 10 are marked `#[ignore]` with precise root-cause diagnostics
- Each ignored test documents exactly which parser function, AST node, or execution field needs to be extended to enable the pattern

## Test inventory

| Test | Status | Root cause for ignore |
|------|--------|-----------------------|
| `spa134_match_with_where_return` | PASS | — |
| `spa134_match_with_where_empty_result` | PASS | — |
| `spa134_match_with_count_where_filter_blocks_row` | PASS | passes (correct result for wrong reason — documented) |
| `spa134_match_with_match_return` | ignored | `parse_with_pipeline` calls `expect_tok(Return)` — no second MATCH parseable |
| `spa134_match_with_count_where_filter` | ignored | `eval_expr(CountStar)` returns `Value::Null` per row; no aggregation in WITH |
| `spa134_match_with_order_limit_match_return` | ignored | ORDER BY ignored + no second MATCH parseable |
| `spa134_unwind_with_transform_return` | ignored | `parse_unwind` calls `expect_tok(Return)` immediately after alias |
| `spa134_match_with_collect_unwind_return` | ignored | UNWIND after WITH not parsed; collect() needs aggregate-aware WITH |
| `spa134_three_stage_match_with_pipeline` | ignored | No multi-stage Pipeline AST variant |
| `spa134_exists_subquery_with_clause_return` | ignored | `build_row_vals` does not inject NodeRef; `eval_exists_subquery` returns false |
| `spa134_exists_subquery_where_in_with_clause` | ignored | `with_vals` map lacks NodeRef; same root cause as above |
| `spa134_match_with_order_by_limit_return` | ignored | `execute_match_with` parses `order_by` field but never consumes it |
| `spa134_match_with_count_no_filter_return` | ignored | CountStar returns Null per row instead of aggregate Int64 |

## Test plan

- [x] `cargo test -p sparrowdb --test spa_134_multi_clause` — 3 passed, 0 failed, 10 ignored
- [x] All `#[ignore]` annotations include the exact function/field that blocks the pattern
- [x] No other test files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)