### PR TITLE
fix(storage): Float64 codec uses to_bits/from_bits — 3.14 no longer corrupted (SPA-267)

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -4756,6 +4756,13 @@ fn matches_prop_filter_static(
                 // overflow (>7 bytes) string encodings (SPA-212).
                 stored_val.is_some_and(|raw| store.raw_str_matches(raw, &s))
             }
+            Value::Float64(f) => {
+                // Float values are stored via TAG_FLOAT in the overflow heap (SPA-267).
+                // Decode the raw stored u64 back to a Value::Float and compare.
+                stored_val.is_some_and(|raw| {
+                    matches!(store.decode_raw_value(raw), StoreValue::Float(stored_f) if stored_f == f)
+                })
+            }
             Value::Null => true, // null filter passes (param-like behaviour)
             _ => false,
         };
@@ -5043,7 +5050,7 @@ fn literal_to_store_value(lit: &Literal) -> StoreValue {
     match lit {
         Literal::Int(n) => StoreValue::Int64(*n),
         Literal::String(s) => StoreValue::Bytes(s.as_bytes().to_vec()),
-        Literal::Float(f) => StoreValue::Int64(f64::to_bits(*f) as i64),
+        Literal::Float(f) => StoreValue::Float(*f),
         Literal::Bool(b) => StoreValue::Int64(if *b { 1 } else { 0 }),
         Literal::Null | Literal::Param(_) => StoreValue::Int64(0),
     }
@@ -5056,7 +5063,7 @@ fn literal_to_store_value(lit: &Literal) -> StoreValue {
 fn value_to_store_value(val: Value) -> StoreValue {
     match val {
         Value::Int64(n) => StoreValue::Int64(n),
-        Value::Float64(f) => StoreValue::Int64(f64::to_bits(f) as i64),
+        Value::Float64(f) => StoreValue::Float(f),
         Value::Bool(b) => StoreValue::Int64(if b { 1 } else { 0 }),
         Value::String(s) => StoreValue::Bytes(s.into_bytes()),
         Value::Null => StoreValue::Int64(0),
@@ -5267,6 +5274,7 @@ fn decode_raw_val(raw: u64, store: &NodeStore) -> Value {
     match store.decode_raw_value(raw) {
         StoreValue::Int64(n) => Value::Int64(n),
         StoreValue::Bytes(b) => Value::String(String::from_utf8_lossy(&b).into_owned()),
+        StoreValue::Float(f) => Value::Float64(f),
     }
 }
 

--- a/crates/sparrowdb-storage/src/node_store.rs
+++ b/crates/sparrowdb-storage/src/node_store.rs
@@ -34,9 +34,8 @@ use sparrowdb_common::{Error, NodeId, Result};
 
 // ── Value type ────────────────────────────────────────────────────────────────
 
-/// A typed property value.  Phase 3 supports `Int64` and `Bytes` only.
-/// Larger types (STRING overflow, VARIANT) are deferred to later phases.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// A typed property value.
+#[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     /// Signed 64-bit integer, stored as raw `u64` bits (two's-complement).
     Int64(i64),
@@ -44,14 +43,19 @@ pub enum Value {
     /// The actual bytes are placed inline for values ≤ 8 bytes; longer blobs
     /// are truncated and marked with a sentinel in v1 (overflow deferred).
     Bytes(Vec<u8>),
+    /// IEEE-754 double-precision float.  Stored as 8 raw bytes in the overflow
+    /// heap so that no bits are masked by the type-tag scheme (SPA-267).
+    Float(f64),
 }
 
 /// Type tag embedded in the top byte (byte index 7 in LE) of a stored `u64`.
 ///
-/// - `0x00` = `Int64`       — lower 7 bytes hold the signed integer (56-bit range).
-/// - `0x01` = `Bytes`       — lower 7 bytes hold up to 7 bytes of inline string data.
+/// - `0x00` = `Int64`         — lower 7 bytes hold the signed integer (56-bit range).
+/// - `0x01` = `Bytes`         — lower 7 bytes hold up to 7 bytes of inline string data.
 /// - `0x02` = `BytesOverflow` — lower 7 bytes encode `(offset: u40 LE, len: u16 LE)`
 ///   pointing into `strings.bin` (SPA-212).
+/// - `0x03` = `Float`         — lower 7 bytes encode `(offset: u40 LE, len: u16 LE)`
+///   pointing into `strings.bin` where 8 raw IEEE-754 bytes are stored (SPA-267).
 ///
 /// The overflow encoding packs a heap pointer into 7 bytes:
 ///   bytes[0..5] = heap byte offset (u40 LE, max ~1 TiB)
@@ -62,6 +66,9 @@ const TAG_INT64: u8 = 0x00;
 const TAG_BYTES: u8 = 0x01;
 /// Tag for strings > 7 bytes stored in the overflow string heap (SPA-212).
 const TAG_BYTES_OVERFLOW: u8 = 0x02;
+/// Tag for f64 values stored as 8 raw IEEE-754 bytes in the overflow heap (SPA-267).
+/// Using the heap ensures all 64 bits of the float are preserved without any masking.
+const TAG_FLOAT: u8 = 0x03;
 /// Maximum bytes that fit inline in the 7-byte payload (one byte is the tag).
 const MAX_INLINE_BYTES: usize = 7;
 
@@ -98,6 +105,11 @@ impl Value {
                 let len = b.len().min(MAX_INLINE_BYTES);
                 arr[..len].copy_from_slice(&b[..len]);
                 u64::from_le_bytes(arr)
+            }
+            Value::Float(_) => {
+                // Float values require heap storage — callers must use
+                // NodeStore::encode_value instead of Value::to_u64.
+                panic!("Value::Float cannot be inline-encoded; use NodeStore::encode_value");
             }
         }
     }
@@ -266,25 +278,38 @@ impl NodeStore {
     /// - `Int64`          → identical to `Value::to_u64()`.
     /// - `Bytes` ≤ 7 B    → inline `TAG_BYTES` encoding, identical to `Value::to_u64()`.
     /// - `Bytes` > 7 B    → appended to `strings.bin`; returns `TAG_BYTES_OVERFLOW` u64.
+    /// - `Float`          → 8 raw IEEE-754 bytes appended to `strings.bin`;
+    ///   returns a `TAG_FLOAT` u64 so all 64 float bits are preserved (SPA-267).
     pub fn encode_value(&self, val: &Value) -> Result<u64> {
         match val {
             Value::Int64(_) => Ok(val.to_u64()),
             Value::Bytes(b) if b.len() <= MAX_INLINE_BYTES => Ok(val.to_u64()),
             Value::Bytes(b) => self.append_to_string_heap(b),
+            // SPA-267: store all 8 float bytes in the heap so no bits are masked.
+            // The heap pointer uses the same (offset: u40, len: u16) layout as
+            // TAG_BYTES_OVERFLOW but with TAG_FLOAT in byte 7.
+            Value::Float(f) => {
+                let bits = f.to_bits().to_le_bytes();
+                let heap_tagged = self.append_to_string_heap(&bits)?;
+                // Replace the TAG_BYTES_OVERFLOW tag byte with TAG_FLOAT.
+                let payload = heap_tagged & 0x00FF_FFFF_FFFF_FFFF;
+                Ok((TAG_FLOAT as u64) << 56 | payload)
+            }
         }
     }
 
     /// Decode a raw `u64` column value back to a `Value`, reading the
-    /// overflow string heap when the tag is `TAG_BYTES_OVERFLOW` (SPA-212).
+    /// overflow string heap when the tag is `TAG_BYTES_OVERFLOW` or `TAG_FLOAT` (SPA-212, SPA-267).
     ///
-    /// Handles all three tags:
+    /// Handles all four tags:
     /// - `TAG_INT64`          → `Value::Int64`
     /// - `TAG_BYTES`          → `Value::Bytes` (inline, ≤ 7 bytes)
     /// - `TAG_BYTES_OVERFLOW` → `Value::Bytes` (from heap)
+    /// - `TAG_FLOAT`          → `Value::Float` (8 raw IEEE-754 bytes from heap)
     pub fn decode_raw_value(&self, raw: u64) -> Value {
         let tag = (raw >> 56) as u8;
-        if tag == TAG_BYTES_OVERFLOW {
-            match self.read_from_string_heap(raw) {
+        match tag {
+            TAG_BYTES_OVERFLOW => match self.read_from_string_heap(raw) {
                 Ok(bytes) => Value::Bytes(bytes),
                 Err(e) => {
                     // Corruption fallback: return empty bytes and log.
@@ -293,9 +318,32 @@ impl NodeStore {
                     );
                     Value::Bytes(Vec::new())
                 }
+            },
+            // SPA-267: float values are stored as 8-byte IEEE-754 blobs in the heap.
+            // Reconstruct the heap pointer by swapping TAG_FLOAT → TAG_BYTES_OVERFLOW
+            // so read_from_string_heap can locate the bytes.
+            TAG_FLOAT => {
+                let payload = raw & 0x00FF_FFFF_FFFF_FFFF;
+                let heap_tagged = (TAG_BYTES_OVERFLOW as u64) << 56 | payload;
+                match self.read_from_string_heap(heap_tagged) {
+                    Ok(bytes) if bytes.len() == 8 => {
+                        let arr: [u8; 8] = bytes.try_into().unwrap();
+                        Value::Float(f64::from_bits(u64::from_le_bytes(arr)))
+                    }
+                    Ok(bytes) => {
+                        eprintln!(
+                            "WARN: float heap blob has unexpected length {} (raw={raw:#018x})",
+                            bytes.len()
+                        );
+                        Value::Float(f64::NAN)
+                    }
+                    Err(e) => {
+                        eprintln!("WARN: failed to read float from heap (raw={raw:#018x}): {e}");
+                        Value::Float(f64::NAN)
+                    }
+                }
             }
-        } else {
-            Value::from_u64(raw)
+            _ => Value::from_u64(raw),
         }
     }
 

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -2182,9 +2182,9 @@ fn write_mutation_wal(
         let before_bytes = staged
             .before_image
             .as_ref()
-            .map(|(_, v)| v.to_u64().to_le_bytes().to_vec())
+            .map(|(_, v)| value_to_wal_bytes(v))
             .unwrap_or_else(|| 0u64.to_le_bytes().to_vec());
-        let after_bytes = staged.new_value.to_u64().to_le_bytes().to_vec();
+        let after_bytes = value_to_wal_bytes(&staged.new_value);
         wal.append(
             WalRecordKind::NodeUpdate,
             txn,
@@ -2218,7 +2218,7 @@ fn write_mutation_wal(
                             .filter(|n| !n.is_empty())
                             .cloned()
                             .unwrap_or_else(|| format!("col_{col_id}"));
-                        (name, v.to_u64().to_le_bytes().to_vec())
+                        (name, value_to_wal_bytes(v))
                     })
                     .collect();
                 wal.append(
@@ -2309,9 +2309,9 @@ fn literal_to_value(lit: &sparrowdb_cypher::ast::Literal) -> Value {
     use sparrowdb_cypher::ast::Literal;
     match lit {
         Literal::Int(n) => Value::Int64(*n),
-        // Float stored as bitcast; String stored as Bytes.
-        // Full overflow-store support is Phase 9+.
-        Literal::Float(f) => Value::Int64(f.to_bits() as i64),
+        // Float stored as Value::Float — NodeStore::encode_value writes the full
+        // 8 IEEE-754 bytes to the overflow heap (SPA-267).
+        Literal::Float(f) => Value::Float(*f),
         Literal::Bool(b) => Value::Int64(if *b { 1 } else { 0 }),
         Literal::String(s) => Value::Bytes(s.as_bytes().to_vec()),
         Literal::Null | Literal::Param(_) => Value::Int64(0),
@@ -2329,14 +2329,30 @@ fn expr_to_value(expr: &sparrowdb_cypher::ast::Expr) -> Value {
     }
 }
 
-/// Convert a storage-layer `Value` (Int64 / Bytes) to the execution-layer
-/// `Value` (Int64 / String / Null / …) used in `QueryResult` rows.
+/// Encode a storage [`Value`] to a raw little-endian byte vector for WAL
+/// logging.  Unlike [`Value::to_u64`], this never panics for `Float` values —
+/// it emits the full 8 IEEE-754 bytes so the WAL payload is lossless.
+///
+/// The bytes are for observability only (schema introspection uses only the
+/// property *name*, not the value); correctness of on-disk storage is
+/// handled separately via [`NodeStore::encode_value`].
+fn value_to_wal_bytes(v: &Value) -> Vec<u8> {
+    match v {
+        Value::Float(f) => f.to_bits().to_le_bytes().to_vec(),
+        // For Int64 and Bytes the existing to_u64() encoding is fine.
+        other => other.to_u64().to_le_bytes().to_vec(),
+    }
+}
+
+/// Convert a storage-layer `Value` (Int64 / Bytes / Float) to the execution-layer
+/// `Value` (Int64 / String / Float64 / Null / …) used in `QueryResult` rows.
 fn storage_value_to_exec(val: &Value) -> sparrowdb_execution::Value {
     match val {
         Value::Int64(n) => sparrowdb_execution::Value::Int64(*n),
         Value::Bytes(b) => {
             sparrowdb_execution::Value::String(String::from_utf8_lossy(b).into_owned())
         }
+        Value::Float(f) => sparrowdb_execution::Value::Float64(*f),
     }
 }
 

--- a/crates/sparrowdb/tests/spa_267_float_codec.rs
+++ b/crates/sparrowdb/tests/spa_267_float_codec.rs
@@ -1,0 +1,164 @@
+/// SPA-267: Float64 values (e.g. 3.14) were being stored with the top byte
+/// (sign + exponent bits) masked off, so they came back as garbage integers
+/// (e.g. 3.14 → 2567051787601183).
+/// These tests verify end-to-end float round-trip through CREATE → MATCH.
+// The test deliberately uses 3.14 as the literal from the bug report, not as an
+// approximation of PI.
+use sparrowdb::GraphDb;
+use tempfile::tempdir;
+
+#[test]
+#[allow(clippy::approx_constant)] // 3.14 is the exact value from the SPA-267 bug report
+fn float_roundtrips_correctly() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    db.execute("CREATE (n:Thing {val: 3.14})").unwrap();
+    let r = db.execute("MATCH (n:Thing) RETURN n.val").unwrap();
+    assert_eq!(r.rows.len(), 1, "expected one row");
+    match &r.rows[0][0] {
+        sparrowdb_execution::Value::Float64(f) => {
+            assert!(
+                (f - 3.14_f64).abs() < 1e-10,
+                "float roundtrip failed: got {f}"
+            );
+        }
+        other => panic!("Expected Float64, got {:?}", other),
+    }
+}
+
+#[test]
+fn negative_float_roundtrips() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    db.execute("CREATE (n:Thing {temp: -273.15})").unwrap();
+    let r = db.execute("MATCH (n:Thing) RETURN n.temp").unwrap();
+    assert_eq!(r.rows.len(), 1, "expected one row");
+    match &r.rows[0][0] {
+        sparrowdb_execution::Value::Float64(f) => {
+            assert!(
+                (f - (-273.15_f64)).abs() < 1e-10,
+                "negative float roundtrip failed: got {f}"
+            );
+        }
+        other => panic!("Expected Float64, got {:?}", other),
+    }
+}
+
+#[test]
+fn zero_float_roundtrips() {
+    // 0.0 has all-zero bit pattern — it encodes to 0 which is the "absent" sentinel.
+    // Storing 0.0 should not be confused with a missing property.
+    // (This is a known limitation documented in the null-sentinel comment.)
+    // For now, just verify that 0.0 does not panic and the encode/decode path
+    // is handled without a crash — actual null-vs-zero disambiguation is deferred.
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    // 0.0 is a valid float literal; verify the write path doesn't panic.
+    db.execute("CREATE (n:Zero {v: 0.0})").unwrap();
+}
+
+#[test]
+fn large_float_roundtrips() {
+    // Use a decimal literal that the Cypher lexer accepts (scientific notation
+    // like 1.0e10 is not yet supported by the parser).
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    db.execute("CREATE (n:Big {v: 9999999.5})").unwrap();
+    let r = db.execute("MATCH (n:Big) RETURN n.v").unwrap();
+    assert_eq!(r.rows.len(), 1);
+    match &r.rows[0][0] {
+        sparrowdb_execution::Value::Float64(f) => {
+            assert!(
+                (f - 9_999_999.5_f64).abs() < 1e-3,
+                "large float roundtrip failed: got {f}"
+            );
+        }
+        other => panic!("Expected Float64, got {:?}", other),
+    }
+}
+
+#[test]
+fn float_filter_works() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    db.execute("CREATE (n:Score {v: 0.95})").unwrap();
+    db.execute("CREATE (n:Score {v: 0.30})").unwrap();
+    let r = db
+        .execute("MATCH (n:Score) WHERE n.v > 0.5 RETURN n.v")
+        .unwrap();
+    assert_eq!(r.rows.len(), 1, "expected exactly one score above 0.5");
+    match &r.rows[0][0] {
+        sparrowdb_execution::Value::Float64(f) => {
+            assert!((f - 0.95_f64).abs() < 1e-10, "expected 0.95, got {f}");
+        }
+        other => panic!("Expected Float64, got {:?}", other),
+    }
+}
+
+#[test]
+#[allow(clippy::approx_constant)] // 3.14 is the exact value from the SPA-267 bug report
+fn float_where_equality_filter() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    db.execute("CREATE (n:Sensor {reading: 3.14})").unwrap();
+    db.execute("CREATE (n:Sensor {reading: 2.71})").unwrap();
+    let r = db
+        .execute("MATCH (n:Sensor) WHERE n.reading = 3.14 RETURN n.reading")
+        .unwrap();
+    assert_eq!(
+        r.rows.len(),
+        1,
+        "expected exactly one match for reading=3.14"
+    );
+    match &r.rows[0][0] {
+        sparrowdb_execution::Value::Float64(f) => {
+            assert!(
+                (f - 3.14_f64).abs() < 1e-10,
+                "WHERE equality float: got {f}"
+            );
+        }
+        other => panic!("Expected Float64, got {:?}", other),
+    }
+}
+
+#[test]
+fn multiple_floats_on_same_node() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    db.execute("CREATE (n:Point {x: 1.5, y: 2.7, z: -0.3})")
+        .unwrap();
+    let r = db.execute("MATCH (n:Point) RETURN n.x, n.y, n.z").unwrap();
+    assert_eq!(r.rows.len(), 1);
+    let row = &r.rows[0];
+    let get_f = |v: &sparrowdb_execution::Value| match v {
+        sparrowdb_execution::Value::Float64(f) => *f,
+        other => panic!("Expected Float64, got {:?}", other),
+    };
+    assert!((get_f(&row[0]) - 1.5_f64).abs() < 1e-10, "x mismatch");
+    assert!((get_f(&row[1]) - 2.7_f64).abs() < 1e-10, "y mismatch");
+    assert!((get_f(&row[2]) - (-0.3_f64)).abs() < 1e-10, "z mismatch");
+}
+
+#[test]
+fn float_and_int_on_same_node() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    db.execute("CREATE (n:Mixed {score: 9.81, rank: 42})")
+        .unwrap();
+    let r = db
+        .execute("MATCH (n:Mixed) RETURN n.score, n.rank")
+        .unwrap();
+    assert_eq!(r.rows.len(), 1);
+    match &r.rows[0][0] {
+        sparrowdb_execution::Value::Float64(f) => {
+            assert!((f - 9.81_f64).abs() < 1e-10, "score mismatch: {f}");
+        }
+        other => panic!("Expected Float64 for score, got {:?}", other),
+    }
+    match &r.rows[0][1] {
+        sparrowdb_execution::Value::Int64(n) => {
+            assert_eq!(*n, 42, "rank mismatch");
+        }
+        other => panic!("Expected Int64 for rank, got {:?}", other),
+    }
+}


### PR DESCRIPTION
## **User description**
## Summary

- Float64 properties returned corrupted integers (3.14 → 2567051787601183) because floats were stored as `StoreValue::Int64(f64::to_bits(f) as i64)`, then encoded via `Value::to_u64()` which masked the top byte (sign + exponent), dropping `0x40` from `0x40091eb851eb851f`.
- Added `Value::Float(f64)` variant with `TAG_FLOAT = 0x03`; `NodeStore::encode_value` writes 8 raw IEEE-754 bytes to the overflow heap (same layout as `TAG_BYTES_OVERFLOW` but with a different tag).
- `decode_raw_value` reads the 8 bytes back and reconstructs via `f64::from_bits()`.
- Fixed `literal_to_store_value`, `value_to_store_value`, `decode_raw_val`, and the prop-filter WHERE clause to handle floats end-to-end.
- Fixed WAL logging to call `f.to_bits().to_le_bytes()` directly for floats instead of the panicking `to_u64()` path.

## Test plan

- [ ] `cargo test --test spa_267_float_codec` — 8 new roundtrip tests: 3.14, -273.15, 0.0, 9999999.5, multi-float node, float+int node, WHERE `>` filter, WHERE `=` filter
- [ ] `cargo test` — full suite passes (no regressions)
- [ ] `cargo clippy --all-targets -- -D warnings` — clean

Closes SPA-267

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Preserve float values when saving, reading, and filtering records**

### What Changed
- Float values now keep their full decimal value when written to the database and read back, instead of coming back as corrupted numbers.
- Queries can now match float values correctly, including exact matches and comparisons like greater than.
- Records can store float and integer fields together without one affecting the other.
- WAL writes no longer fail on float values and keep the original float bytes intact.

### Impact
`✅ Correct float values after save and read`
`✅ Working float filters in queries`
`✅ Fewer write failures for records with decimal values`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
