### PR TITLE
fix(engine): undirected MATCH count(m) GROUP BY includes all nodes (SPA-241)

### DIFF
--- a/crates/sparrowdb/tests/spa_151_kms_query_validation.rs
+++ b/crates/sparrowdb/tests/spa_151_kms_query_validation.rs
@@ -893,9 +893,6 @@ fn kms_q23_count_star_with_label() {
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[test]
-#[ignore = "GAP-K: undirected (n)-[:RELATED_TO]-(m) with count(m) GROUP BY n.id \
-            does not return both endpoints. know-003 (target-only node) is missing \
-            from results. Needs sub-ticket under SPA-151 for symmetric undirected agg."]
 fn kms_q24_undirected_relationship_count_per_node() {
     let (_dir, db) = make_db();
     setup_kms_graph(&db);


### PR DESCRIPTION
## **User description**
## Summary

- The GAP-K test (`kms_q24_undirected_relationship_count_per_node`) was marked `#[ignore]` because `MATCH (n:Knowledge)-[:RELATED_TO]-(m:Knowledge) RETURN n.id, count(m)` did not return rows for nodes that only appear as edge targets (`know-003` is only ever the destination of `know-002→know-003`)
- SPA-257 (already merged) fixed the root cause: the backward-pass deduplication used `seen_undirected.contains(&(a_slot, b_slot))` instead of `(b_slot, a_slot)`, which was suppressing legitimate backward traversal rows
- With SPA-257 merged, the backward pass correctly emits rows binding the physical target node to the `n` pattern variable, so all three connected Knowledge nodes appear in the GROUP BY result
- This PR simply removes the `#[ignore]` attribute — no engine changes needed

## Test plan

- [x] `cargo test -p sparrowdb --test spa_151_kms_query_validation` — 35 passed, 0 failed (up from 34 with 1 ignored)
- [x] `cargo test -p sparrowdb` — 0 failures across all test files

Closes SPA-241

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Undirected relationship counts now include nodes that only appear on the right side of a connection**

### What Changed
- The undirected relationship count test was re-enabled because the query now returns all connected Knowledge nodes, including nodes that only appear as targets
- This fixes the missing-row behavior in `MATCH (n:Knowledge)-[:RELATED_TO]-(m:Knowledge) RETURN n.id, count(m)` so hub counts are complete

### Impact
`✅ Complete relationship counts in undirected queries`
`✅ Fewer missing nodes in hub detection results`
`✅ More reliable Graph query validation`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
