### PR TITLE
fix(engine): undirected MATCH (a)-[:R]-(b) returns both traversal directions (SPA-257)

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -2560,10 +2560,9 @@ impl Engine {
                 // checkpoint).  Falls back to None gracefully when no
                 // checkpoint has been run yet so pre-checkpoint databases
                 // still return correct results via the delta log path.
-                let csr_bwd: Option<CsrBackward> =
-                    EdgeStore::open(&self.db_root, storage_rel_id)
-                        .and_then(|s| s.open_bwd())
-                        .ok();
+                let csr_bwd: Option<CsrBackward> = EdgeStore::open(&self.db_root, storage_rel_id)
+                    .and_then(|s| s.open_bwd())
+                    .ok();
 
                 // Scan the b-side (physical dst label = tbl_dst_label_id).
                 for b_slot in 0..hwm_bwd {

--- a/crates/sparrowdb/tests/uc1_social_graph.rs
+++ b/crates/sparrowdb/tests/uc1_social_graph.rs
@@ -4,6 +4,7 @@
 //! Acceptance check #4: two_hop_match_via_binary_asp_join
 
 use sparrowdb_catalog::catalog::Catalog;
+use sparrowdb_common::col_id_of;
 use sparrowdb_execution::engine::Engine;
 use sparrowdb_storage::csr::CsrForward;
 use sparrowdb_storage::node_store::{NodeStore, Value as StoreValue};
@@ -17,36 +18,54 @@ fn setup_social_graph(dir: &std::path::Path) -> Engine {
         .expect("KNOWS rel table");
 
     let mut store = NodeStore::open(dir).expect("node store");
-    // col 0 = name (stored as i64 id: 1=Alice, 2=Bob, 3=Carol, 4=Dave, 5=Eve)
-    // col 1 = age
+    // Use col_id_of so the column ids match what the execution engine computes
+    // from Cypher property names (FNV-hashed).  Previously, raw integer literals
+    // 0 and 1 were used, which don't match col_id_of("col_0") / col_id_of("col_1").
+    let col_0 = col_id_of("col_0"); // name: 1=Alice, 2=Bob, 3=Carol, 4=Dave, 5=Eve
+    let col_1 = col_id_of("col_1"); // age
     let alice = store
         .create_node(
             person_id,
-            &[(0, StoreValue::Int64(1)), (1, StoreValue::Int64(30))],
+            &[
+                (col_0, StoreValue::Int64(1)),
+                (col_1, StoreValue::Int64(30)),
+            ],
         )
         .expect("Alice");
     let bob = store
         .create_node(
             person_id,
-            &[(0, StoreValue::Int64(2)), (1, StoreValue::Int64(25))],
+            &[
+                (col_0, StoreValue::Int64(2)),
+                (col_1, StoreValue::Int64(25)),
+            ],
         )
         .expect("Bob");
     let carol = store
         .create_node(
             person_id,
-            &[(0, StoreValue::Int64(3)), (1, StoreValue::Int64(35))],
+            &[
+                (col_0, StoreValue::Int64(3)),
+                (col_1, StoreValue::Int64(35)),
+            ],
         )
         .expect("Carol");
     let dave = store
         .create_node(
             person_id,
-            &[(0, StoreValue::Int64(4)), (1, StoreValue::Int64(28))],
+            &[
+                (col_0, StoreValue::Int64(4)),
+                (col_1, StoreValue::Int64(28)),
+            ],
         )
         .expect("Dave");
     let _eve = store
         .create_node(
             person_id,
-            &[(0, StoreValue::Int64(5)), (1, StoreValue::Int64(22))],
+            &[
+                (col_0, StoreValue::Int64(5)),
+                (col_1, StoreValue::Int64(22)),
+            ],
         )
         .expect("Eve");
 


### PR DESCRIPTION
## **User description**
## Summary

- Fixes `MATCH (a)-[:R]-(b)` to return both `(Alice, Bob)` and `(Bob, Alice)` when the relationship `Alice->Bob` exists (was returning only 1 row instead of 2)
- Root cause: backward-pass dedup check used `(a_slot, b_slot)` (checking if Alice→Bob was already emitted) instead of `(b_slot, a_slot)` (checking if Bob→Alice was already emitted), incorrectly suppressing the backward traversal
- Secondary fix: also load `CsrBackward` file so post-checkpoint databases get correct undirected results, not just pre-checkpoint (delta-only) databases

## Test plan

- [x] `undirected_returns_both_directions` — was failing, now passes (2 rows returned)
- [x] `undirected_with_src_prop_filter` — still passes (1 filtered row)
- [x] `undirected_from_destination_side` — still passes (backward traversal works)
- [x] All 3 tests in `spa_193_undirected_pattern.rs` pass

Linear: SPA-257

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Return both directions for undirected graph matches, even after checkpointing**

### What Changed
- Undirected relationship matches now return the reverse row as expected, so `MATCH (a)-[:R]-(b)` can yield both `(Alice, Bob)` and `(Bob, Alice)` when the edge exists
- Results now stay correct after checkpointing, not just before it, so undirected queries work across both stored and recently added data
- Duplicate reverse rows are still filtered out when the same pair would be produced more than once

### Impact
`✅ Correct undirected query results`
`✅ Fewer missing graph matches`
`✅ Consistent results after checkpoint`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed backward graph traversal deduplication to eliminate duplicate results and properly align edge ordering.
  * Enhanced backward traversal to correctly merge checkpointed data with recent transaction logs.

* **Tests**
  * Updated test configuration to use computed column identifiers for property lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->