### PR TITLE
feat(cypher): WITH pipeline — MATCH/UNWIND chaining and EXISTS subquery (SPA-134)

### DIFF
--- a/crates/sparrowdb-cypher/src/ast.rs
+++ b/crates/sparrowdb-cypher/src/ast.rs
@@ -175,6 +175,16 @@ pub enum BinOpKind {
     EndsWith,
     Or,
     And,
+    /// Arithmetic: `a + b`
+    Add,
+    /// Arithmetic: `a - b`
+    Sub,
+    /// Arithmetic: `a * b`
+    Mul,
+    /// Arithmetic: `a / b`
+    Div,
+    /// Arithmetic: `a % b`
+    Mod,
 }
 
 /// RETURN clause item.
@@ -302,6 +312,65 @@ pub struct MatchWithStatement {
     pub distinct: bool,
 }
 
+/// A single stage in a multi-clause pipeline (SPA-134).
+///
+/// Pipelines are sequences of clauses that pass intermediate row sets from
+/// one stage to the next.  Each stage receives the projected rows from its
+/// predecessor and either transforms them or re-traverses the graph.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PipelineStage {
+    /// `WITH expr AS alias [, ...] [WHERE pred]` — project + optionally filter rows.
+    /// Also carries optional ORDER BY / SKIP / LIMIT that are applied to the WITH output.
+    With {
+        clause: WithClause,
+        order_by: Vec<(Expr, SortDir)>,
+        skip: Option<u64>,
+        limit: Option<u64>,
+    },
+    /// `MATCH pattern [WHERE pred]` — re-traverse the graph, constraining by the
+    /// variables that were projected in the preceding WITH stage.
+    Match {
+        patterns: Vec<PathPattern>,
+        where_clause: Option<Expr>,
+    },
+    /// `UNWIND alias_expr AS new_alias` — unwind a list variable from the preceding
+    /// WITH into individual rows.
+    Unwind { alias: String, new_alias: String },
+}
+
+/// A multi-clause Cypher pipeline (SPA-134).
+///
+/// Covers patterns such as:
+/// - `MATCH … WITH … MATCH … RETURN`
+/// - `UNWIND … WITH … RETURN`
+/// - `MATCH … WITH … ORDER BY … LIMIT … MATCH … RETURN`
+/// - Three-stage `MATCH … WITH … MATCH … WITH … RETURN`
+///
+/// Execution is left-to-right: the first stage produces an initial row set
+/// (from the leading MATCH or UNWIND), then each subsequent stage transforms
+/// or re-traverses until the final RETURN clause produces the output.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PipelineStatement {
+    /// Leading MATCH clause (if any). May be absent for UNWIND-led pipelines.
+    pub leading_match: Option<Vec<PathPattern>>,
+    /// Optional WHERE on the leading MATCH.
+    pub leading_where: Option<Expr>,
+    /// For UNWIND-led pipelines: the list expression and binding alias.
+    pub leading_unwind: Option<(Expr, String)>,
+    /// Ordered sequence of intermediate pipeline stages.
+    pub stages: Vec<PipelineStage>,
+    /// Final RETURN clause.
+    pub return_clause: ReturnClause,
+    /// Optional ORDER BY on the final RETURN.
+    pub return_order_by: Vec<(Expr, SortDir)>,
+    /// Optional SKIP on the final RETURN.
+    pub return_skip: Option<u64>,
+    /// Optional LIMIT on the final RETURN.
+    pub return_limit: Option<u64>,
+    /// Whether RETURN DISTINCT was requested.
+    pub distinct: bool,
+}
+
 /// OPTIONAL MATCH statement (standalone).
 ///
 /// Left-outer-join semantics: if no rows match (label missing or zero nodes),
@@ -384,4 +453,6 @@ pub enum Statement {
     Optimize,
     /// CALL procedure dispatch (SPA-170 — KMS full-text search).
     Call(CallStatement),
+    /// Multi-clause pipeline: MATCH/UNWIND … WITH … MATCH … WITH … RETURN (SPA-134).
+    Pipeline(PipelineStatement),
 }

--- a/crates/sparrowdb-cypher/src/binder.rs
+++ b/crates/sparrowdb-cypher/src/binder.rs
@@ -68,6 +68,8 @@ pub fn bind(stmt: Statement, catalog: &Catalog) -> Result<BoundStatement> {
         // CALL: procedure name and args are validated at execution time by the
         // procedure dispatcher.  No catalog lookups are required here.
         Statement::Call(_) => {}
+        // Pipeline: label binding is deferred to execution time (SPA-134).
+        Statement::Pipeline(_) => {}
     }
     Ok(BoundStatement { inner: stmt })
 }

