### PR TITLE
fix(fulltext): YIELD score returns relevance score, not null (SPA-239)

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -335,7 +335,7 @@ impl Engine {
         // Open the fulltext index (read-only; no flush on this path).
         // `FulltextIndex::open` validates the name for path traversal.
         let index = FulltextIndex::open(&self.db_root, &index_name)?;
-        let node_ids = index.search(&query);
+        let hits = index.search_with_scores(&query);
 
         // Determine which column names to project.
         // Default to ["node"] when no YIELD clause was specified.
@@ -345,18 +345,28 @@ impl Engine {
             c.yield_columns.clone()
         };
 
-        // Validate YIELD columns — only "node" is defined for this procedure.
-        if let Some(bad_col) = yield_cols.iter().find(|c| c.as_str() != "node") {
+        // Validate YIELD columns — "node" and "score" are supported.
+        if let Some(bad_col) = yield_cols
+            .iter()
+            .find(|c| c.as_str() != "node" && c.as_str() != "score")
+        {
             return Err(sparrowdb_common::Error::InvalidArgument(format!(
                 "unsupported YIELD column for db.index.fulltext.queryNodes: {bad_col}"
             )));
         }
 
         // Build result rows: one per matching node.
+        // Each column emits the appropriate value: NodeRef for "node", Float64 for "score".
         let mut rows: Vec<Vec<Value>> = Vec::new();
-        for raw_id in node_ids {
+        for (raw_id, score) in hits {
             let node_id = sparrowdb_common::NodeId(raw_id);
-            let row: Vec<Value> = yield_cols.iter().map(|_| Value::NodeRef(node_id)).collect();
+            let row: Vec<Value> = yield_cols
+                .iter()
+                .map(|col| match col.as_str() {
+                    "score" => Value::Float64(score),
+                    _ => Value::NodeRef(node_id),
+                })
+                .collect();
             rows.push(row);
         }
 

--- a/crates/sparrowdb-storage/src/fulltext_index.rs
+++ b/crates/sparrowdb-storage/src/fulltext_index.rs
@@ -83,17 +83,46 @@ impl FulltextIndex {
     ///
     /// Results are deduplicated; order is unspecified.
     pub fn search(&self, query: &str) -> Vec<u64> {
-        let mut seen = std::collections::BTreeSet::new();
-        let mut result = Vec::new();
-        for term in tokenize(query) {
-            if let Some(ids) = self.entries.get(&term) {
+        self.search_with_scores(query)
+            .into_iter()
+            .map(|(id, _score)| id)
+            .collect()
+    }
+
+    /// Search for `query` — returns `(node_id, score)` pairs for every matching
+    /// node, sorted by descending score then ascending node id for determinism.
+    ///
+    /// Score is the number of distinct query terms that matched the node,
+    /// normalised to `[0.0, 1.0]` by dividing by the total number of unique
+    /// query terms.  A single-term query always yields score `1.0` for every
+    /// hit.  This is a simple term-frequency approximation — suitable for
+    /// ranking without full BM25 bookkeeping.
+    pub fn search_with_scores(&self, query: &str) -> Vec<(u64, f64)> {
+        let terms = tokenize(query);
+        let total_terms = terms.len().max(1) as f64;
+
+        // Count how many distinct query terms match each node.
+        let mut hit_counts: HashMap<u64, usize> = HashMap::new();
+        for term in &terms {
+            if let Some(ids) = self.entries.get(term.as_str()) {
                 for &id in ids {
-                    if seen.insert(id) {
-                        result.push(id);
-                    }
+                    *hit_counts.entry(id).or_insert(0) += 1;
                 }
             }
         }
+
+        // Convert hit counts to normalised scores.
+        let mut result: Vec<(u64, f64)> = hit_counts
+            .into_iter()
+            .map(|(id, count)| (id, count as f64 / total_terms))
+            .collect();
+
+        // Sort: descending score, then ascending node id for determinism.
+        result.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+        });
         result
     }
 

--- a/crates/sparrowdb/tests/spa_151_kms_query_validation.rs
+++ b/crates/sparrowdb/tests/spa_151_kms_query_validation.rs
@@ -29,8 +29,8 @@
 //!           parsed; SPA-155 confirmed UNWIND+RETURN works but UNWIND+MATCH is not.
 //!   GAP-H: `n.type IN ['ContextTrigger','ToolRoute']` combined with
 //!           `labels(n)` filtering — compound label+property filter pattern.
-//!   GAP-I: `CALL ... YIELD node, score` — only `node` YIELD column supported;
-//!           `score` column raises InvalidArgument error.
+//!   GAP-I: FIXED (SPA-239) — `CALL ... YIELD node, score` now supported;
+//!           `score` returns a normalised relevance float in [0.0, 1.0].
 //!   GAP-J: `coalesce(missing_prop, name, 'default')` — coalesce does not skip
 //!           Null from a missing property and falls through to Null rather than
 //!           the next non-null argument.
@@ -660,9 +660,6 @@ fn kms_q17_about_relationship_to_organization() {
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[test]
-#[ignore = "GAP-I: CALL db.index.fulltext.queryNodes YIELD node, score — \
-            'score' YIELD column not implemented (only 'node' supported). \
-            SPA-170 implements the procedure; score ranking needs a sub-ticket under SPA-151."]
 fn kms_q18_fulltext_search_call_procedure() {
     let (_dir, db) = make_db();
 


### PR DESCRIPTION
## **User description**
## Summary
- `CALL db.index.fulltext.queryNodes(...) YIELD node, score` now returns a numeric score instead of raising `InvalidArgument`
- Score is a normalised float in `[0.0, 1.0]` representing the fraction of distinct query terms that matched the node — higher means more relevant
- Results are sorted by descending score (then ascending node id for determinism), matching Neo4j's ranking behaviour
- `YIELD node` (without score) continues to work unchanged

## Implementation
- Added `FulltextIndex::search_with_scores(&str) -> Vec<(u64, f64)>` in `sparrowdb-storage/src/fulltext_index.rs`; existing `search()` delegates to it
- Updated `call_fulltext_query_nodes` in `engine.rs` to accept `"score"` as a valid YIELD column and emit `Value::Float64` for it
- Un-ignored GAP-I test `kms_q18_fulltext_search_call_procedure` in `spa_151_kms_query_validation.rs`

## Test plan
- [x] `kms_q18_fulltext_search_call_procedure` (previously `#[ignore]`) now passes
- [x] All 35 passing KMS validation tests still pass; 9 remaining ignores unchanged
- [x] All 5 `spa_fulltext` tests pass
- [x] All 4 `fulltext_index` unit tests pass

Closes SPA-239

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Return fulltext search scores with results**

### What Changed
- `CALL db.index.fulltext.queryNodes(...) YIELD node, score` now returns a numeric relevance score instead of failing
- Scores are shown as floats from `0.0` to `1.0`, with higher values for nodes that match more query terms
- Fulltext search results are ordered by relevance, then by node id for stable output
- The KMS validation test for this query now runs and covers the returned score column

### Impact
`✅ Fewer fulltext query failures`
`✅ Clearer search ranking results`
`✅ Working score output for query-based result ordering`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
