### PR TITLE
chore: final acceptance sweep — all 14 checks pass (SPA-106)

### DIFF
--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -1,0 +1,59 @@
+# SPA-106: Acceptance Check Status
+
+All 14 acceptance checks defined in `crates/sparrowdb/tests/acceptance.rs` pass
+on this branch.  Run the suite with:
+
+```
+cargo test --workspace --test acceptance -- --nocapture
+```
+
+## Check Matrix
+
+| # | Name | Description | Status |
+|---|------|-------------|--------|
+| 1 | `check_1_one_hop_scan` | `(a:Person)-[:KNOWS]->(b:Person)` 1-hop MATCH | PASS |
+| 2 | `check_2_two_hop_asp_join` | 2-hop friend-of-friend via ASP-Join | PASS |
+| 3 | `check_3_wal_crash_recovery` | WriteTx dropped without commit; uncommitted data absent after reopen; committed data survives | PASS |
+| 4 | `check_4_checkpoint_optimize_no_error` | CHECKPOINT and OPTIMIZE succeed; data readable afterward | PASS |
+| 5 | `check_5_snapshot_isolation` | Old ReadTx sees pre-write snapshot; new ReadTx sees post-write value | PASS |
+| 6 | `check_6_encryption_auth_wrong_key` | Wrong key returns `EncryptionAuthFailed`; correct key round-trips cleanly | PASS |
+| 7 | `check_7_order_by_large_result` | ORDER BY ASC on 50-node result; output is in ascending order | PASS |
+| 8 | `check_8_python_binding_skip_if_not_configured` | Python binding (skipped — requires maturin + Python) | SKIP |
+| 9 | `check_9_nodejs_binding_skip_if_not_configured` | Node.js binding (skipped — requires napi-rs build + Node.js) | SKIP |
+| 10 | `check_10_mutation_round_trip` | MERGE idempotent; MATCH…SET updates property; CREATE edge queryable | PASS |
+| 11 | `check_11_mvcc_write_write_conflict` | Second `begin_write` returns `WriterBusy`; lock released on drop | PASS |
+| 12 | `check_12_unwind_list_expansion` | `UNWIND [10,20,30]`; string list; empty list | PASS |
+| 13 | `check_13_variable_length_paths` | `[:LINK*1]` and `[:LINK*1..2]` return correct hop counts | PASS |
+| 14 | `check_14_fulltext_search` | `CALL db.index.fulltext.queryNodes(...)` returns matching node | PASS |
+
+Checks 8 and 9 are intentional skips (external runtime required).
+The CI `acceptance` job counts them as passing — `test result: ok. 14 passed`.
+
+## Regressions Fixed in This Branch
+
+Two pre-existing regressions were found and fixed during this sweep:
+
+### 1. `spa_193_undirected_pattern::undirected_returns_both_directions`
+
+**Root cause** (`crates/sparrowdb-execution/src/engine.rs`):
+The backward pass of `(a)-[r]-(b)` matching checked
+`seen_undirected.contains(&(a_slot, b_slot))` to avoid re-emitting pairs
+already produced by the forward pass.  This was backwards: the backward
+row about to be emitted is `(b_slot, a_slot)`, so the dedup check must be
+`seen_undirected.contains(&(b_slot, a_slot))`.  With the wrong check, any
+directed edge a→b suppressed its own backward traversal, returning only 1
+row instead of 2.
+
+**Fix**: Changed the contains() key from `(a_slot, b_slot)` to `(b_slot, a_slot)`.
+
+### 2. `uc1_social_graph` — col_id mismatch
+
+**Root cause** (`crates/sparrowdb/tests/uc1_social_graph.rs`):
+The test stored node properties using raw integer col_ids `0` and `1`
+(literal), but the execution engine looks up properties via
+`col_id_of("col_0")` / `col_id_of("col_1")` (FNV-1a hash, values
+2141575598 and 2158353217).  The mismatch caused property filters like
+`{col_0: 1}` to never match, returning 0 rows.
+
+**Fix**: Updated the test to call `col_id_of("col_0")` / `col_id_of("col_1")`
+when building the node store, aligning stored keys with the engine's lookup.


### PR DESCRIPTION
## **User description**
## Summary

- Ran `cargo test --workspace` in a clean worktree — zero failures across all committed test files
- All 14 acceptance checks in `crates/sparrowdb/tests/acceptance.rs` pass: 12 substantive, 2 intentional skips (Python/Node.js bindings require external runtimes)
- Added `ACCEPTANCE.md` with the full check matrix and regression documentation
- Fixed 2 pre-existing regressions found during the sweep

## Regressions Fixed

**1. Undirected pattern returns only 1 row instead of 2 (SPA-193)**
- File: `crates/sparrowdb-execution/src/engine.rs`
- The backward-pass dedup check used `(a_slot, b_slot)` instead of `(b_slot, a_slot)`, causing the b→a traversal of a directed a→b edge to be incorrectly suppressed
- Test: `spa_193_undirected_pattern::undirected_returns_both_directions`

**2. `uc1_social_graph` col_id mismatch — 0 rows returned**
- File: `crates/sparrowdb/tests/uc1_social_graph.rs`
- Test stored properties with raw col_ids `0`/`1` but engine looked them up via `col_id_of("col_0")` (FNV hash). Mismatch caused all prop filters to fail.
- Tests: `single_reader_match_person_names`, `two_hop_match_via_binary_asp_join`

## Test Plan

- [x] `cargo test --workspace --test acceptance` → 14 passed, 0 failed
- [x] `cargo test --workspace` → 0 failures across all committed test files
- [x] `cargo test --test spa_193_undirected_pattern` → 3 passed
- [x] `cargo test --test uc1_social_graph` → 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix undirected graph matches and restore social graph test results**

### What Changed
- Undirected pattern matches now return both directions when a connection exists, instead of dropping the reverse row
- The UC-1 social graph test data now uses the same property IDs as the engine, so person-name and two-hop matches return rows again
- Added an acceptance summary document that lists all 14 checks and the regressions fixed in this branch

### Impact
`✅ Correct results for undirected graph queries`
`✅ Fewer zero-row surprises in social graph searches`
`✅ Clearer acceptance check status for release validation`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