--- a/crates/sparrowdb-cypher/src/lexer.rs
+++ b/crates/sparrowdb-cypher/src/lexer.rs
@@ -70,6 +70,9 @@ pub enum Token {
     Dash,      // -
     Pipe,      // |
     Star,      // *
+    Plus,      // +
+    Slash,     // /
+    Percent,   // %
     DotDot,    // ..
 
     // Operators
@@ -203,6 +206,18 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>> {
                     i += 1;
                     Token::Dash
                 }
+            }
+            '+' => {
+                i += 1;
+                Token::Plus
+            }
+            '/' => {
+                i += 1;
+                Token::Slash
+            }
+            '%' => {
+                i += 1;
+                Token::Percent
             }
             '$' => {
                 i += 1;

--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -9,8 +9,8 @@ use crate::ast::{
     BinOpKind, CallStatement, CreateStatement, EdgeDir, ExistsPattern, Expr, ListPredicateKind,
     Literal, MatchCreateStatement, MatchMutateStatement, MatchOptionalMatchStatement,
     MatchStatement, MergeStatement, Mutation, NodePattern, OptionalMatchStatement, PathPattern,
-    PropEntry, RelPattern, ReturnClause, ReturnItem, ShortestPathExpr, SortDir, Statement,
-    UnionStatement, UnwindStatement,
+    PipelineStage, PipelineStatement, PropEntry, RelPattern, ReturnClause, ReturnItem,
+    ShortestPathExpr, SortDir, Statement, UnionStatement, UnwindStatement, WithClause, WithItem,
 };
 use crate::lexer::{tokenize, Token};
 
@@ -556,7 +556,7 @@ impl Parser {
         patterns: Vec<PathPattern>,
         match_where: Option<Expr>,
     ) -> Result<Statement> {
-        use crate::ast::{MatchWithStatement, WithClause, WithItem};
+        use crate::ast::MatchWithStatement;
 
         // Consume WITH token.
         self.expect_tok(&Token::With)?;
@@ -588,21 +588,9 @@ impl Parser {
             where_clause: with_where,
         };
 
-        // RETURN clause.
-        self.expect_tok(&Token::Return)?;
-        let distinct = if matches!(self.peek(), Token::Distinct) {
-            self.advance();
-            true
-        } else {
-            false
-        };
-        let return_items = self.parse_return_items()?;
-        let return_clause = crate::ast::ReturnClause {
-            items: return_items,
-        };
-
-        // ORDER BY
-        let order_by = if matches!(self.peek(), Token::Order) {
+        // Optional ORDER BY / SKIP / LIMIT that belong to this WITH stage.
+        // These are consumed before checking for a continuation clause (MATCH/WITH/UNWIND).
+        let with_order_by = if matches!(self.peek(), Token::Order) {
             self.advance();
             self.expect_tok(&Token::By)?;
             self.parse_order_by_items()?
@@ -610,8 +598,7 @@ impl Parser {
             vec![]
         };
 
-        // SKIP
-        let skip = if matches!(self.peek(), Token::Skip) {
+        let with_skip = if matches!(self.peek(), Token::Skip) {
             self.advance();
             match self.advance().clone() {
                 Token::Integer(n) => {
@@ -631,8 +618,7 @@ impl Parser {
             None
         };
 
-        // LIMIT
-        let limit = if matches!(self.peek(), Token::Limit) {
+        let with_limit = if matches!(self.peek(), Token::Limit) {
             self.advance();
             match self.advance().clone() {
                 Token::Integer(n) => {
@@ -652,16 +638,309 @@ impl Parser {
             None
         };
 
-        Ok(Statement::MatchWith(MatchWithStatement {
-            match_patterns: patterns,
-            match_where,
-            with_clause,
-            return_clause,
-            order_by,
-            skip,
-            limit,
-            distinct,
-        }))
+        // Peek at the next token to decide: RETURN → simple MatchWith,
+        // MATCH/WITH/UNWIND → multi-stage Pipeline (SPA-134).
+        match self.peek().clone() {
+            Token::Return => {
+                // Simple single-WITH pipeline: MATCH … WITH … RETURN …
+                self.advance(); // consume RETURN
+                let distinct = if matches!(self.peek(), Token::Distinct) {
+                    self.advance();
+                    true
+                } else {
+                    false
+                };
+                let return_items = self.parse_return_items()?;
+                let return_clause = ReturnClause {
+                    items: return_items,
+                };
+
+                // ORDER BY / SKIP / LIMIT on the RETURN (i.e. not on the WITH).
+                let order_by = if matches!(self.peek(), Token::Order) {
+                    self.advance();
+                    self.expect_tok(&Token::By)?;
+                    self.parse_order_by_items()?
+                } else {
+                    with_order_by
+                };
+
+                let skip = if matches!(self.peek(), Token::Skip) {
+                    self.advance();
+                    match self.advance().clone() {
+                        Token::Integer(n) => {
+                            if n < 0 {
+                                return Err(Error::InvalidArgument(
+                                    "SKIP must be non-negative".into(),
+                                ));
+                            }
+                            Some(n as u64)
+                        }
+                        other => {
+                            return Err(Error::InvalidArgument(format!(
+                                "expected integer after SKIP, got {:?}",
+                                other
+                            )))
+                        }
+                    }
+                } else {
+                    with_skip
+                };
+
+                let limit = if matches!(self.peek(), Token::Limit) {
+                    self.advance();
+                    match self.advance().clone() {
+                        Token::Integer(n) => {
+                            if n < 0 {
+                                return Err(Error::InvalidArgument(
+                                    "LIMIT must be non-negative".into(),
+                                ));
+                            }
+                            Some(n as u64)
+                        }
+                        other => {
+                            return Err(Error::InvalidArgument(format!(
+                                "expected integer after LIMIT, got {:?}",
+                                other
+                            )))
+                        }
+                    }
+                } else {
+                    with_limit
+                };
+
+                Ok(Statement::MatchWith(MatchWithStatement {
+                    match_patterns: patterns,
+                    match_where,
+                    with_clause,
+                    return_clause,
+                    order_by,
+                    skip,
+                    limit,
+                    distinct,
+                }))
+            }
+            // Continuation clause: MATCH, WITH, or UNWIND → build Pipeline.
+            Token::Match | Token::With | Token::Unwind => {
+                let first_with_stage = PipelineStage::With {
+                    clause: with_clause,
+                    order_by: with_order_by,
+                    skip: with_skip,
+                    limit: with_limit,
+                };
+                self.parse_pipeline_continuation(
+                    Some(patterns),
+                    match_where,
+                    None,
+                    vec![first_with_stage],
+                )
+            }
+            other => Err(Error::InvalidArgument(format!(
+                "expected RETURN, MATCH, WITH, or UNWIND after WITH clause, got {:?}",
+                other
+            ))),
+        }
+    }
+
+    /// Parse the remainder of a multi-clause pipeline after the initial stages have
+    /// been set up.  Accumulates additional MATCH / WITH / UNWIND stages until a
+    /// RETURN clause terminates the pipeline.
+    fn parse_pipeline_continuation(
+        &mut self,
+        leading_match: Option<Vec<PathPattern>>,
+        leading_where: Option<Expr>,
+        leading_unwind: Option<(crate::ast::Expr, String)>,
+        mut stages: Vec<PipelineStage>,
+    ) -> Result<Statement> {
+        loop {
+            match self.peek().clone() {
+                Token::Match => {
+                    // Parse a MATCH stage.
+                    self.advance(); // consume MATCH
+                    let patterns = self.parse_pattern_list()?;
+                    let where_clause = if matches!(self.peek(), Token::Where) {
+                        self.advance();
+                        Some(self.parse_expr()?)
+                    } else {
+                        None
+                    };
+                    stages.push(PipelineStage::Match {
+                        patterns,
+                        where_clause,
+                    });
+                }
+                Token::With => {
+                    // Parse a WITH stage.
+                    self.advance(); // consume WITH
+                    let mut items: Vec<WithItem> = Vec::new();
+                    loop {
+                        let expr = self.parse_expr()?;
+                        self.expect_tok(&Token::As)?;
+                        let alias = self.expect_ident()?;
+                        items.push(WithItem { expr, alias });
+                        if matches!(self.peek(), Token::Comma) {
+                            self.advance();
+                        } else {
+                            break;
+                        }
+                    }
+                    let where_clause = if matches!(self.peek(), Token::Where) {
+                        self.advance();
+                        Some(self.parse_expr()?)
+                    } else {
+                        None
+                    };
+                    let clause = WithClause {
+                        items,
+                        where_clause,
+                    };
+                    // ORDER BY / SKIP / LIMIT on this intermediate WITH.
+                    let order_by = if matches!(self.peek(), Token::Order) {
+                        self.advance();
+                        self.expect_tok(&Token::By)?;
+                        self.parse_order_by_items()?
+                    } else {
+                        vec![]
+                    };
+                    let skip = if matches!(self.peek(), Token::Skip) {
+                        self.advance();
+                        match self.advance().clone() {
+                            Token::Integer(n) => {
+                                if n < 0 {
+                                    return Err(Error::InvalidArgument(
+                                        "SKIP must be non-negative".into(),
+                                    ));
+                                }
+                                Some(n as u64)
+                            }
+                            other => {
+                                return Err(Error::InvalidArgument(format!(
+                                    "expected integer after SKIP, got {:?}",
+                                    other
+                                )))
+                            }
+                        }
+                    } else {
+                        None
+                    };
+                    let limit = if matches!(self.peek(), Token::Limit) {
+                        self.advance();
+                        match self.advance().clone() {
+                            Token::Integer(n) => {
+                                if n < 0 {
+                                    return Err(Error::InvalidArgument(
+                                        "LIMIT must be non-negative".into(),
+                                    ));
+                                }
+                                Some(n as u64)
+                            }
+                            other => {
+                                return Err(Error::InvalidArgument(format!(
+                                    "expected integer after LIMIT, got {:?}",
+                                    other
+                                )))
+                            }
+                        }
+                    } else {
+                        None
+                    };
+                    stages.push(PipelineStage::With {
+                        clause,
+                        order_by,
+                        skip,
+                        limit,
+                    });
+                }
+                Token::Unwind => {
+                    // Parse an UNWIND stage: UNWIND alias_var AS new_alias.
+                    self.advance(); // consume UNWIND
+                                    // In pipeline context the "list" to unwind is a variable name.
+                    let alias = self.expect_ident()?;
+                    self.expect_tok(&Token::As)?;
+                    let new_alias = self.expect_ident()?;
+                    stages.push(PipelineStage::Unwind { alias, new_alias });
+                }
+                Token::Return => {
+                    // Terminal clause.
+                    self.advance(); // consume RETURN
+                    let distinct = if matches!(self.peek(), Token::Distinct) {
+                        self.advance();
+                        true
+                    } else {
+                        false
+                    };
+                    let return_items = self.parse_return_items()?;
+                    let return_clause = ReturnClause {
+                        items: return_items,
+                    };
+                    let return_order_by = if matches!(self.peek(), Token::Order) {
+                        self.advance();
+                        self.expect_tok(&Token::By)?;
+                        self.parse_order_by_items()?
+                    } else {
+                        vec![]
+                    };
+                    let return_skip = if matches!(self.peek(), Token::Skip) {
+                        self.advance();
+                        match self.advance().clone() {
+                            Token::Integer(n) => {
+                                if n < 0 {
+                                    return Err(Error::InvalidArgument(
+                                        "SKIP must be non-negative".into(),
+                                    ));
+                                }
+                                Some(n as u64)
+                            }
+                            other => {
+                                return Err(Error::InvalidArgument(format!(
+                                    "expected integer after SKIP, got {:?}",
+                                    other
+                                )))
+                            }
+                        }
+                    } else {
+                        None
+                    };
+                    let return_limit = if matches!(self.peek(), Token::Limit) {
+                        self.advance();
+                        match self.advance().clone() {
+                            Token::Integer(n) => {
+                                if n < 0 {
+                                    return Err(Error::InvalidArgument(
+                                        "LIMIT must be non-negative".into(),
+                                    ));
+                                }
+                                Some(n as u64)
+                            }
+                            other => {
+                                return Err(Error::InvalidArgument(format!(
+                                    "expected integer after LIMIT, got {:?}",
+                                    other
+                                )))
+                            }
+                        }
+                    } else {
+                        None
+                    };
+                    return Ok(Statement::Pipeline(PipelineStatement {
+                        leading_match,
+                        leading_where,
+                        leading_unwind,
+                        stages,
+                        return_clause,
+                        return_order_by,
+                        return_skip,
+                        return_limit,
+                        distinct,
+                    }));
+                }
+                other => {
+                    return Err(Error::InvalidArgument(format!(
+                        "expected MATCH, WITH, UNWIND, or RETURN in pipeline, got {:?}",
+                        other
+                    )))
+                }
+            }
+        }
     }
 
     // ── MERGE ─────────────────────────────────────────────────────────────────
@@ -756,6 +1035,12 @@ impl Parser {
         let expr = self.parse_unwind_expr()?;
         self.expect_tok(&Token::As)?;
         let alias = self.expect_ident()?;
+
+        // If the next token is WITH, this is a pipeline: UNWIND … WITH … RETURN (SPA-134).
+        if matches!(self.peek(), Token::With) {
+            return self.parse_pipeline_continuation(None, None, Some((expr, alias)), vec![]);
+        }
+
         self.expect_tok(&Token::Return)?;
         let items = self.parse_return_items()?;
         Ok(Statement::Unwind(UnwindStatement {
@@ -1247,7 +1532,7 @@ impl Parser {
     }
 
     fn parse_comparison(&mut self) -> Result<Expr> {
-        let left = self.parse_atom()?;
+        let left = self.parse_additive()?;
 
         // Handle `expr IS NULL` / `expr IS NOT NULL`
         if matches!(self.peek(), Token::Is) {
@@ -1349,12 +1634,53 @@ impl Parser {
             _ => return Ok(left),
         };
         self.advance();
-        let right = self.parse_atom()?;
+        let right = self.parse_additive()?;
         Ok(Expr::BinOp {
             left: Box::new(left),
             op,
             right: Box::new(right),
         })
+    }
+
+    /// Parse additive expressions: `a + b`, `a - b`.
+    fn parse_additive(&mut self) -> Result<Expr> {
+        let mut left = self.parse_multiplicative()?;
+        loop {
+            let op = match self.peek() {
+                Token::Plus => BinOpKind::Add,
+                Token::Dash => BinOpKind::Sub,
+                _ => break,
+            };
+            self.advance();
+            let right = self.parse_multiplicative()?;
+            left = Expr::BinOp {
+                left: Box::new(left),
+                op,
+                right: Box::new(right),
+            };
+        }
+        Ok(left)
+    }
+
+    /// Parse multiplicative expressions: `a * b`, `a / b`, `a % b`.
+    fn parse_multiplicative(&mut self) -> Result<Expr> {
+        let mut left = self.parse_atom()?;
+        loop {
+            let op = match self.peek() {
+                Token::Star => BinOpKind::Mul,
+                Token::Slash => BinOpKind::Div,
+                Token::Percent => BinOpKind::Mod,
+                _ => break,
+            };
+            self.advance();
+            let right = self.parse_atom()?;
+            left = Expr::BinOp {
+                left: Box::new(left),
+                op,
+                right: Box::new(right),
+            };
+        }
+        Ok(left)
     }
 
     /// Parse a comma-separated list of atom expressions up to `]`.

--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -13,8 +13,8 @@ use sparrowdb_common::{col_id_of, NodeId, Result};
 use sparrowdb_cypher::ast::{
     BinOpKind, CallStatement, CreateStatement, Expr, ListPredicateKind, Literal,
     MatchCreateStatement, MatchMutateStatement, MatchOptionalMatchStatement, MatchStatement,
-    MatchWithStatement, Mutation, OptionalMatchStatement, PathPattern, ReturnItem, SortDir,
-    Statement, UnionStatement, UnwindStatement, WithClause,
+    MatchWithStatement, Mutation, OptionalMatchStatement, PathPattern, PipelineStage,
+    PipelineStatement, ReturnItem, SortDir, Statement, UnionStatement, UnwindStatement, WithClause,
 };
 use sparrowdb_cypher::{bind, parse};
 use sparrowdb_storage::csr::CsrForward;
@@ -258,6 +258,7 @@ impl Engine {
             Statement::Union(u) => self.execute_union(u),
             Statement::Checkpoint | Statement::Optimize => Ok(QueryResult::empty(vec![])),
             Statement::Call(c) => self.execute_call(&c),
+            Statement::Pipeline(p) => self.execute_pipeline(&p),
         }
     }
 
@@ -1127,36 +1128,121 @@ impl Engine {
             &m.with_clause,
         )?;
 
-        // Step 2 & 3: project through WITH + filter.
-        let mut projected: Vec<HashMap<String, Value>> = Vec::new();
-        for row_vals in &intermediate {
-            let mut with_vals: HashMap<String, Value> = HashMap::new();
-            for item in &m.with_clause.items {
-                let val = eval_expr(&item.expr, row_vals);
-                with_vals.insert(item.alias.clone(), val);
-            }
-            if let Some(ref where_expr) = m.with_clause.where_clause {
-                let mut with_vals_p = with_vals.clone();
-                with_vals_p.extend(self.dollar_params());
-                if !self.eval_where_graph(where_expr, &with_vals_p) {
-                    continue;
+        // Step 2: check if WITH clause has aggregate expressions.
+        // If so, we aggregate the intermediate rows first, producing one output row
+        // per unique grouping key.
+        let has_agg = m
+            .with_clause
+            .items
+            .iter()
+            .any(|item| is_aggregate_expr(&item.expr));
+
+        let projected: Vec<HashMap<String, Value>> = if has_agg {
+            // Aggregate the intermediate rows into a set of projected rows.
+            let agg_rows = self.aggregate_with_items(&intermediate, &m.with_clause.items);
+            // Apply WHERE filter on the aggregated rows.
+            agg_rows
+                .into_iter()
+                .filter(|with_vals| {
+                    if let Some(ref where_expr) = m.with_clause.where_clause {
+                        let mut with_vals_p = with_vals.clone();
+                        with_vals_p.extend(self.dollar_params());
+                        self.eval_where_graph(where_expr, &with_vals_p)
+                    } else {
+                        true
+                    }
+                })
+                .map(|mut with_vals| {
+                    with_vals.extend(self.dollar_params());
+                    with_vals
+                })
+                .collect()
+        } else {
+            // Non-aggregate path: project each row through the WITH items.
+            let mut projected: Vec<HashMap<String, Value>> = Vec::new();
+            for row_vals in &intermediate {
+                let mut with_vals: HashMap<String, Value> = HashMap::new();
+                for item in &m.with_clause.items {
+                    let val = self.eval_expr_graph(&item.expr, row_vals);
+                    with_vals.insert(item.alias.clone(), val);
+                    // SPA-134: if the WITH item is a bare Var (e.g. `n AS person`),
+                    // also inject the NodeRef under the alias so that EXISTS subqueries
+                    // in a subsequent WHERE clause can resolve the source node.
+                    if let sparrowdb_cypher::ast::Expr::Var(ref src_var) = item.expr {
+                        if let Some(node_ref) = row_vals.get(src_var) {
+                            if matches!(node_ref, Value::NodeRef(_)) {
+                                with_vals.insert(item.alias.clone(), node_ref.clone());
+                                with_vals.insert(
+                                    format!("{}.__node_id__", item.alias),
+                                    node_ref.clone(),
+                                );
+                            }
+                        }
+                        // Also check __node_id__ key.
+                        let nid_key = format!("{src_var}.__node_id__");
+                        if let Some(node_ref) = row_vals.get(&nid_key) {
+                            with_vals
+                                .insert(format!("{}.__node_id__", item.alias), node_ref.clone());
+                        }
+                    }
                 }
+                if let Some(ref where_expr) = m.with_clause.where_clause {
+                    let mut with_vals_p = with_vals.clone();
+                    with_vals_p.extend(self.dollar_params());
+                    if !self.eval_where_graph(where_expr, &with_vals_p) {
+                        continue;
+                    }
+                }
+                // Merge dollar_params into the projected row so that downstream
+                // RETURN/ORDER-BY/SKIP/LIMIT expressions can resolve $param references.
+                with_vals.extend(self.dollar_params());
+                projected.push(with_vals);
             }
-            // Merge dollar_params into the projected row so that downstream
-            // RETURN/ORDER-BY/SKIP/LIMIT expressions can resolve $param references.
-            with_vals.extend(self.dollar_params());
-            projected.push(with_vals);
+            projected
+        };
+
+        // Step 3: project RETURN from the WITH-projected rows.
+        let column_names = extract_return_column_names(&m.return_clause.items);
+
+        // Apply ORDER BY on the projected rows (which still have all WITH aliases)
+        // before projecting down to RETURN columns — this allows ORDER BY on columns
+        // that are not in the RETURN clause (e.g. ORDER BY age when only name is returned).
+        let mut ordered_projected = projected;
+        if !m.order_by.is_empty() {
+            ordered_projected.sort_by(|a, b| {
+                for (expr, dir) in &m.order_by {
+                    let val_a = eval_expr(expr, a);
+                    let val_b = eval_expr(expr, b);
+                    let cmp = compare_values(&val_a, &val_b);
+                    let cmp = if *dir == SortDir::Desc {
+                        cmp.reverse()
+                    } else {
+                        cmp
+                    };
+                    if cmp != std::cmp::Ordering::Equal {
+                        return cmp;
+                    }
+                }
+                std::cmp::Ordering::Equal
+            });
         }
 
-        // Step 4: project RETURN from the WITH-projected rows.
-        let column_names = extract_return_column_names(&m.return_clause.items);
-        let mut rows: Vec<Vec<Value>> = projected
+        // Apply SKIP / LIMIT before final projection.
+        if let Some(skip) = m.skip {
+            let skip = (skip as usize).min(ordered_projected.len());
+            ordered_projected.drain(0..skip);
+        }
+        if let Some(lim) = m.limit {
+            ordered_projected.truncate(lim as usize);
+        }
+
+        let mut rows: Vec<Vec<Value>> = ordered_projected
             .iter()
             .map(|with_vals| {
                 m.return_clause
                     .items
                     .iter()
-                    .map(|item| eval_expr(&item.expr, with_vals))
+                    .map(|item| self.eval_expr_graph(&item.expr, with_vals))
                     .collect()
             })
             .collect();
@@ -1164,18 +1250,706 @@ impl Engine {
         if m.distinct {
             deduplicate_rows(&mut rows);
         }
-        if let Some(skip) = m.skip {
-            let skip = (skip as usize).min(rows.len());
-            rows.drain(0..skip);
+
+        Ok(QueryResult {
+            columns: column_names,
+            rows,
+        })
+    }
+
+    /// Aggregate a set of raw scan rows through a list of WITH items that
+    /// include aggregate expressions (COUNT(*), collect(), etc.).
+    ///
+    /// Returns one `HashMap<String, Value>` per unique grouping key.
+    fn aggregate_with_items(
+        &self,
+        rows: &[HashMap<String, Value>],
+        items: &[sparrowdb_cypher::ast::WithItem],
+    ) -> Vec<HashMap<String, Value>> {
+        // Classify each WITH item as key or aggregate.
+        let key_indices: Vec<usize> = items
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| !is_aggregate_expr(&item.expr))
+            .map(|(i, _)| i)
+            .collect();
+        let agg_indices: Vec<usize> = items
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| is_aggregate_expr(&item.expr))
+            .map(|(i, _)| i)
+            .collect();
+
+        // Build groups.
+        let mut group_keys: Vec<Vec<Value>> = Vec::new();
+        let mut group_accum: Vec<Vec<Vec<Value>>> = Vec::new(); // [group][agg_pos] → values
+
+        for row_vals in rows {
+            let key: Vec<Value> = key_indices
+                .iter()
+                .map(|&i| eval_expr(&items[i].expr, row_vals))
+                .collect();
+            let group_idx = if let Some(pos) = group_keys.iter().position(|k| k == &key) {
+                pos
+            } else {
+                group_keys.push(key);
+                group_accum.push(vec![vec![]; agg_indices.len()]);
+                group_keys.len() - 1
+            };
+            for (ai, &ri) in agg_indices.iter().enumerate() {
+                match &items[ri].expr {
+                    sparrowdb_cypher::ast::Expr::CountStar => {
+                        group_accum[group_idx][ai].push(Value::Int64(1));
+                    }
+                    sparrowdb_cypher::ast::Expr::FnCall { name, args }
+                        if name.to_lowercase() == "collect" =>
+                    {
+                        let val = if !args.is_empty() {
+                            eval_expr(&args[0], row_vals)
+                        } else {
+                            Value::Null
+                        };
+                        if !matches!(val, Value::Null) {
+                            group_accum[group_idx][ai].push(val);
+                        }
+                    }
+                    sparrowdb_cypher::ast::Expr::FnCall { name, args }
+                        if matches!(
+                            name.to_lowercase().as_str(),
+                            "count" | "sum" | "avg" | "min" | "max"
+                        ) =>
+                    {
+                        let val = if !args.is_empty() {
+                            eval_expr(&args[0], row_vals)
+                        } else {
+                            Value::Null
+                        };
+                        if !matches!(val, Value::Null) {
+                            group_accum[group_idx][ai].push(val);
+                        }
+                    }
+                    _ => {}
+                }
+            }
         }
-        if let Some(lim) = m.limit {
-            rows.truncate(lim as usize);
+
+        // If no rows were seen, still produce one output row for global aggregates
+        // (e.g. COUNT(*) over an empty scan returns 0).
+        if rows.is_empty() && key_indices.is_empty() {
+            let mut out_row: HashMap<String, Value> = HashMap::new();
+            for &ri in &agg_indices {
+                let val = match &items[ri].expr {
+                    sparrowdb_cypher::ast::Expr::CountStar => Value::Int64(0),
+                    sparrowdb_cypher::ast::Expr::FnCall { name, .. }
+                        if name.to_lowercase() == "collect" =>
+                    {
+                        Value::List(vec![])
+                    }
+                    _ => Value::Int64(0),
+                };
+                out_row.insert(items[ri].alias.clone(), val);
+            }
+            return vec![out_row];
+        }
+
+        // Finalize each group.
+        let mut result: Vec<HashMap<String, Value>> = Vec::new();
+        for (gi, key_vals) in group_keys.iter().enumerate() {
+            let mut out_row: HashMap<String, Value> = HashMap::new();
+            // Insert key values.
+            for (ki, &ri) in key_indices.iter().enumerate() {
+                out_row.insert(items[ri].alias.clone(), key_vals[ki].clone());
+            }
+            // Finalize aggregates.
+            for (ai, &ri) in agg_indices.iter().enumerate() {
+                let accum = &group_accum[gi][ai];
+                let val = match &items[ri].expr {
+                    sparrowdb_cypher::ast::Expr::CountStar => Value::Int64(accum.len() as i64),
+                    sparrowdb_cypher::ast::Expr::FnCall { name, .. }
+                        if name.to_lowercase() == "collect" =>
+                    {
+                        Value::List(accum.clone())
+                    }
+                    sparrowdb_cypher::ast::Expr::FnCall { name, .. }
+                        if name.to_lowercase() == "count" =>
+                    {
+                        Value::Int64(accum.len() as i64)
+                    }
+                    sparrowdb_cypher::ast::Expr::FnCall { name, .. }
+                        if name.to_lowercase() == "sum" =>
+                    {
+                        let sum: i64 = accum
+                            .iter()
+                            .filter_map(|v| {
+                                if let Value::Int64(n) = v {
+                                    Some(*n)
+                                } else {
+                                    None
+                                }
+                            })
+                            .sum();
+                        Value::Int64(sum)
+                    }
+                    sparrowdb_cypher::ast::Expr::FnCall { name, .. }
+                        if name.to_lowercase() == "min" =>
+                    {
+                        accum
+                            .iter()
+                            .min_by(|a, b| compare_values(a, b))
+                            .cloned()
+                            .unwrap_or(Value::Null)
+                    }
+                    sparrowdb_cypher::ast::Expr::FnCall { name, .. }
+                        if name.to_lowercase() == "max" =>
+                    {
+                        accum
+                            .iter()
+                            .max_by(|a, b| compare_values(a, b))
+                            .cloned()
+                            .unwrap_or(Value::Null)
+                    }
+                    _ => Value::Null,
+                };
+                out_row.insert(items[ri].alias.clone(), val);
+            }
+            result.push(out_row);
+        }
+        result
+    }
+
+    /// Execute a multi-clause Cypher pipeline (SPA-134).
+    ///
+    /// Executes stages left-to-right, passing the intermediate row set from
+    /// one stage to the next, then projects the final RETURN clause.
+    fn execute_pipeline(&self, p: &PipelineStatement) -> Result<QueryResult> {
+        // Step 1: Produce the initial row set from the leading clause.
+        let mut current_rows: Vec<HashMap<String, Value>> =
+            if let Some((expr, alias)) = &p.leading_unwind {
+                // UNWIND-led pipeline: expand the list into individual rows.
+                let values = eval_list_expr(expr, &self.params)?;
+                values
+                    .into_iter()
+                    .map(|v| {
+                        let mut m = HashMap::new();
+                        m.insert(alias.clone(), v);
+                        m
+                    })
+                    .collect()
+            } else if let Some(ref patterns) = p.leading_match {
+                // MATCH-led pipeline: scan the graph.
+                // For the pipeline we need a dummy WithClause (scan will collect all
+                // col IDs needed by subsequent stages).  Use a wide scan that includes
+                // NodeRefs for EXISTS support.
+                self.collect_pipeline_match_rows(patterns, p.leading_where.as_ref())?
+            } else {
+                vec![HashMap::new()]
+            };
+
+        // Step 2: Execute pipeline stages in order.
+        for stage in &p.stages {
+            match stage {
+                PipelineStage::With {
+                    clause,
+                    order_by,
+                    skip,
+                    limit,
+                } => {
+                    // SPA-134: ORDER BY in a WITH clause can reference variables from the
+                    // PRECEDING stage (before projection).  Apply ORDER BY / SKIP / LIMIT
+                    // on current_rows (pre-projection) first, then project.
+                    if !order_by.is_empty() {
+                        current_rows.sort_by(|a, b| {
+                            for (expr, dir) in order_by {
+                                let va = eval_expr(expr, a);
+                                let vb = eval_expr(expr, b);
+                                let cmp = compare_values(&va, &vb);
+                                let cmp = if *dir == SortDir::Desc {
+                                    cmp.reverse()
+                                } else {
+                                    cmp
+                                };
+                                if cmp != std::cmp::Ordering::Equal {
+                                    return cmp;
+                                }
+                            }
+                            std::cmp::Ordering::Equal
+                        });
+                    }
+                    if let Some(s) = skip {
+                        let s = (*s as usize).min(current_rows.len());
+                        current_rows.drain(0..s);
+                    }
+                    if let Some(l) = limit {
+                        current_rows.truncate(*l as usize);
+                    }
+
+                    // Check for aggregates.
+                    let has_agg = clause
+                        .items
+                        .iter()
+                        .any(|item| is_aggregate_expr(&item.expr));
+                    let next_rows: Vec<HashMap<String, Value>> = if has_agg {
+                        let agg_rows = self.aggregate_with_items(&current_rows, &clause.items);
+                        agg_rows
+                            .into_iter()
+                            .filter(|with_vals| {
+                                if let Some(ref where_expr) = clause.where_clause {
+                                    let mut wv = with_vals.clone();
+                                    wv.extend(self.dollar_params());
+                                    self.eval_where_graph(where_expr, &wv)
+                                } else {
+                                    true
+                                }
+                            })
+                            .map(|mut with_vals| {
+                                with_vals.extend(self.dollar_params());
+                                with_vals
+                            })
+                            .collect()
+                    } else {
+                        let mut next_rows: Vec<HashMap<String, Value>> = Vec::new();
+                        for row_vals in &current_rows {
+                            let mut with_vals: HashMap<String, Value> = HashMap::new();
+                            for item in &clause.items {
+                                let val = self.eval_expr_graph(&item.expr, row_vals);
+                                with_vals.insert(item.alias.clone(), val);
+                                // Propagate NodeRef for bare variable aliases.
+                                if let sparrowdb_cypher::ast::Expr::Var(ref src_var) = item.expr {
+                                    if let Some(nr @ Value::NodeRef(_)) = row_vals.get(src_var) {
+                                        with_vals.insert(item.alias.clone(), nr.clone());
+                                        with_vals.insert(
+                                            format!("{}.__node_id__", item.alias),
+                                            nr.clone(),
+                                        );
+                                    }
+                                    let nid_key = format!("{src_var}.__node_id__");
+                                    if let Some(nr) = row_vals.get(&nid_key) {
+                                        with_vals.insert(
+                                            format!("{}.__node_id__", item.alias),
+                                            nr.clone(),
+                                        );
+                                    }
+                                }
+                            }
+                            if let Some(ref where_expr) = clause.where_clause {
+                                let mut wv = with_vals.clone();
+                                wv.extend(self.dollar_params());
+                                if !self.eval_where_graph(where_expr, &wv) {
+                                    continue;
+                                }
+                            }
+                            with_vals.extend(self.dollar_params());
+                            next_rows.push(with_vals);
+                        }
+                        next_rows
+                    };
+                    current_rows = next_rows;
+                }
+                PipelineStage::Match {
+                    patterns,
+                    where_clause,
+                } => {
+                    // Re-traverse the graph for each row in current_rows,
+                    // substituting WITH-projected values for inline prop filters.
+                    let mut next_rows: Vec<HashMap<String, Value>> = Vec::new();
+                    for binding in &current_rows {
+                        let new_rows = self.execute_pipeline_match_stage(
+                            patterns,
+                            where_clause.as_ref(),
+                            binding,
+                        )?;
+                        next_rows.extend(new_rows);
+                    }
+                    current_rows = next_rows;
+                }
+                PipelineStage::Unwind { alias, new_alias } => {
+                    // Unwind a list variable from the current row set.
+                    let mut next_rows: Vec<HashMap<String, Value>> = Vec::new();
+                    for row_vals in &current_rows {
+                        let list_val = row_vals.get(alias.as_str()).cloned().unwrap_or(Value::Null);
+                        let items = match list_val {
+                            Value::List(v) => v,
+                            other => vec![other],
+                        };
+                        for item in items {
+                            let mut new_row = row_vals.clone();
+                            new_row.insert(new_alias.clone(), item);
+                            next_rows.push(new_row);
+                        }
+                    }
+                    current_rows = next_rows;
+                }
+            }
+        }
+
+        // Step 3: PROJECT the RETURN clause.
+        let column_names = extract_return_column_names(&p.return_clause.items);
+
+        // Apply ORDER BY on the fully-projected rows before narrowing to RETURN columns.
+        if !p.return_order_by.is_empty() {
+            current_rows.sort_by(|a, b| {
+                for (expr, dir) in &p.return_order_by {
+                    let va = eval_expr(expr, a);
+                    let vb = eval_expr(expr, b);
+                    let cmp = compare_values(&va, &vb);
+                    let cmp = if *dir == SortDir::Desc {
+                        cmp.reverse()
+                    } else {
+                        cmp
+                    };
+                    if cmp != std::cmp::Ordering::Equal {
+                        return cmp;
+                    }
+                }
+                std::cmp::Ordering::Equal
+            });
+        }
+
+        if let Some(skip) = p.return_skip {
+            let skip = (skip as usize).min(current_rows.len());
+            current_rows.drain(0..skip);
+        }
+        if let Some(lim) = p.return_limit {
+            current_rows.truncate(lim as usize);
+        }
+
+        let mut rows: Vec<Vec<Value>> = current_rows
+            .iter()
+            .map(|row_vals| {
+                p.return_clause
+                    .items
+                    .iter()
+                    .map(|item| self.eval_expr_graph(&item.expr, row_vals))
+                    .collect()
+            })
+            .collect();
+
+        if p.distinct {
+            deduplicate_rows(&mut rows);
         }
 
         Ok(QueryResult {
             columns: column_names,
             rows,
         })
+    }
+
+    /// Collect all rows for a leading MATCH in a pipeline without a bound WithClause.
+    ///
+    /// Unlike `collect_match_rows_for_with`, this performs a wide scan that includes
+    /// all stored column IDs for each label, and always injects NodeRef entries so
+    /// EXISTS subqueries and subsequent MATCH stages can resolve node references.
+    fn collect_pipeline_match_rows(
+        &self,
+        patterns: &[PathPattern],
+        where_clause: Option<&Expr>,
+    ) -> Result<Vec<HashMap<String, Value>>> {
+        if patterns.is_empty() {
+            return Ok(vec![HashMap::new()]);
+        }
+
+        // For simplicity handle single-node pattern (no relationship hops in leading MATCH).
+        let pat = &patterns[0];
+        let node = &pat.nodes[0];
+        let var_name = node.var.as_str();
+        let label = node.labels.first().cloned().unwrap_or_default();
+
+        let label_id = match self.catalog.get_label(&label)? {
+            Some(id) => id as u32,
+            None => return Ok(vec![]),
+        };
+        let hwm = self.store.hwm_for_label(label_id)?;
+        let col_ids: Vec<u32> = self.store.col_ids_for_label(label_id).unwrap_or_default();
+
+        let mut result: Vec<HashMap<String, Value>> = Vec::new();
+        for slot in 0..hwm {
+            let node_id = NodeId(((label_id as u64) << 32) | slot);
+            if self.is_node_tombstoned(node_id) {
+                continue;
+            }
+            let props = match self.store.get_node_raw(node_id, &col_ids) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+            if !self.matches_prop_filter(&props, &node.props) {
+                continue;
+            }
+            let mut row_vals = build_row_vals(&props, var_name, &col_ids, &self.store);
+            // Always inject NodeRef for EXISTS and next-stage MATCH.
+            row_vals.insert(var_name.to_string(), Value::NodeRef(node_id));
+            row_vals.insert(format!("{var_name}.__node_id__"), Value::NodeRef(node_id));
+
+            if let Some(wexpr) = where_clause {
+                let mut row_vals_p = row_vals.clone();
+                row_vals_p.extend(self.dollar_params());
+                if !self.eval_where_graph(wexpr, &row_vals_p) {
+                    continue;
+                }
+            }
+            result.push(row_vals);
+        }
+        Ok(result)
+    }
+
+    /// Execute a MATCH stage within a pipeline, given a set of variable bindings
+    /// from the preceding WITH stage.
+    ///
+    /// For each node pattern in `patterns`:
+    /// - Scan the label.
+    /// - Filter by inline prop filters, substituting any value that matches
+    ///   a variable name from `binding` (e.g. `{name: pname}` where `pname`
+    ///   is bound in the preceding WITH).
+    fn execute_pipeline_match_stage(
+        &self,
+        patterns: &[PathPattern],
+        where_clause: Option<&Expr>,
+        binding: &HashMap<String, Value>,
+    ) -> Result<Vec<HashMap<String, Value>>> {
+        if patterns.is_empty() {
+            return Ok(vec![binding.clone()]);
+        }
+
+        let pat = &patterns[0];
+
+        // Check if this is a relationship hop pattern.
+        if !pat.rels.is_empty() {
+            // Relationship traversal in a pipeline MATCH stage.
+            // Currently supports single-hop: (src)-[:REL]->(dst)
+            return self.execute_pipeline_match_hop(pat, where_clause, binding);
+        }
+
+        let node = &pat.nodes[0];
+        let var_name = node.var.as_str();
+        let label = node.labels.first().cloned().unwrap_or_default();
+
+        let label_id = match self.catalog.get_label(&label)? {
+            Some(id) => id as u32,
+            None => return Ok(vec![]),
+        };
+        let hwm = self.store.hwm_for_label(label_id)?;
+        let col_ids: Vec<u32> = self.store.col_ids_for_label(label_id).unwrap_or_default();
+
+        let mut result: Vec<HashMap<String, Value>> = Vec::new();
+        let params = self.dollar_params();
+        for slot in 0..hwm {
+            let node_id = NodeId(((label_id as u64) << 32) | slot);
+            if self.is_node_tombstoned(node_id) {
+                continue;
+            }
+            let props = match self.store.get_node_raw(node_id, &col_ids) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+
+            // Evaluate inline prop filters, resolving variable references from binding.
+            if !self.matches_prop_filter_with_binding(&props, &node.props, binding, &params) {
+                continue;
+            }
+
+            let mut row_vals = build_row_vals(&props, var_name, &col_ids, &self.store);
+            // Merge binding variables so upstream aliases remain in scope.
+            row_vals.extend(binding.clone());
+            row_vals.insert(var_name.to_string(), Value::NodeRef(node_id));
+            row_vals.insert(format!("{var_name}.__node_id__"), Value::NodeRef(node_id));
+
+            if let Some(wexpr) = where_clause {
+                let mut row_vals_p = row_vals.clone();
+                row_vals_p.extend(params.clone());
+                if !self.eval_where_graph(wexpr, &row_vals_p) {
+                    continue;
+                }
+            }
+            result.push(row_vals);
+        }
+        Ok(result)
+    }
+
+    /// Execute a single-hop relationship traversal in a pipeline MATCH stage.
+    ///
+    /// Handles `(src:Label {props})-[:REL]->(dst:Label {props})` where `src` or `dst`
+    /// variable names may already be bound in `binding`.
+    fn execute_pipeline_match_hop(
+        &self,
+        pat: &sparrowdb_cypher::ast::PathPattern,
+        where_clause: Option<&Expr>,
+        binding: &HashMap<String, Value>,
+    ) -> Result<Vec<HashMap<String, Value>>> {
+        if pat.nodes.len() < 2 || pat.rels.is_empty() {
+            return Ok(vec![]);
+        }
+        let src_pat = &pat.nodes[0];
+        let dst_pat = &pat.nodes[1];
+        let rel_pat = &pat.rels[0];
+
+        let src_label = src_pat.labels.first().cloned().unwrap_or_default();
+        let dst_label = dst_pat.labels.first().cloned().unwrap_or_default();
+
+        let src_label_id = match self.catalog.get_label(&src_label)? {
+            Some(id) => id as u32,
+            None => return Ok(vec![]),
+        };
+        let dst_label_id = match self.catalog.get_label(&dst_label)? {
+            Some(id) => id as u32,
+            None => return Ok(vec![]),
+        };
+
+        let src_col_ids: Vec<u32> = self
+            .store
+            .col_ids_for_label(src_label_id)
+            .unwrap_or_default();
+        let dst_col_ids: Vec<u32> = self
+            .store
+            .col_ids_for_label(dst_label_id)
+            .unwrap_or_default();
+        let params = self.dollar_params();
+
+        // Find candidate src nodes.
+        let src_candidates: Vec<NodeId> = {
+            // If the src var is already bound as a NodeRef, use that directly.
+            let bound_src = binding
+                .get(&src_pat.var)
+                .or_else(|| binding.get(&format!("{}.__node_id__", src_pat.var)));
+            if let Some(Value::NodeRef(nid)) = bound_src {
+                vec![*nid]
+            } else {
+                let hwm = self.store.hwm_for_label(src_label_id)?;
+                let mut cands = Vec::new();
+                for slot in 0..hwm {
+                    let node_id = NodeId(((src_label_id as u64) << 32) | slot);
+                    if self.is_node_tombstoned(node_id) {
+                        continue;
+                    }
+                    if let Ok(props) = self.store.get_node_raw(node_id, &src_col_ids) {
+                        if self.matches_prop_filter_with_binding(
+                            &props,
+                            &src_pat.props,
+                            binding,
+                            &params,
+                        ) {
+                            cands.push(node_id);
+                        }
+                    }
+                }
+                cands
+            }
+        };
+
+        let rel_table_id = self.resolve_rel_table_id(src_label_id, dst_label_id, &rel_pat.rel_type);
+
+        let mut result: Vec<HashMap<String, Value>> = Vec::new();
+        for src_id in src_candidates {
+            let src_slot = src_id.0 & 0xFFFF_FFFF;
+            let dst_slots: Vec<u64> = match &rel_table_id {
+                RelTableLookup::Found(rtid) => self.csr_neighbors(*rtid, src_slot),
+                RelTableLookup::NotFound => continue,
+                RelTableLookup::All => self.csr_neighbors_all(src_slot),
+            };
+            // Also check the delta.
+            let delta_slots: Vec<u64> = self
+                .read_delta_all()
+                .into_iter()
+                .filter(|r| {
+                    let r_src_label = (r.src.0 >> 32) as u32;
+                    let r_src_slot = r.src.0 & 0xFFFF_FFFF;
+                    r_src_label == src_label_id && r_src_slot == src_slot
+                })
+                .map(|r| r.dst.0 & 0xFFFF_FFFF)
+                .collect();
+            let all_slots: std::collections::HashSet<u64> =
+                dst_slots.into_iter().chain(delta_slots).collect();
+
+            for dst_slot in all_slots {
+                let dst_id = NodeId(((dst_label_id as u64) << 32) | dst_slot);
+                if self.is_node_tombstoned(dst_id) {
+                    continue;
+                }
+                if let Ok(dst_props) = self.store.get_node_raw(dst_id, &dst_col_ids) {
+                    if !self.matches_prop_filter_with_binding(
+                        &dst_props,
+                        &dst_pat.props,
+                        binding,
+                        &params,
+                    ) {
+                        continue;
+                    }
+                    let src_props = self
+                        .store
+                        .get_node_raw(src_id, &src_col_ids)
+                        .unwrap_or_default();
+                    let mut row_vals =
+                        build_row_vals(&src_props, &src_pat.var, &src_col_ids, &self.store);
+                    row_vals.extend(build_row_vals(
+                        &dst_props,
+                        &dst_pat.var,
+                        &dst_col_ids,
+                        &self.store,
+                    ));
+                    // Merge upstream bindings.
+                    row_vals.extend(binding.clone());
+                    row_vals.insert(src_pat.var.clone(), Value::NodeRef(src_id));
+                    row_vals.insert(
+                        format!("{}.__node_id__", src_pat.var),
+                        Value::NodeRef(src_id),
+                    );
+                    row_vals.insert(dst_pat.var.clone(), Value::NodeRef(dst_id));
+                    row_vals.insert(
+                        format!("{}.__node_id__", dst_pat.var),
+                        Value::NodeRef(dst_id),
+                    );
+
+                    if let Some(wexpr) = where_clause {
+                        let mut row_vals_p = row_vals.clone();
+                        row_vals_p.extend(params.clone());
+                        if !self.eval_where_graph(wexpr, &row_vals_p) {
+                            continue;
+                        }
+                    }
+                    result.push(row_vals);
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    /// Filter a node's props against a set of PropEntry filters, resolving variable
+    /// references from `binding` before comparing.
+    ///
+    /// For example, `{name: pname}` where `pname` is a variable in `binding` will
+    /// look up `binding["pname"]` and use it as the expected value.
+    fn matches_prop_filter_with_binding(
+        &self,
+        props: &[(u32, u64)],
+        filters: &[sparrowdb_cypher::ast::PropEntry],
+        binding: &HashMap<String, Value>,
+        params: &HashMap<String, Value>,
+    ) -> bool {
+        for f in filters {
+            let col_id = prop_name_to_col_id(&f.key);
+            let stored_raw = props.iter().find(|(c, _)| *c == col_id).map(|(_, v)| *v);
+
+            // Evaluate the filter expression, first substituting from binding.
+            let filter_val = match &f.value {
+                sparrowdb_cypher::ast::Expr::Var(v) => {
+                    // Variable reference — look up in binding.
+                    binding.get(v).cloned().unwrap_or(Value::Null)
+                }
+                other => eval_expr(other, params),
+            };
+
+            let stored_val = stored_raw.map(|raw| decode_raw_val(raw, &self.store));
+            let matches = match (stored_val, &filter_val) {
+                (Some(Value::String(a)), Value::String(b)) => &a == b,
+                (Some(Value::Int64(a)), Value::Int64(b)) => a == *b,
+                (Some(Value::Bool(a)), Value::Bool(b)) => a == *b,
+                (Some(Value::Float64(a)), Value::Float64(b)) => a == *b,
+                (None, Value::Null) => true,
+                _ => false,
+            };
+            if !matches {
+                return false;
+            }
+        }
+        true
     }
 
     /// Scan a MATCH pattern and return one `HashMap<String, Value>` per matching row.
@@ -1231,7 +2005,11 @@ impl Engine {
                 if !self.matches_prop_filter(&props, &node.props) {
                     continue;
                 }
-                let row_vals = build_row_vals(&props, var_name, &all_col_ids, &self.store);
+                let mut row_vals = build_row_vals(&props, var_name, &all_col_ids, &self.store);
+                // SPA-134: inject NodeRef so eval_exists_subquery can resolve the
+                // source node ID when EXISTS { } appears in MATCH WHERE or WITH WHERE.
+                row_vals.insert(var_name.to_string(), Value::NodeRef(node_id));
+                row_vals.insert(format!("{var_name}.__node_id__"), Value::NodeRef(node_id));
                 if let Some(wexpr) = &where_clause {
                     let mut row_vals_p = row_vals.clone();
                     row_vals_p.extend(self.dollar_params());
@@ -3581,6 +4359,28 @@ impl Engine {
                 Value::Bool(b) => Value::Bool(!b),
                 _ => Value::Null,
             },
+            // SPA-134: PropAccess where the variable resolves to a NodeRef (e.g. `WITH n AS person
+            // RETURN person.name`).  Fetch the property from the node store directly.
+            Expr::PropAccess { var, prop } => {
+                // Try normal key first (col_N or direct "var.prop" entry).
+                let normal = eval_expr(expr, vals);
+                if !matches!(normal, Value::Null) {
+                    return normal;
+                }
+                // Fallback: if the variable is a NodeRef, read the property from the store.
+                if let Some(Value::NodeRef(node_id)) = vals
+                    .get(var.as_str())
+                    .or_else(|| vals.get(&format!("{var}.__node_id__")))
+                {
+                    let col_id = prop_name_to_col_id(prop);
+                    if let Ok(props) = self.store.get_node_raw(*node_id, &[col_id]) {
+                        if let Some(&(_, raw)) = props.iter().find(|(c, _)| *c == col_id) {
+                            return decode_raw_val(raw, &self.store);
+                        }
+                    }
+                }
+                Value::Null
+            }
             _ => eval_expr(expr, vals),
         }
     }
@@ -4619,6 +5419,51 @@ fn eval_expr(expr: &Expr, vals: &HashMap<String, Value>) -> Value {
                 },
                 BinOpKind::Or => match (&lv, &rv) {
                     (Value::Bool(a), Value::Bool(b)) => Value::Bool(*a || *b),
+                    _ => Value::Null,
+                },
+                BinOpKind::Add => match (&lv, &rv) {
+                    (Value::Int64(a), Value::Int64(b)) => Value::Int64(a + b),
+                    (Value::Float64(a), Value::Float64(b)) => Value::Float64(a + b),
+                    (Value::Int64(a), Value::Float64(b)) => Value::Float64(*a as f64 + b),
+                    (Value::Float64(a), Value::Int64(b)) => Value::Float64(a + *b as f64),
+                    (Value::String(a), Value::String(b)) => Value::String(format!("{a}{b}")),
+                    _ => Value::Null,
+                },
+                BinOpKind::Sub => match (&lv, &rv) {
+                    (Value::Int64(a), Value::Int64(b)) => Value::Int64(a - b),
+                    (Value::Float64(a), Value::Float64(b)) => Value::Float64(a - b),
+                    (Value::Int64(a), Value::Float64(b)) => Value::Float64(*a as f64 - b),
+                    (Value::Float64(a), Value::Int64(b)) => Value::Float64(a - *b as f64),
+                    _ => Value::Null,
+                },
+                BinOpKind::Mul => match (&lv, &rv) {
+                    (Value::Int64(a), Value::Int64(b)) => Value::Int64(a * b),
+                    (Value::Float64(a), Value::Float64(b)) => Value::Float64(a * b),
+                    (Value::Int64(a), Value::Float64(b)) => Value::Float64(*a as f64 * b),
+                    (Value::Float64(a), Value::Int64(b)) => Value::Float64(a * *b as f64),
+                    _ => Value::Null,
+                },
+                BinOpKind::Div => match (&lv, &rv) {
+                    (Value::Int64(a), Value::Int64(b)) => {
+                        if *b == 0 {
+                            Value::Null
+                        } else {
+                            Value::Int64(a / b)
+                        }
+                    }
+                    (Value::Float64(a), Value::Float64(b)) => Value::Float64(a / b),
+                    (Value::Int64(a), Value::Float64(b)) => Value::Float64(*a as f64 / b),
+                    (Value::Float64(a), Value::Int64(b)) => Value::Float64(a / *b as f64),
+                    _ => Value::Null,
+                },
+                BinOpKind::Mod => match (&lv, &rv) {
+                    (Value::Int64(a), Value::Int64(b)) => {
+                        if *b == 0 {
+                            Value::Null
+                        } else {
+                            Value::Int64(a % b)
+                        }
+                    }
                     _ => Value::Null,
                 },
             }

--- a/crates/sparrowdb/tests/spa_134_multi_clause.rs
+++ b/crates/sparrowdb/tests/spa_134_multi_clause.rs
@@ -58,10 +58,6 @@ fn seed_social_graph(db: &sparrowdb::GraphDb) {
 // Tracked by: SPA-134 (this ticket) — implement multi-stage MATCH … WITH … MATCH.
 
 #[test]
-#[ignore = "SPA-134: second MATCH after WITH is not parsed; \
-            parse_with_pipeline calls expect_tok(Return) so any non-RETURN token \
-            (including MATCH) triggers a parse error; \
-            a new AST node and parser branch are needed"]
 fn spa134_match_with_match_return() {
     let (_dir, db) = make_db();
     seed_social_graph(&db);
@@ -145,10 +141,6 @@ fn spa134_match_with_where_return() {
 // Tracked by: SPA-134 (this ticket) — aggregate functions in WITH clause.
 
 #[test]
-#[ignore = "SPA-134: COUNT(*) in WITH is not aggregated; \
-            execute_match_with iterates rows and calls eval_expr per row — \
-            eval_expr(CountStar, row) returns Value::Null, not the aggregate count; \
-            aggregation in the WITH stage is not yet implemented"]
 fn spa134_match_with_count_where_filter() {
     let (_dir, db) = make_db();
     seed_social_graph(&db);
@@ -218,9 +210,6 @@ fn spa134_match_with_count_where_filter_blocks_row() {
 // Tracked by: SPA-134 (this ticket) — ORDER BY in WITH pipeline + multi-stage MATCH.
 
 #[test]
-#[ignore = "SPA-134: second MATCH after WITH is not parsed (same as Test 1); \
-            additionally ORDER BY inside MatchWithStatement is parsed but not \
-            applied by execute_match_with — the order_by field is silently ignored"]
 fn spa134_match_with_order_limit_match_return() {
     let (_dir, db) = make_db();
     seed_social_graph(&db);
@@ -257,9 +246,6 @@ fn spa134_match_with_order_limit_match_return() {
 // Tracked by: SPA-134 (this ticket) — add WITH support after UNWIND.
 
 #[test]
-#[ignore = "SPA-134: WITH after UNWIND is not parsed; \
-            parse_unwind calls expect_tok(Return) immediately after AS <alias>; \
-            UnwindStatement only supports RETURN as the continuation clause"]
 fn spa134_unwind_with_transform_return() {
     let (_dir, db) = make_db();
 
@@ -286,10 +272,6 @@ fn spa134_unwind_with_transform_return() {
 // Tracked by: SPA-134 (this ticket) — UNWIND as continuation after WITH.
 
 #[test]
-#[ignore = "SPA-134: UNWIND after WITH is not parsed; \
-            parse_with_pipeline calls expect_tok(Return) so any other token \
-            (including UNWIND) triggers a parse error; \
-            additionally collect() in WITH requires aggregate-aware execution"]
 fn spa134_match_with_collect_unwind_return() {
     let (_dir, db) = make_db();
     seed_social_graph(&db);
@@ -338,9 +320,6 @@ fn spa134_match_with_collect_unwind_return() {
 // Tracked by: SPA-134 (this ticket) — full multi-stage pipeline execution.
 
 #[test]
-#[ignore = "SPA-134: three-stage MATCH … WITH … MATCH … WITH … RETURN is not supported; \
-            would require a new Statement variant (e.g. Pipeline) or recursive \
-            clause composition in the AST and execution engine"]
 fn spa134_three_stage_match_with_pipeline() {
     let (_dir, db) = make_db();
     seed_social_graph(&db);
@@ -385,10 +364,6 @@ fn spa134_three_stage_match_with_pipeline() {
 // Tracked by: SPA-134 (this ticket) — inject NodeRef into WITH-pipeline row_vals.
 
 #[test]
-#[ignore = "SPA-134: EXISTS in MATCH WHERE before WITH produces 0 rows; \
-            collect_match_rows_for_with uses build_row_vals which does not inject \
-            a NodeRef into the row map; eval_exists_subquery cannot resolve the \
-            source node ID and always returns false"]
 fn spa134_exists_subquery_with_clause_return() {
     let (_dir, db) = make_db();
     seed_social_graph(&db);
@@ -431,12 +406,6 @@ fn spa134_exists_subquery_with_clause_return() {
 /// the NodeRef is not available in the projected with_vals map, so the
 /// EXISTS predicate cannot resolve the source node and returns false.
 #[test]
-#[ignore = "SPA-134: EXISTS in the WITH WHERE clause is also unsupported; \
-            the projected with_vals map (built by execute_match_with step 2) \
-            does not carry a NodeRef entry for the variable, \
-            so eval_exists_subquery always returns false; \
-            additionally WITH n AS person is the correct syntax — \
-            WITH n WHERE ... (without AS) is a parse error"]
 fn spa134_exists_subquery_where_in_with_clause() {
     let (_dir, db) = make_db();
     seed_social_graph(&db);
@@ -477,10 +446,6 @@ fn spa134_exists_subquery_where_in_with_clause() {
 /// execution engine (execute_match_with does not use m.order_by or apply sorting).
 /// Marked ignored because the ORDER BY result is non-deterministic.
 #[test]
-#[ignore = "SPA-134: ORDER BY in execute_match_with is parsed into m.order_by \
-            but the field is never consumed — execute_match_with applies \
-            m.skip/m.limit but not m.order_by; \
-            result row ordering is non-deterministic (insertion order)"]
 fn spa134_match_with_order_by_limit_return() {
     let (_dir, db) = make_db();
     seed_social_graph(&db);
@@ -545,9 +510,6 @@ fn spa134_match_with_where_empty_result() {
 /// CountStar. This test documents the current (incorrect) behaviour: 3 rows of
 /// Null are returned rather than 1 row of Int64(3).
 #[test]
-#[ignore = "SPA-134: COUNT(*) in WITH is not aggregated; \
-            eval_expr(CountStar, row) returns Value::Null per row; \
-            the engine returns 3 rows of Null instead of 1 row of Int64(3)"]
 fn spa134_match_with_count_no_filter_return() {
     let (_dir, db) = make_db();
     seed_social_graph(&db);


### PR DESCRIPTION
## **User description**
## Summary

- Parser now handles `WITH...MATCH`, `WITH...UNWIND`, `ORDER BY...LIMIT...MATCH` pipelines and three-stage `MATCH...WITH...MATCH...WITH...RETURN` chains
- EXISTS subquery in MATCH WHERE and WITH WHERE clauses now correctly resolves source nodes via NodeRef injection
- COUNT(\*) and `collect()` aggregation in WITH clause (previously returned Null per row, now returns correct aggregate)
- Arithmetic operators (`+`, `-`, `*`, `/`, `%`) added to parser and expression evaluator
- ORDER BY in WITH clause correctly applies to pre-projection rows (supports `ORDER BY n.age` after `WITH n.name AS name`)
- All 13 tests in `spa_134_multi_clause.rs` pass; 0 ignored

## Test plan

- [x] `spa134_match_with_match_return` — MATCH...WITH...MATCH...RETURN
- [x] `spa134_match_with_count_where_filter` — COUNT(*) in WITH with WHERE filter
- [x] `spa134_match_with_order_limit_match_return` — WITH ORDER BY LIMIT MATCH RETURN
- [x] `spa134_unwind_with_transform_return` — UNWIND...WITH x*2 AS y RETURN y
- [x] `spa134_match_with_collect_unwind_return` — collect() → UNWIND fanout
- [x] `spa134_three_stage_match_with_pipeline` — 3-stage pipeline
- [x] `spa134_exists_subquery_with_clause_return` — EXISTS in MATCH WHERE before WITH
- [x] `spa134_exists_subquery_where_in_with_clause` — EXISTS in WITH WHERE + NodeRef prop access
- [x] `spa134_match_with_order_by_limit_return` — ORDER BY + LIMIT in RETURN after WITH
- [x] `spa134_match_with_count_no_filter_return` — COUNT(*) in WITH without WHERE
- [x] Full test suite passes (pre-existing `undirected_returns_both_directions` failure not introduced by this PR)

Closes SPA-134

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Support multi-stage Cypher pipelines, arithmetic, and aggregate WITH clauses**

### What Changed
- Queries can now continue after `WITH` or `UNWIND` with another `MATCH`, `WITH`, or `UNWIND`, ending in a final `RETURN`
- `WITH` clauses now handle sorting, skipping, and limiting at the right stage, including cases where `ORDER BY` uses fields not returned
- `WITH` now returns correct results for aggregates like `count(*)` and `collect()`, instead of one null row per input row
- Arithmetic expressions using `+`, `-`, `*`, `/`, and `%` are now accepted in queries
- `EXISTS { ... }` works in `MATCH WHERE` and `WITH WHERE`, and aliases created with `WITH n AS person` can keep using node properties in later clauses

### Impact
`✅ Longer MATCH/WITH query chains`
`✅ Correct counts and collected lists in WITH`
`✅ Clearer results from filtered and sorted pipeline queries`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
