### PR TITLE
test(cypher): Phase 9 path acceptance tests — varpath, shortestPath, EXISTS, multi-pattern (SPA-139)

### DIFF
--- a/crates/sparrowdb/tests/spa_139_phase9_path_acceptance.rs
+++ b/crates/sparrowdb/tests/spa_139_phase9_path_acceptance.rs
@@ -63,9 +63,7 @@ fn varpath_range_1_to_3_correct_set() {
     }
 
     let result = db
-        .execute(
-            "MATCH (a:Node {name: 'Alice'})-[:LINK*1..3]->(b:Node) RETURN b.name",
-        )
+        .execute("MATCH (a:Node {name: 'Alice'})-[:LINK*1..3]->(b:Node) RETURN b.name")
         .expect("[:LINK*1..3] query must succeed");
 
     let names = col_strings(&result, 0);
@@ -115,14 +113,10 @@ fn varpath_with_endpoint_property_filter() {
     db.execute("CREATE (n:Node {name: 'Carol', active: false})")
         .unwrap();
 
-    db.execute(
-        "MATCH (a:Node {name: 'Alice'}), (b:Node {name: 'Bob'}) CREATE (a)-[:LINK]->(b)",
-    )
-    .unwrap();
-    db.execute(
-        "MATCH (a:Node {name: 'Bob'}), (b:Node {name: 'Carol'}) CREATE (a)-[:LINK]->(b)",
-    )
-    .unwrap();
+    db.execute("MATCH (a:Node {name: 'Alice'}), (b:Node {name: 'Bob'}) CREATE (a)-[:LINK]->(b)")
+        .unwrap();
+    db.execute("MATCH (a:Node {name: 'Bob'}), (b:Node {name: 'Carol'}) CREATE (a)-[:LINK]->(b)")
+        .unwrap();
 
     let result = db
         .execute(
@@ -158,19 +152,13 @@ fn shortest_path_prefers_minimum_hops() {
     db.execute("CREATE (n:Node {name: 'C'})").unwrap();
 
     // Direct A→C
-    db.execute(
-        "MATCH (a:Node {name: 'A'}), (c:Node {name: 'C'}) CREATE (a)-[:LINK]->(c)",
-    )
-    .unwrap();
+    db.execute("MATCH (a:Node {name: 'A'}), (c:Node {name: 'C'}) CREATE (a)-[:LINK]->(c)")
+        .unwrap();
     // Indirect A→B→C
-    db.execute(
-        "MATCH (a:Node {name: 'A'}), (b:Node {name: 'B'}) CREATE (a)-[:LINK]->(b)",
-    )
-    .unwrap();
-    db.execute(
-        "MATCH (b:Node {name: 'B'}), (c:Node {name: 'C'}) CREATE (b)-[:LINK]->(c)",
-    )
-    .unwrap();
+    db.execute("MATCH (a:Node {name: 'A'}), (b:Node {name: 'B'}) CREATE (a)-[:LINK]->(b)")
+        .unwrap();
+    db.execute("MATCH (b:Node {name: 'B'}), (c:Node {name: 'C'}) CREATE (b)-[:LINK]->(c)")
+        .unwrap();
 
     let result = db
         .execute(
@@ -237,9 +225,7 @@ fn exists_filters_by_label_on_target() {
     .unwrap();
 
     let result = db
-        .execute(
-            "MATCH (n:Person) WHERE EXISTS { (n)-[:KNOWS]->(:Employee) } RETURN n.name",
-        )
+        .execute("MATCH (n:Person) WHERE EXISTS { (n)-[:KNOWS]->(:Employee) } RETURN n.name")
         .expect("EXISTS with label filter must succeed");
 
     assert_eq!(
@@ -269,8 +255,10 @@ fn exists_with_target_property_condition() {
 
     db.execute("CREATE (n:Manager {name: 'Alice'})").unwrap();
     db.execute("CREATE (n:Manager {name: 'Bob'})").unwrap();
-    db.execute("CREATE (p:Project {title: 'Alpha', status: 'active'})").unwrap();
-    db.execute("CREATE (p:Project {title: 'Beta', status: 'closed'})").unwrap();
+    db.execute("CREATE (p:Project {title: 'Alpha', status: 'active'})")
+        .unwrap();
+    db.execute("CREATE (p:Project {title: 'Beta', status: 'closed'})")
+        .unwrap();
 
     db.execute(
         "MATCH (m:Manager {name: 'Alice'}), (p:Project {title: 'Alpha'}) \
@@ -371,9 +359,7 @@ fn multi_pattern_match_then_create_rel() {
     .unwrap();
 
     let result = db
-        .execute(
-            "MATCH (s:Supplier)-[:SUPPLIES]->(p:Product) RETURN s.name, p.name",
-        )
+        .execute("MATCH (s:Supplier)-[:SUPPLIES]->(p:Product) RETURN s.name, p.name")
         .expect("traversal after multi-pattern MATCH…CREATE must succeed");
 
     assert_eq!(
@@ -410,7 +396,8 @@ fn three_hop_inline_chain() {
     let (_dir, db) = make_db();
 
     for name in &["Alpha", "Beta", "Gamma", "Delta"] {
-        db.execute(&format!("CREATE (n:Step {{name: '{name}'}})")).unwrap();
+        db.execute(&format!("CREATE (n:Step {{name: '{name}'}})"))
+            .unwrap();
     }
     for (src, dst) in &[("Alpha", "Beta"), ("Beta", "Gamma"), ("Gamma", "Delta")] {
         db.execute(&format!(
@@ -469,7 +456,8 @@ fn varpath_lower_bound_excludes_shallow_nodes() {
     let (_dir, db) = make_db();
 
     for name in &["Start", "Mid", "End"] {
-        db.execute(&format!("CREATE (n:Hop {{name: '{name}'}})")).unwrap();
+        db.execute(&format!("CREATE (n:Hop {{name: '{name}'}})"))
+            .unwrap();
     }
     for (src, dst) in &[("Start", "Mid"), ("Mid", "End")] {
         db.execute(&format!(
@@ -479,9 +467,7 @@ fn varpath_lower_bound_excludes_shallow_nodes() {
     }
 
     let result = db
-        .execute(
-            "MATCH (a:Hop {name: 'Start'})-[:JUMP*2..3]->(b:Hop) RETURN b.name",
-        )
+        .execute("MATCH (a:Hop {name: 'Start'})-[:JUMP*2..3]->(b:Hop) RETURN b.name")
         .expect("[:JUMP*2..3] must succeed");
 
     let names = col_strings(&result, 0);


### PR DESCRIPTION
## **User description**
## Summary

- Adds `spa_139_phase9_path_acceptance.rs` with 10 integration tests covering all Phase 9 path-related Cypher features
- 8 tests pass; 2 marked `#[ignore]` with ticket references for known engine gaps

## Tests

| Test | Status | Notes |
|------|--------|-------|
| `varpath_range_1_to_3_correct_set` | PASS | `[:LINK*1..3]` reaches depth 1–3, excludes depth 4 |
| `varpath_lower_bound_excludes_shallow_nodes` | PASS | `[:JUMP*2..3]` excludes depth-1 nodes |
| `varpath_with_endpoint_property_filter` | IGNORED | SPA-232: BFS engine ignores dst inline property filter |
| `shortest_path_prefers_minimum_hops` | PASS | Two paths exist; BFS returns length 1 not 2 |
| `shortest_path_null_when_disconnected` | PASS | NULL when no path exists |
| `exists_filters_by_label_on_target` | PASS | `EXISTS { (n)-[:KNOWS]->(:Employee) }` correct |
| `exists_with_target_property_condition` | PASS | `EXISTS { ... {:status:'active'} }` correct |
| `multi_pattern_match_cross_product` | PASS | 2×2 cross-product = 4 rows |
| `multi_pattern_match_then_create_rel` | PASS | MATCH…CREATE creates correct edge |
| `three_hop_inline_chain` | IGNORED | SPA-252: 3-hop binding bug — all columns return same node |

## Gap Tickets

- **SPA-232** (existing): varpath BFS engine does not apply dst property filter
- **SPA-252** (new): 3-hop inline chain `(a)-[:R]->(b)-[:R]->(c)-[:R]->(d)` returns wrong variable bindings

## Test plan

- [x] `cargo test --test spa_139_phase9_path_acceptance` → 8 passed, 2 ignored, 0 failed
- [x] New gap ticket SPA-252 filed for the 3-hop binding bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add Phase 9 path acceptance test coverage**

### What Changed
- Adds a new acceptance test suite for Phase 9 path queries, covering variable-length paths, shortest path results, `EXISTS` filters, multi-pattern matches, and chained path binding.
- Verifies variable-length paths respect both the lower and upper hop limits, including cases that should exclude deeper or shallower nodes.
- Checks that `shortestPath` returns the shortest route when multiple paths exist and returns `NULL` when no route connects the nodes.
- Confirms `EXISTS` works with target labels and nested target properties, and that matching multiple patterns returns the full cross-product and can feed a relationship creation.
- Keeps two known failing cases marked as ignored so they remain visible as gaps: endpoint property filtering on variable-length paths and 3-hop inline path bindings.

### Impact
`✅ Clearer path query coverage`
`✅ Faster detection of path query regressions`
`✅ Visible tracking of known Cypher gaps`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive acceptance test coverage for Phase 9 path features in the Cypher query engine, validating variable-length relationship traversals with range bounds, shortest path algorithms, EXISTS-based filtering with property conditions, cross-product joins from multi-pattern matches, and relationship creation from pattern combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->