### PR TITLE
feat(cypher): coalesce(expr, ...) function (SPA-240)

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -5022,7 +5022,49 @@ fn needs_node_ref_in_return(items: &[ReturnItem]) -> bool {
         matches!(&item.expr, Expr::FnCall { name, .. } if name.to_lowercase() == "id")
             || matches!(&item.expr, Expr::Var(_))
             || expr_needs_graph(&item.expr)
+            || expr_needs_eval_path(&item.expr)
     })
+}
+
+/// Returns `true` when the expression contains a scalar `FnCall` that cannot
+/// be resolved by the fast `project_row` column-name lookup.
+///
+/// `project_row` maps column names like `"n.name"` directly to stored property
+/// values.  Any function call such as `coalesce(n.missing, n.name)`,
+/// `toUpper(n.name)`, or `size(n.name)` produces a column name like
+/// `"coalesce(n.missing, n.name)"` which has no matching stored property.
+/// Those expressions must be evaluated via `eval_expr` on the full row map.
+///
+/// Aggregate functions (`count`, `sum`, etc.) are already handled via the
+/// `use_agg` flag; we exclude them here to avoid double-counting.
+fn expr_needs_eval_path(expr: &Expr) -> bool {
+    match expr {
+        Expr::FnCall { name, args } => {
+            let name_lc = name.to_lowercase();
+            // Aggregates are handled separately by use_agg.
+            if matches!(
+                name_lc.as_str(),
+                "count" | "sum" | "avg" | "min" | "max" | "collect"
+            ) {
+                return false;
+            }
+            // Any other FnCall (coalesce, toUpper, size, labels, type, id, etc.)
+            // needs the eval path.  We include id/labels/type here even though
+            // they are special-cased in eval_expr, because the fast project_row
+            // path cannot handle them at all.
+            let _ = args; // args not needed for this check
+            true
+        }
+        // Recurse into compound expressions that may contain FnCalls.
+        Expr::BinOp { left, right, .. } => {
+            expr_needs_eval_path(left) || expr_needs_eval_path(right)
+        }
+        Expr::And(l, r) | Expr::Or(l, r) => expr_needs_eval_path(l) || expr_needs_eval_path(r),
+        Expr::Not(inner) | Expr::IsNull(inner) | Expr::IsNotNull(inner) => {
+            expr_needs_eval_path(inner)
+        }
+        _ => false,
+    }
 }
 
 /// Collect the variable names that appear as bare `Expr::Var` in a RETURN clause (SPA-213).

