### PR TITLE
feat(engine): execute_with_timeout() for query deadline enforcement (SPA-254)

### DIFF
--- a/crates/sparrowdb-common/src/lib.rs
+++ b/crates/sparrowdb-common/src/lib.rs
@@ -49,6 +49,11 @@ pub enum Error {
     NodeHasEdges {
         node_id: u64,
     },
+    /// The per-query deadline was exceeded before the query could complete.
+    ///
+    /// Returned by [`GraphDb::execute_with_timeout`] when the supplied
+    /// [`std::time::Duration`] expires during scan or traversal.
+    QueryTimeout,
 }
 
 impl std::fmt::Display for Error {
@@ -78,6 +83,7 @@ impl std::fmt::Display for Error {
                 f,
                 "node {node_id} has attached edges and cannot be deleted without removing them first"
             ),
+            Error::QueryTimeout => write!(f, "query timeout: deadline exceeded"),
         }
     }
 }

--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -66,6 +66,13 @@ pub struct Engine {
     /// - CONTAINS: linear scan avoids per-slot property-decode overhead.
     /// - STARTS WITH: binary-search prefix range — O(log n + k).
     pub text_index: TextIndex,
+    /// Optional per-query deadline (SPA-254).
+    ///
+    /// When `Some`, the engine checks this deadline at the top of each hot
+    /// scan / traversal loop iteration.  If `Instant::now() >= deadline`,
+    /// `Error::QueryTimeout` is returned immediately.  `None` means no
+    /// deadline (backward-compatible default).
+    pub deadline: Option<std::time::Instant>,
 }
 
 impl Engine {
@@ -107,6 +114,7 @@ impl Engine {
             params: HashMap::new(),
             prop_index,
             text_index,
+            deadline: None,
         }
     }
 
