### PR TITLE
fix(bfs): varpath dst property filter in variable-length path traversal (SPA-262)

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -4745,6 +4745,12 @@ fn matches_prop_filter_static(
                 // Use StoreValue::to_u64() for canonical encoding (SPA-169).
                 stored_val == Some(StoreValue::Int64(n).to_u64())
             }
+            Value::Bool(b) => {
+                // Booleans are stored as Int64(1) for true, Int64(0) for false
+                // (see value_to_store_value / literal_to_store_value).
+                let expected = StoreValue::Int64(if b { 1 } else { 0 }).to_u64();
+                stored_val == Some(expected)
+            }
             Value::String(s) => {
                 // Use store.raw_str_matches to handle both inline (≤7 bytes) and
                 // overflow (>7 bytes) string encodings (SPA-212).

--- a/crates/sparrowdb/tests/spa_139_phase9_path_acceptance.rs
+++ b/crates/sparrowdb/tests/spa_139_phase9_path_acceptance.rs
@@ -102,7 +102,6 @@ fn varpath_range_1_to_3_correct_set() {
 /// GAP: SPA-232 — varpath BFS engine does not apply inline endpoint property
 /// filters; the dst filter is silently ignored and returns an empty set.
 #[test]
-#[ignore = "SPA-232: varpath dst property filter not yet applied by BFS engine"]
 fn varpath_with_endpoint_property_filter() {
     let (_dir, db) = make_db();
 


### PR DESCRIPTION
## **User description**
## Summary
- Boolean property filters (`{active: true}`) in inline node patterns were silently rejected by `matches_prop_filter_static` because the `Value::Bool` match arm was missing — all booleans fell through to `_ => false`
- Booleans are stored as `StoreValue::Int64(1)` / `StoreValue::Int64(0)`, so the fix adds a `Value::Bool(b)` arm that encodes `b` the same way and compares against the stored value
- Un-ignored `varpath_with_endpoint_property_filter` test (previously tracked as SPA-232, superseded by SPA-262)

Closes SPA-262

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Variable-length path queries now respect endpoint property filters and boolean node properties**

### What Changed
- Variable-length path searches now return only endpoints that match the requested property filter, instead of ignoring the filter
- Queries that filter on boolean properties like `{active: true}` now match nodes correctly
- The previously skipped acceptance test for endpoint property filtering now runs

### Impact
`✅ Correct path results with endpoint filters`
`✅ Working boolean property searches`
`✅ Fewer empty or wrong graph query results`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
