### PR TITLE
feat(cypher): UNWIND ['a','b'] AS x MATCH (n {id: x}) pipeline (SPA-237)

### DIFF
--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -1036,8 +1036,10 @@ impl Parser {
         self.expect_tok(&Token::As)?;
         let alias = self.expect_ident()?;
 
-        // If the next token is WITH, this is a pipeline: UNWIND … WITH … RETURN (SPA-134).
-        if matches!(self.peek(), Token::With) {
+        // If the next token is WITH or MATCH, this is a pipeline:
+        //   UNWIND … WITH … RETURN  (SPA-134)
+        //   UNWIND … MATCH … RETURN (SPA-237)
+        if matches!(self.peek(), Token::With | Token::Match) {
             return self.parse_pipeline_continuation(None, None, Some((expr, alias)), vec![]);
         }
 

--- a/crates/sparrowdb/tests/spa_237_unwind_match.rs
+++ b/crates/sparrowdb/tests/spa_237_unwind_match.rs
@@ -1,0 +1,135 @@
+/// SPA-237: UNWIND list AS x MATCH (n {id: x}) RETURN … pipeline.
+///
+/// Validates that values produced by an UNWIND clause can be used as
+/// variable references inside a subsequent MATCH clause's inline property
+/// filters, enabling bulk-lookup patterns used by LangChain and Graphiti.
+use sparrowdb::GraphDb;
+use tempfile::tempdir;
+
+fn open_db() -> (GraphDb, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    (db, dir)
+}
+
+/// Basic: UNWIND list, MATCH on id property, RETURN name.
+/// Only nodes whose id appears in the list should be returned.
+#[test]
+fn unwind_list_then_match_filters_by_id() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {id: 'a', name: 'Alpha'})")
+        .unwrap();
+    db.execute("CREATE (n:Item {id: 'b', name: 'Beta'})")
+        .unwrap();
+    db.execute("CREATE (n:Item {id: 'c', name: 'Gamma'})")
+        .unwrap();
+
+    let r = db
+        .execute("UNWIND ['a', 'b'] AS x MATCH (n:Item {id: x}) RETURN n.name")
+        .unwrap();
+
+    assert_eq!(
+        r.rows.len(),
+        2,
+        "Only items with id 'a' or 'b' should be returned"
+    );
+
+    let names: Vec<String> = r.rows.iter().map(|row| row[0].to_string()).collect();
+    assert!(
+        names.contains(&"\"Alpha\"".to_string()) || names.contains(&"Alpha".to_string()),
+        "Expected Alpha in results, got {:?}",
+        names
+    );
+    assert!(
+        names.contains(&"\"Beta\"".to_string()) || names.contains(&"Beta".to_string()),
+        "Expected Beta in results, got {:?}",
+        names
+    );
+}
+
+/// Two-element list, two matching nodes, verify row count equals 2.
+#[test]
+fn unwind_match_returns_correct_row_count() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (k:Knowledge {id: 'k1', title: 'Rust'})")
+        .unwrap();
+    db.execute("CREATE (k:Knowledge {id: 'k2', title: 'Go'})")
+        .unwrap();
+    db.execute("CREATE (k:Knowledge {id: 'k3', title: 'Python'})")
+        .unwrap();
+
+    let r = db
+        .execute("UNWIND ['k1', 'k2'] AS kid MATCH (k:Knowledge {id: kid}) RETURN k.title")
+        .unwrap();
+
+    assert_eq!(
+        r.rows.len(),
+        2,
+        "Expected exactly 2 rows, got {}",
+        r.rows.len()
+    );
+}
+
+/// Empty list: UNWIND produces no rows → no MATCH → empty result.
+#[test]
+fn unwind_empty_list_yields_no_rows() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {id: 'a', name: 'Alpha'})")
+        .unwrap();
+
+    let r = db
+        .execute("UNWIND [] AS x MATCH (n:Item {id: x}) RETURN n.name")
+        .unwrap();
+
+    assert_eq!(r.rows.len(), 0, "Empty UNWIND list should produce 0 rows");
+}
+
+/// List element with no matching node → that element contributes 0 rows.
+#[test]
+fn unwind_list_element_with_no_match_is_skipped() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Node {id: 'exists', val: 1})")
+        .unwrap();
+
+    let r = db
+        .execute("UNWIND ['exists', 'missing'] AS x MATCH (n:Node {id: x}) RETURN n.val")
+        .unwrap();
+
+    assert_eq!(r.rows.len(), 1, "Only the existing node should be returned");
+}
+
+/// Single-element list matches one node.
+#[test]
+fn unwind_single_element_list_matches_one_node() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (p:Person {uid: 'p1', name: 'Alice'})")
+        .unwrap();
+    db.execute("CREATE (p:Person {uid: 'p2', name: 'Bob'})")
+        .unwrap();
+
+    let r = db
+        .execute("UNWIND ['p1'] AS pid MATCH (p:Person {uid: pid}) RETURN p.name")
+        .unwrap();
+
+    assert_eq!(r.rows.len(), 1);
+}
+
+/// UNWIND followed by MATCH then WITH then RETURN (multi-stage pipeline).
+#[test]
+fn unwind_match_with_return_pipeline() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Doc {id: 'd1', score: 10})").unwrap();
+    db.execute("CREATE (n:Doc {id: 'd2', score: 20})").unwrap();
+    db.execute("CREATE (n:Doc {id: 'd3', score: 5})").unwrap();
+
+    let r = db
+        .execute(
+            "UNWIND ['d1', 'd2'] AS x \
+             MATCH (n:Doc {id: x}) \
+             WITH n.score AS s \
+             RETURN s",
+        )
+        .unwrap();
+
+    assert_eq!(r.rows.len(), 2, "Expected 2 rows from d1 and d2");
+}


### PR DESCRIPTION
## **User description**
## Summary
- Adds support for `UNWIND list AS x MATCH (n {id: x}) RETURN …` query patterns
- Enables bulk-lookup workflows used by LangChain and Graphiti where a list of IDs is unwound then each element is resolved to a graph node
- The fix is a **1-line parser change**: `parse_unwind` now routes into `parse_pipeline_continuation` when the next token is `MATCH` (in addition to the existing `WITH` case from SPA-134)
- The execution engine already handled this correctly via `leading_unwind` + `PipelineStage::Match` — no engine changes needed

## Test plan
- [x] `unwind_list_then_match_filters_by_id` — basic case: 3 nodes, 2-element list, only 2 returned
- [x] `unwind_match_returns_correct_row_count` — 2 matches from 3-node graph
- [x] `unwind_empty_list_yields_no_rows` — empty UNWIND → empty result
- [x] `unwind_list_element_with_no_match_is_skipped` — non-matching list elements produce 0 rows
- [x] `unwind_single_element_list_matches_one_node` — single element list
- [x] `unwind_match_with_return_pipeline` — multi-stage: UNWIND → MATCH → WITH → RETURN
- [x] Full `cargo test -p sparrowdb` suite passes (no regressions)

Closes SPA-237

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Allow UNWIND lists to flow directly into MATCH lookups**

### What Changed
- Queries using `UNWIND ... AS ... MATCH ... RETURN ...` now run instead of stopping after `UNWIND`
- Values from the list can be used inside the following `MATCH` clause to find matching nodes by property
- Added coverage for empty lists, missing matches, single-item lists, and multi-step pipelines with `WITH`

### Impact
`✅ Bulk lookup queries now work`
`✅ Fewer failed graph searches after UNWIND`
`✅ Clearer support for list-driven MATCH pipelines`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