@@ -133,6 +141,30 @@ impl Engine {
     pub fn with_params(mut self, params: HashMap<String, Value>) -> Self {
         self.params = params;
         self
+    }
+
+    /// Set a per-query deadline (SPA-254).
+    ///
+    /// The engine will return [`sparrowdb_common::Error::QueryTimeout`] if
+    /// `Instant::now() >= deadline` during any hot scan or traversal loop.
+    pub fn with_deadline(mut self, deadline: std::time::Instant) -> Self {
+        self.deadline = Some(deadline);
+        self
+    }
+
+    /// Check whether the per-query deadline has passed (SPA-254).
+    ///
+    /// Returns `Err(QueryTimeout)` if a deadline is set and has expired,
+    /// `Ok(())` otherwise.  Inline so the hot-path cost when `deadline` is
+    /// `None` compiles down to a single branch-not-taken.
+    #[inline]
+    fn check_deadline(&self) -> sparrowdb_common::Result<()> {
+        if let Some(dl) = self.deadline {
+            if std::time::Instant::now() >= dl {
+                return Err(sparrowdb_common::Error::QueryTimeout);
+            }
+        }
+        Ok(())
     }
 
     // ── Per-type CSR / delta helpers ─────────────────────────────────────────
@@ -868,6 +900,9 @@ impl Engine {
                 let mut pattern_rows: Vec<HashMap<String, NodeId>> = Vec::new();
 
                 for src_slot in 0..hwm_src {
+                    // SPA-254: check per-query deadline at every slot boundary.
+                    self.check_deadline()?;
+
                     let src_node = NodeId(((src_label_id as u64) << 32) | src_slot);
 
                     if self.is_node_tombstoned(src_node) {
@@ -1855,6 +1890,9 @@ impl Engine {
             };
 
         for slot in slot_iter {
+            // SPA-254: check per-query deadline at every slot boundary.
+            self.check_deadline()?;
+
             let node_id = NodeId(((label_id_u32 as u64) << 32) | slot);
             if slot < 1024 || slot % 10_000 == 0 {
                 tracing::trace!(slot = slot, node_id = node_id.0, "scan emit");
@@ -2045,6 +2083,9 @@ impl Engine {
             };
 
             for slot in 0..hwm {
+                // SPA-254: check per-query deadline at every slot boundary.
+                self.check_deadline()?;
+
                 let node_id = NodeId(((label_id_u32 as u64) << 32) | slot);
 
                 // Skip tombstoned nodes (SPA-164/SPA-216): use
@@ -2285,6 +2326,9 @@ impl Engine {
 
             // Scan source nodes for this label.
             for src_slot in 0..hwm_src {
+                // SPA-254: check per-query deadline at every slot boundary.
+                self.check_deadline()?;
+
                 let src_node = NodeId(((effective_src_label_id as u64) << 32) | src_slot);
                 let src_props = if !col_ids_src.is_empty() || !src_node_pat.props.is_empty() {
                     let all_needed: Vec<u32> = {
@@ -2912,6 +2956,9 @@ impl Engine {
 
         // Scan source nodes.
         for src_slot in 0..hwm_src {
+            // SPA-254: check per-query deadline at every slot boundary.
+            self.check_deadline()?;
+
             let src_node = NodeId(((src_label_id as u64) << 32) | src_slot);
             let src_needed: Vec<u32> = {
                 let mut v = vec![];
@@ -3143,6 +3190,9 @@ impl Engine {
         let mut rows: Vec<Vec<Value>> = Vec::new();
 
         for src_slot in 0..hwm_src {
+            // SPA-254: check per-query deadline at every slot boundary.
+            self.check_deadline()?;
+
             let src_node_id = NodeId(((src_label_id as u64) << 32) | src_slot);
 
             // Skip tombstoned nodes.
@@ -3414,6 +3464,9 @@ impl Engine {
             std::collections::HashSet::new();
 
         for src_slot in 0..hwm_src {
+            // SPA-254: check per-query deadline at every slot boundary.
+            self.check_deadline()?;
+
             let src_node = NodeId(((src_label_id as u64) << 32) | src_slot);
 
             // Fetch source props (for filter + projection).

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -478,6 +478,96 @@ impl GraphDb {
         }
     }
 
+    /// Execute a Cypher query with a per-query timeout (SPA-254).
+    ///
+    /// Identical to [`execute`](Self::execute) but sets a deadline of
+    /// `Instant::now() + timeout` before dispatching to the engine.  The
+    /// engine checks the deadline at the top of every hot scan / traversal
+    /// loop.  If the deadline passes before the query completes,
+    /// [`Error::QueryTimeout`] is returned.
+    ///
+    /// `execute_with_timeout` only supports read-only (`MATCH … RETURN`)
+    /// statements today; mutation statements are forwarded to the existing
+    /// write-transaction code path **without** a timeout (they typically
+    /// complete in O(1) writes and are not the source of runaway queries).
+    ///
+    /// # Example
+    /// ```no_run
+    /// use sparrowdb::GraphDb;
+    /// use std::time::Duration;
+    ///
+    /// let db = GraphDb::open(std::path::Path::new("/tmp/g.sparrow")).unwrap();
+    /// let result = db.execute_with_timeout(
+    ///     "MATCH (n:Person) RETURN n.name",
+    ///     Duration::from_secs(5),
+    /// );
+    /// match result {
+    ///     Ok(qr) => println!("{} rows", qr.rows.len()),
+    ///     Err(sparrowdb::Error::QueryTimeout) => eprintln!("query timed out"),
+    ///     Err(e) => eprintln!("error: {e}"),
+    /// }
+    /// ```
+    pub fn execute_with_timeout(
+        &self,
+        cypher: &str,
+        timeout: std::time::Duration,
+    ) -> Result<QueryResult> {
+        use sparrowdb_cypher::ast::Statement;
+        use sparrowdb_cypher::{bind, parse};
+
+        let stmt = parse(cypher)?;
+        let catalog_snap = Catalog::open(&self.inner.path)?;
+        let bound = bind(stmt, &catalog_snap)?;
+
+        // Delegate CHECKPOINT/OPTIMIZE immediately — no timeout needed.
+        match &bound.inner {
+            Statement::Checkpoint => {
+                self.checkpoint()?;
+                return Ok(QueryResult::empty(vec![]));
+            }
+            Statement::Optimize => {
+                self.optimize()?;
+                return Ok(QueryResult::empty(vec![]));
+            }
+            _ => {}
+        }
+
+        if Engine::is_mutation(&bound.inner) {
+            // Mutation statements go through the standard write-transaction
+            // path; they are not the source of runaway queries.
+            return match bound.inner {
+                Statement::Merge(ref m) => self.execute_merge(m),
+                Statement::MatchMutate(ref mm) => self.execute_match_mutate(mm),
+                Statement::MatchCreate(ref mc) => self.execute_match_create(mc),
+                Statement::Create(ref c) => self.execute_create_standalone(c),
+                _ => unreachable!(),
+            };
+        }
+
+        let _span = info_span!("sparrowdb.query_with_timeout").entered();
+        let deadline = std::time::Instant::now() + timeout;
+
+        let mut engine = {
+            let _open_span = info_span!("sparrowdb.open_engine").entered();
+            let csrs = open_csr_map(&self.inner.path);
+            Engine::new(
+                NodeStore::open(&self.inner.path)?,
+                catalog_snap,
+                csrs,
+                &self.inner.path,
+            )
+            .with_deadline(deadline)
+        };
+
+        let result = {
+            let _exec_span = info_span!("sparrowdb.execute").entered();
+            engine.execute_statement(bound.inner)?
+        };
+
+        tracing::debug!(rows = result.rows.len(), "query_with_timeout complete");
+        Ok(result)
+    }
+
     /// Internal: execute a standalone `CREATE (a)-[:R]->(b)` statement.
     ///
     /// Creates all declared nodes, then for each edge in the pattern looks up

--- a/crates/sparrowdb/tests/spa_254_query_timeout.rs
+++ b/crates/sparrowdb/tests/spa_254_query_timeout.rs
@@ -1,0 +1,101 @@
+//! SPA-254: per-query timeout via `GraphDb::execute_with_timeout`.
+//!
+//! Tests verify:
+//! 1. Normal queries complete successfully within a generous timeout.
+//! 2. A near-zero timeout (1 ns) either times out or completes without panic.
+//! 3. `Error::QueryTimeout` is correctly distinguished from other errors.
+
+use sparrowdb::GraphDb;
+use std::time::Duration;
+use tempfile::tempdir;
+
+#[test]
+fn execute_with_timeout_normal_query_completes() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    db.execute("CREATE (n:Node {v: 1})").unwrap();
+
+    // 5-second deadline is far more than enough for a single-node scan.
+    let r = db
+        .execute_with_timeout("MATCH (n:Node) RETURN n.v", Duration::from_secs(5))
+        .unwrap();
+    assert_eq!(r.rows.len(), 1);
+}
+
+#[test]
+fn execute_with_timeout_returns_correct_values() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    for i in 0..5i64 {
+        db.execute(&format!("CREATE (n:Item {{val: {}}})", i))
+            .unwrap();
+    }
+
+    let r = db
+        .execute_with_timeout("MATCH (n:Item) RETURN n.val", Duration::from_secs(10))
+        .unwrap();
+    assert_eq!(r.rows.len(), 5);
+}
+
+#[test]
+fn execute_with_timeout_very_short_does_not_panic() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    // Create enough nodes to give the scanner something to do.
+    for i in 0..200 {
+        db.execute(&format!("CREATE (n:Node {{v: {}}})", i))
+            .unwrap();
+    }
+
+    // 1ns timeout: may expire before or during the scan.
+    // Important: this must NOT panic — it should either succeed or return QueryTimeout.
+    let result = db.execute_with_timeout("MATCH (n:Node) RETURN n.v", Duration::from_nanos(1));
+    match result {
+        Ok(_) => {}                               // completed before deadline checked — fine
+        Err(sparrowdb::Error::QueryTimeout) => {} // timed out — expected
+        Err(e) => panic!("unexpected error: {e}"),
+    }
+}
+
+#[test]
+fn execute_with_timeout_zero_duration_does_not_panic() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    db.execute("CREATE (n:Node {v: 42})").unwrap();
+
+    // Zero duration: deadline is already in the past by the time we check.
+    let result = db.execute_with_timeout("MATCH (n:Node) RETURN n.v", Duration::ZERO);
+    match result {
+        Ok(_) => {}
+        Err(sparrowdb::Error::QueryTimeout) => {}
+        Err(e) => panic!("unexpected error: {e}"),
+    }
+}
+
+#[test]
+fn execute_with_timeout_query_timeout_error_display() {
+    // Verify that QueryTimeout has a meaningful Display string.
+    let msg = format!("{}", sparrowdb::Error::QueryTimeout);
+    assert!(!msg.is_empty(), "QueryTimeout Display must not be empty");
+    assert!(
+        msg.contains("timeout") || msg.contains("deadline"),
+        "QueryTimeout message should mention timeout or deadline, got: {msg}"
+    );
+}
+
+#[test]
+fn execute_with_timeout_create_statement_completes() {
+    // Mutation statements (CREATE) should not be affected by the timeout
+    // mechanism (they go through the standard write-transaction path).
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+
+    let result = db.execute_with_timeout(
+        "CREATE (n:Widget {name: 'sprocket'})",
+        Duration::from_secs(10),
+    );
+    assert!(
+        result.is_ok(),
+        "CREATE through execute_with_timeout should succeed"
+    );
+}


### PR DESCRIPTION
## **User description**
## Summary
- `GraphDb::execute_with_timeout(cypher, duration)` sets a per-query `Instant` deadline and passes it into the execution engine via the new `Engine::with_deadline()` builder
- `Engine::check_deadline()` is called at every slot boundary in all hot scan/traversal loops: `execute_scan`, `execute_scan_all_labels`, `execute_one_hop`, `execute_two_hop`, `execute_n_hop`, and `execute_variable_length`
- Returns `Err(QueryTimeout)` the moment the deadline passes, preventing runaway recursive graph queries from hanging the process indefinitely
- `Error::QueryTimeout` added to `sparrowdb-common` with a clear display message
- Existing `execute()` is unchanged — `deadline` field defaults to `None` (zero overhead, backward compatible)

## Test plan
- [x] `execute_with_timeout_normal_query_completes` — 5s deadline, single node scan completes
- [x] `execute_with_timeout_returns_correct_values` — result set is correct under generous timeout
- [x] `execute_with_timeout_very_short_does_not_panic` — 1ns deadline, 200-node scan; verifies no panic, accepts Ok or QueryTimeout
- [x] `execute_with_timeout_zero_duration_does_not_panic` — `Duration::ZERO`; verifies no panic
- [x] `execute_with_timeout_query_timeout_error_display` — `QueryTimeout` Display contains "timeout" or "deadline"
- [x] `execute_with_timeout_create_statement_completes` — mutation statements routed through write-tx path, unaffected by timeout
- [x] Full test suite: 0 failures

Closes SPA-254

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add per-query timeouts for read queries**

### What Changed
- Read queries can now stop and return a timeout error if they run past the requested deadline.
- Long scans and graph traversals now stop checking progress at each node slot, so runaway queries end instead of hanging.
- Timeout errors now have a clear message, while existing write and maintenance commands keep working through the normal path.

### Impact
`✅ Fewer runaway query hangs`
`✅ Clearer timeout errors for slow searches`
`✅ Safer long graph traversals`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
