### PR TITLE
feat(python): context manager + GIL release (SPA-103, SPA-256)

### DIFF
--- a/crates/sparrowdb-python/src/lib.rs
+++ b/crates/sparrowdb-python/src/lib.rs
@@ -52,11 +52,13 @@ fn value_to_py(py: Python<'_>, v: &sparrowdb_execution::Value) -> PyObject {
 
 /// Python wrapper around the top-level SparrowDB handle.
 ///
+/// Supports the context manager protocol (SPA-103):
+///
 /// ```python
 /// import sparrowdb, tempfile, os
 /// with tempfile.TemporaryDirectory() as d:
-///     db = sparrowdb.GraphDb(os.path.join(d, "test.db"))
-///     db.checkpoint()
+///     with sparrowdb.GraphDb(os.path.join(d, "test.db")) as db:
+///         db.checkpoint()
 /// ```
 #[cfg(feature = "python")]
 #[pyclass(name = "GraphDb")]
@@ -75,17 +77,46 @@ impl PyGraphDb {
         Ok(PyGraphDb { inner: db })
     }
 
+    // ── Context manager protocol (SPA-103) ────────────────────────────────────
+
+    /// Support ``with sparrowdb.GraphDb(path) as db:`` syntax.
+    ///
+    /// Returns ``self`` — SparrowDB cleans up via Rust's ``Drop`` trait, so no
+    /// extra work is needed here.
+    fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    /// Exit the context manager.
+    ///
+    /// SparrowDB cleans up via Rust's ``Drop`` trait; this method simply
+    /// returns ``False`` so that any Python exception propagates normally.
+    #[pyo3(signature = (_exc_type=None, _exc_val=None, _exc_tb=None))]
+    fn __exit__(
+        &self,
+        _exc_type: Option<&Bound<'_, PyAny>>,
+        _exc_val: Option<&Bound<'_, PyAny>>,
+        _exc_tb: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<bool> {
+        Ok(false) // do not suppress exceptions
+    }
+
+    // ── I/O methods — release the GIL (SPA-256) ──────────────────────────────
+
     /// Run a WAL checkpoint — folds the delta log into the CSR base files.
-    fn checkpoint(&self) -> PyResult<()> {
-        self.inner
-            .checkpoint()
+    ///
+    /// Releases the GIL while the checkpoint I/O runs so other Python threads
+    /// can make progress concurrently (SPA-256).
+    fn checkpoint(&self, py: Python<'_>) -> PyResult<()> {
+        py.allow_threads(|| self.inner.checkpoint())
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
     }
 
     /// Run an OPTIMIZE — like checkpoint but also sorts neighbour lists.
-    fn optimize(&self) -> PyResult<()> {
-        self.inner
-            .optimize()
+    ///
+    /// Releases the GIL while the optimise I/O runs (SPA-256).
+    fn optimize(&self, py: Python<'_>) -> PyResult<()> {
+        py.allow_threads(|| self.inner.optimize())
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
     }
 
@@ -113,20 +144,24 @@ impl PyGraphDb {
         Ok(PyWriteTx { inner: Some(tx) })
     }
 
-    /// Execute a read-only Cypher query and return a list of row-dicts.
+    /// Execute a Cypher query and return a list of row-dicts.
     ///
     /// Each row is a ``dict`` mapping column name → value.  Supported value
     /// types: ``None``, ``int``, ``float``, ``bool``, ``str``.
     /// ``NodeRef`` and ``EdgeRef`` are returned as ``int`` (their packed id).
+    ///
+    /// The GIL is released while the query executes so multiple Python threads
+    /// can issue queries concurrently (SPA-256).
     ///
     /// Example::
     ///
     ///     results = db.execute("MATCH (n) RETURN n.name LIMIT 10")
     ///     # [{"n.name": "Alice"}, ...]
     fn execute(&self, py: Python<'_>, cypher: &str) -> PyResult<PyObject> {
-        let result = self
-            .inner
-            .execute(cypher)
+        // SPA-256: release the GIL during the blocking storage scan so that
+        // other Python threads (e.g. a thread pool) can run concurrently.
+        let result = py
+            .allow_threads(|| self.inner.execute(cypher))
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
         let list = PyList::empty_bound(py);

--- a/tests/python/test_sparrowdb_e2e.py
+++ b/tests/python/test_sparrowdb_e2e.py
@@ -154,3 +154,58 @@ def test_column_names_present_in_result():
         row = rows[0]
         assert "n.x" in row, f"Expected key 'n.x' in row dict, got keys: {list(row.keys())}"
         assert row["n.x"] == 42
+
+
+# ── SPA-103: Context manager ──────────────────────────────────────────────────
+
+
+def test_context_manager(tmp_path):
+    """``with sparrowdb.GraphDb(path) as db:`` syntax works end-to-end."""
+    GraphDb = _db()
+    with GraphDb(str(tmp_path / "cm.db")) as db:
+        db.execute("CREATE (n:Test {val: 1})")
+        rows = db.execute("MATCH (n:Test) RETURN n.val")
+    # rows captured inside the with-block must contain the written value.
+    assert len(rows) == 1, f"Expected 1 row, got {len(rows)}"
+    assert rows[0]["n.val"] == 1, f"Expected n.val=1, got {rows[0]}"
+
+
+def test_context_manager_exception_propagates(tmp_path):
+    """Exceptions raised inside the ``with`` block are not suppressed."""
+    GraphDb = _db()
+    with pytest.raises(ValueError, match="intentional"):
+        with GraphDb(str(tmp_path / "exc.db")) as db:
+            db.execute("CREATE (n:Canary {x: 1})")
+            raise ValueError("intentional")
+
+
+# ── SPA-256: GIL release during execute() ─────────────────────────────────────
+
+
+def test_concurrent_execute_releases_gil(tmp_path):
+    """execute() releases the GIL so multiple threads can query concurrently."""
+    import threading
+
+    GraphDb = _db()
+    db = GraphDb(str(tmp_path / "concurrent.db"))
+    db.execute("CREATE (n:Counter {v: 0})")
+
+    results = []
+    errors = []
+
+    def query():
+        try:
+            rows = db.execute("MATCH (n:Counter) RETURN n.v")
+            results.append(rows[0]["n.v"])
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=query) for _ in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"Thread(s) raised errors: {errors}"
+    assert len(results) == 5, f"Expected 5 results, got {len(results)}"
+    assert all(v == 0 for v in results), f"Unexpected values: {results}"


### PR DESCRIPTION
## **User description**
## Summary

- **SPA-103**: `with sparrowdb.GraphDb(path) as db:` context manager via `__enter__`/`__exit__`. Drop semantics remain — Rust handles cleanup; `__exit__` returns `False` so exceptions propagate normally.
- **SPA-256**: `execute()`, `checkpoint()`, and `optimize()` now call `py.allow_threads(|| ...)` to release the GIL during blocking storage I/O. `GraphDb` wraps `Arc<DbInner>` and is `Send`, so no extra locking is needed.

## Changes

- `crates/sparrowdb-python/src/lib.rs`: added `__enter__`/`__exit__` with `#[pyo3(signature = ...)]` to silence pyo3 deprecation; wrapped all three I/O methods with `py.allow_threads()`; added `py: Python<'_>` parameter to `checkpoint()` and `optimize()`.
- `tests/python/test_sparrowdb_e2e.py`: three new tests — `test_context_manager`, `test_context_manager_exception_propagates`, `test_concurrent_execute_releases_gil`.

## Test plan

- [ ] `maturin develop && python -m pytest tests/python/test_sparrowdb_e2e.py -v -k "context_manager or concurrent"` — all three new tests pass
- [ ] Full e2e suite `python -m pytest tests/python/ -v` remains green
- [ ] `cargo build -p sparrowdb-python --features python` compiles with no errors and no deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add Python context manager support and let queries run without blocking other Python threads**

### What Changed
- `GraphDb` can now be used with `with ... as db:` and exits cleanly without swallowing exceptions.
- Query, checkpoint, and optimize calls now release the Python lock while storage work runs, so other Python threads can keep making progress.
- Added end-to-end tests for context manager use, exception propagation, and concurrent queries.

### Impact
`✅ Cleaner database cleanup in with-blocks`
`✅ Fewer blocked Python threads during database I/O`
`✅ Clearer exception handling in Python database code`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