--- a/crates/sparrowdb/tests/spa_240_coalesce.rs
+++ b/crates/sparrowdb/tests/spa_240_coalesce.rs
@@ -1,0 +1,121 @@
+//! End-to-end tests for SPA-240: `coalesce(expr1, expr2, ...)`.
+//!
+//! `coalesce()` returns the first non-null value among its arguments.
+//! Used heavily in LangChain schema queries and general Cypher applications.
+
+use sparrowdb::open;
+use sparrowdb_execution::types::Value;
+
+fn make_db() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+/// `coalesce(null_prop, non_null_prop, fallback)` returns the first non-null.
+#[test]
+fn coalesce_returns_first_non_null() {
+    let (_dir, db) = make_db();
+    db.execute("CREATE (n:Person {name: 'Alice'})").unwrap();
+
+    let r = db
+        .execute("MATCH (n:Person) RETURN coalesce(n.missing, n.name, 'default')")
+        .expect("coalesce query must succeed");
+
+    assert_eq!(r.rows.len(), 1, "expected one row");
+    assert_eq!(
+        r.rows[0][0],
+        Value::String("Alice".into()),
+        "coalesce should skip the missing property and return n.name"
+    );
+}
+
+/// When all arguments are null, `coalesce()` returns null.
+#[test]
+fn coalesce_returns_null_when_all_null() {
+    let (_dir, db) = make_db();
+    db.execute("CREATE (n:Person {name: 'Alice'})").unwrap();
+
+    let r = db
+        .execute("MATCH (n:Person) RETURN coalesce(n.missing, n.also_missing)")
+        .expect("coalesce with all-null args must succeed");
+
+    assert_eq!(r.rows.len(), 1, "expected one row");
+    assert_eq!(
+        r.rows[0][0],
+        Value::Null,
+        "coalesce should return null when all arguments are null"
+    );
+}
+
+/// `coalesce(null_prop, second_prop)` returns the second property when the first is missing.
+#[test]
+fn coalesce_with_two_props_returns_second() {
+    let (_dir, db) = make_db();
+    db.execute("CREATE (n:Person {id: 'alice-123'})").unwrap();
+
+    let r = db
+        .execute("MATCH (n:Person) RETURN coalesce(n.name, n.id)")
+        .expect("coalesce(n.name, n.id) must succeed");
+
+    assert_eq!(r.rows.len(), 1, "expected one row");
+    assert_eq!(
+        r.rows[0][0],
+        Value::String("alice-123".into()),
+        "coalesce should fall through to n.id when n.name is missing"
+    );
+}
+
+/// `coalesce()` with a literal string fallback returns that literal.
+#[test]
+fn coalesce_literal_fallback() {
+    let (_dir, db) = make_db();
+    db.execute("CREATE (n:Person {name: 'Bob'})").unwrap();
+
+    let r = db
+        .execute("MATCH (n:Person) RETURN coalesce(n.nickname, 'no-nickname')")
+        .expect("coalesce with literal fallback must succeed");
+
+    assert_eq!(r.rows.len(), 1, "expected one row");
+    assert_eq!(
+        r.rows[0][0],
+        Value::String("no-nickname".into()),
+        "coalesce should return the literal fallback when the property is missing"
+    );
+}
+
+/// `coalesce()` with a present first argument short-circuits immediately.
+#[test]
+fn coalesce_short_circuits_on_first_non_null() {
+    let (_dir, db) = make_db();
+    db.execute("CREATE (n:Person {name: 'Carol', nickname: 'Caz'})")
+        .unwrap();
+
+    let r = db
+        .execute("MATCH (n:Person) RETURN coalesce(n.name, n.nickname, 'fallback')")
+        .expect("coalesce short-circuit must succeed");
+
+    assert_eq!(r.rows.len(), 1, "expected one row");
+    assert_eq!(
+        r.rows[0][0],
+        Value::String("Carol".into()),
+        "coalesce should return the first non-null value without evaluating further args"
+    );
+}
+
+/// `RETURN coalesce(...)` works without a MATCH clause (scalar context).
+#[test]
+fn coalesce_scalar_return() {
+    let (_dir, db) = make_db();
+
+    let r = db
+        .execute("RETURN coalesce(null, 42)")
+        .expect("RETURN coalesce(null, 42) must succeed");
+
+    assert_eq!(r.rows.len(), 1, "expected one row");
+    assert_eq!(
+        r.rows[0][0],
+        Value::Int64(42),
+        "coalesce should return 42 when first arg is null"
+    );
+}


### PR DESCRIPTION
## **User description**
## Summary
- `coalesce(expr1, expr2, ...)` returns the first non-null value among its arguments
- The function implementation in `functions.rs` was already present but silently broken in MATCH context
- Root cause: the fast `project_row` path cannot evaluate `FnCall` expressions — it only maps column names like `"n.name"` to stored property values, so `coalesce(n.missing, n.name)` was being looked up as a property name and returning `Null`
- Fix: added `expr_needs_eval_path()` predicate in `engine.rs` that detects any scalar `FnCall` in RETURN items and forces the full `eval_expr` path via `needs_node_ref_in_return()`
- 6 E2E tests cover: first-non-null, all-null, two-prop fallback, literal fallback, short-circuit, and scalar RETURN context

## Side Effect
This fix also corrects other scalar functions (e.g. `toUpper(n.name)`, `size(n.name)`) used in RETURN after MATCH — they had the same silent `Null` bug.

## Test plan
- [x] `cargo test -p sparrowdb --test spa_240_coalesce` — all 6 tests pass
- [x] `cargo test -p sparrowdb` — full suite passes (no regressions)

Closes SPA-240

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make `coalesce()` work in `MATCH` results and scalar queries**

### What Changed
- `coalesce()` now returns the first non-null value correctly when used after `MATCH`, instead of coming back empty or null
- The same fix also applies to other scalar functions in result lists, such as string casing and size checks
- Added end-to-end coverage for first non-null fallback, all-null results, literal fallback, short-circuit behavior, and scalar `RETURN` queries

### Impact
`✅ Correct fallback values in query results`
`✅ Fewer null results from scalar functions after MATCH`
`✅ Safer query behavior for Cypher apps and schema lookups`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
