### PR TITLE
fix(node): audit and document unsafe Send impls (SPA-255)

### DIFF
--- a/crates/sparrowdb-node/src/lib.rs
+++ b/crates/sparrowdb-node/src/lib.rs
@@ -39,7 +39,13 @@ pub struct SparrowDB {
     inner: ::sparrowdb::GraphDb,
 }
 
-// GraphDb uses Arc<DbInner> internally; cross-thread use is safe.
+// SAFETY: napi-rs requires `Send` on all `#[napi]` struct types.  `SparrowDB`
+// wraps `sparrowdb::GraphDb` which is a newtype over `Arc<DbInner>`.  Every
+// field of `DbInner` is `Send`: `PathBuf`, `AtomicU64`, `AtomicBool`,
+// `RwLock<VersionStore>`, `RwLock<NodeVersions>`, and `Option<[u8; 32]>`.
+// There are no raw pointers or `Rc<T>` fields anywhere in the chain.
+// `GraphDb` itself derives `Clone` via `Arc`-clone and is therefore genuinely
+// safe to transfer across threads.
 unsafe impl Send for SparrowDB {}
 
 #[napi]
@@ -106,6 +112,14 @@ pub struct ReadTx {
     inner: ::sparrowdb::ReadTx,
 }
 
+// SAFETY: napi-rs requires `Send` on all `#[napi]` struct types.  `ReadTx`
+// wraps `sparrowdb::ReadTx` which holds: `snapshot_txn_id: u64`,
+// `store: NodeStore` (a `PathBuf` + `HashMap<u32, u64>` — both `Send`), and
+// `inner: Arc<DbInner>` (see `SparrowDB` SAFETY note above).  No raw pointers
+// or `Rc<T>` are present anywhere in the ownership chain.  A `ReadTx` only
+// reads committed state and holds no exclusive resources, so cross-thread
+// transfer is safe as long as the caller does not share a single `ReadTx`
+// reference across threads simultaneously (i.e. `Send` but not `Sync`).
 unsafe impl Send for ReadTx {}
 
 #[napi]
@@ -145,13 +159,27 @@ pub struct WriteTx {
     inner: Option<::sparrowdb::WriteTx>,
 }
 
-// SAFETY: napi-rs requires Send on all #[napi] types.  WriteTx wraps an
-// Arc<DbInner> + WriteGuard (AtomicBool-backed).  We uphold safety by
-// documenting that WriteTx MUST NOT be transferred to a napi worker thread (e.g.
-// via AsyncTask); it is only safe to use from the same thread that opened it.
-// napi-rs currently does not guarantee single-threaded access for object methods
-// without explicit AsyncTask, so callers must not call beginWrite() inside an
-// async napi task.
+// SAFETY: napi-rs requires `Send` on all `#[napi]` struct types.  `WriteTx`
+// wraps `Option<sparrowdb::WriteTx>`.  `sparrowdb::WriteTx` contains:
+//   - `inner: Arc<DbInner>` — `Send` (see `SparrowDB` SAFETY note above)
+//   - `store: NodeStore`    — `Send` (`PathBuf` + `HashMap`, no raw pointers)
+//   - `catalog: Catalog`    — `Send` (`PathBuf` + `Vec` fields, no raw pointers)
+//   - `write_buf: WriteBuffer`           — `Send` (`HashMap` over owned values)
+//   - `wal_mutations: Vec<WalMutation>`  — `Send` (owned enum variants)
+//   - `dirty_nodes: HashSet<u64>`        — `Send`
+//   - `snapshot_txn_id: u64`             — `Send`
+//   - `_guard: WriteGuard`               — `Send` (holds `Arc<DbInner>`)
+//   - `committed: bool`                  — `Send`
+//   - `fulltext_pending: HashMap<String, FulltextIndex>` — `Send` (owned)
+//   - `pending_ops: Vec<PendingOp>`      — `Send` (owned enum variants)
+// No raw pointers or `Rc<T>` anywhere in the chain.
+//
+// Usage constraint: a `WriteTx` holds the exclusive database writer lock via
+// `WriteGuard` (an `AtomicBool` CAS).  It MUST NOT be passed to an async
+// napi `AsyncTask` worker, because doing so would allow multiple threads to
+// drive the same write transaction.  Callers must open and use `WriteTx` on
+// a single JS thread (the napi main thread or a dedicated worker that owns it
+// exclusively).
 unsafe impl Send for WriteTx {}
 
 #[napi]


### PR DESCRIPTION
## **User description**
## Summary

Audited all three \`unsafe impl Send\` in \`sparrowdb-node/src/lib.rs\`. All three are **correct** — no raw pointers or \`Rc<T>\` anywhere in the ownership chains. Changes are documentation-only (SAFETY comments):

- **SparrowDB**: Replaced bare inline comment with a proper \`// SAFETY:\` block. \`GraphDb\` is \`Arc<DbInner>\`; all \`DbInner\` fields are \`Send\` (\`PathBuf\`, \`AtomicU64\`, \`AtomicBool\`, \`RwLock<VersionStore>\`, \`RwLock<NodeVersions>\`, \`Option<[u8; 32]>\`).
- **ReadTx**: Added \`// SAFETY:\` block (previously had none). \`sparrowdb::ReadTx\` holds \`u64\`, \`NodeStore\` (\`PathBuf\` + \`HashMap\`), and \`Arc<DbInner>\` — all \`Send\`, no raw pointers.
- **WriteTx**: Expanded existing \`// SAFETY:\` block to enumerate all eleven fields of \`sparrowdb::WriteTx\` and document the usage constraint that \`WriteTx\` must not be transferred to an async napi \`AsyncTask\` worker.

## Findings

| Type | Raw pointers / Rc? | execute() impl? | Send correct? |
|------|--------------------|-----------------|---------------|
| SparrowDB | No | Yes (fully implemented) | ✅ Yes |
| ReadTx | No | Exists, always throws (SPA-100 pending) | ✅ Yes |
| WriteTx | No | Exists, always throws (use SparrowDB.execute) | ✅ Yes |

## Test plan
- [x] \`cargo clippy -p sparrowdb-node --all-targets -- -D warnings\` passes clean
- [x] \`cargo fmt --all\` applied

Closes SPA-255

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Document the thread-safety guarantees for SparrowDB transactions**

### What Changed
- Added clear safety notes explaining why `SparrowDB`, `ReadTx`, and `WriteTx` can be sent across threads
- Expanded the write transaction note to list the user-facing rule that it must stay on one JS thread and must not be moved into an async worker
- Kept the transaction behavior the same; this change clarifies when each object is safe to use

### Impact
`✅ Clearer guidance for Node.js transaction usage`
`✅ Fewer mistakes when moving transactions across threads`
`✅ Safer async usage of database handles`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
