### PR TITLE
fix(index): lazy selective index build — eliminate scan overhead (SPA-249)

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -2680,9 +2680,24 @@ impl Engine {
         // use the property index for a WHERE-clause equality predicate
         // (`WHERE n.prop = literal`).  The WHERE clause is still re-evaluated
         // per slot for correctness.
+        //
+        // We pre-build the index for any single-equality WHERE prop so the lazy
+        // cache is populated before the immutable borrow below.
+        if index_candidate_slots.is_none() {
+            if let Some(wexpr) = m.where_clause.as_ref() {
+                for prop_name in where_clause_eq_prop_names(wexpr, node.var.as_str()) {
+                    let col_id = sparrowdb_common::col_id_of(prop_name);
+                    let _ =
+                        self.prop_index
+                            .borrow_mut()
+                            .build_for(&self.store, label_id_u32, col_id);
+                }
+            }
+        }
         let where_eq_candidate_slots: Option<Vec<u32>> = if index_candidate_slots.is_none() {
+            let prop_index_ref = self.prop_index.borrow();
             m.where_clause.as_ref().and_then(|wexpr| {
-                try_where_eq_index_lookup(wexpr, node.var.as_str(), label_id_u32, &self.prop_index)
+                try_where_eq_index_lookup(wexpr, node.var.as_str(), label_id_u32, &prop_index_ref)
             })
         } else {
             None
@@ -2691,14 +2706,28 @@ impl Engine {
         // SPA-249 Phase 2: when neither equality path fired, try to use the
         // property index for a WHERE-clause range predicate (`>`, `>=`, `<`, `<=`,
         // or a compound AND of two half-open bounds on the same property).
+        //
+        // Pre-build for any range-predicate WHERE props before the immutable borrow.
+        if index_candidate_slots.is_none() && where_eq_candidate_slots.is_none() {
+            if let Some(wexpr) = m.where_clause.as_ref() {
+                for prop_name in where_clause_range_prop_names(wexpr, node.var.as_str()) {
+                    let col_id = sparrowdb_common::col_id_of(prop_name);
+                    let _ =
+                        self.prop_index
+                            .borrow_mut()
+                            .build_for(&self.store, label_id_u32, col_id);
+                }
+            }
+        }
         let where_range_candidate_slots: Option<Vec<u32>> =
             if index_candidate_slots.is_none() && where_eq_candidate_slots.is_none() {
+                let prop_index_ref = self.prop_index.borrow();
                 m.where_clause.as_ref().and_then(|wexpr| {
                     try_where_range_index_lookup(
                         wexpr,
                         node.var.as_str(),
                         label_id_u32,
-                        &self.prop_index,
+                        &prop_index_ref,
                     )
                 })
             } else {
@@ -5426,6 +5455,78 @@ fn try_text_index_lookup(
     };
 
     Some(slots)
+}
+
+/// SPA-249 (lazy build): Extract all property names referenced in a WHERE-clause
+/// equality predicate (`n.prop = literal` or `literal = n.prop`) so the caller
+/// can pre-build the lazy index for those `(label_id, col_id)` pairs.
+///
+/// Returns an empty vec if the expression does not match the pattern.
+fn where_clause_eq_prop_names<'a>(expr: &'a Expr, node_var: &str) -> Vec<&'a str> {
+    let (left, right) = match expr {
+        Expr::BinOp {
+            left,
+            op: BinOpKind::Eq,
+            right,
+        } => (left.as_ref(), right.as_ref()),
+        _ => return vec![],
+    };
+    if let Expr::PropAccess { var, prop } = left {
+        if var.as_str() == node_var {
+            return vec![prop.as_str()];
+        }
+    }
+    if let Expr::PropAccess { var, prop } = right {
+        if var.as_str() == node_var {
+            return vec![prop.as_str()];
+        }
+    }
+    vec![]
+}
+
+/// SPA-249 (lazy build): Extract all property names referenced in a WHERE-clause
+/// range predicate (`n.prop > literal`, etc., or compound AND) so the caller
+/// can pre-build the lazy index for those `(label_id, col_id)` pairs.
+///
+/// Returns an empty vec if the expression does not match the pattern.
+fn where_clause_range_prop_names<'a>(expr: &'a Expr, node_var: &str) -> Vec<&'a str> {
+    let is_range_op = |op: &BinOpKind| {
+        matches!(
+            op,
+            BinOpKind::Gt | BinOpKind::Ge | BinOpKind::Lt | BinOpKind::Le
+        )
+    };
+
+    // Simple range: `n.prop OP literal` or `literal OP n.prop`.
+    if let Expr::BinOp { left, op, right } = expr {
+        if is_range_op(op) {
+            if let Expr::PropAccess { var, prop } = left.as_ref() {
+                if var.as_str() == node_var {
+                    return vec![prop.as_str()];
+                }
+            }
+            if let Expr::PropAccess { var, prop } = right.as_ref() {
+                if var.as_str() == node_var {
+                    return vec![prop.as_str()];
+                }
+            }
+            return vec![];
+        }
+    }
+
+    // Compound AND: `lhs AND rhs` — collect from both sides.
+    if let Expr::BinOp {
+        left,
+        op: BinOpKind::And,
+        right,
+    } = expr
+    {
+        let mut names: Vec<&'a str> = where_clause_range_prop_names(left, node_var);
+        names.extend(where_clause_range_prop_names(right, node_var));
+        return names;
+    }
+
+    vec![]
 }
 
 /// SPA-249 Phase 1b: Try to use the property equality index for a WHERE-clause

--- a/crates/sparrowdb-storage/src/property_index.rs
+++ b/crates/sparrowdb-storage/src/property_index.rs
@@ -196,7 +196,9 @@ impl PropertyIndex {
             if raw == ABSENT || tombstone_slots.contains(&slot) {
                 continue;
             }
-            btree.entry(raw).or_default().push(slot);
+            // Apply the same sort_key transform used by `build` and `lookup`
+            // so that integer ordering and equality checks are consistent.
+            btree.entry(sort_key(raw)).or_default().push(slot);
         }
 
         Ok(())


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause**: `PropertyIndex::build()` was called in `Engine::new()` on every query, reading ALL `col_{id}.bin` files for ALL labels even when the query had no property filter (e.g. `COUNT(*)`, hop traversals). This caused a 1.1-3x I/O regression on Q2-Q8 benchmarks introduced in the original SPA-249 commit.

- **Fix**: Make the property index lazy and selective via `PropertyIndex::build_for(store, label_id, col_id)`, which reads only the single file needed for the specific property being filtered on.

- **Cache**: A `loaded: HashSet<IndexKey>` field in `PropertyIndex` tracks which `(label_id, col_id)` pairs have been loaded. Cache hits are O(1) with zero I/O. Pairs with no indexable values are still marked loaded to avoid redundant reads.

- **Interior mutability**: `Engine.prop_index` is wrapped in `RefCell<PropertyIndex>` so `execute_scan` can call `build_for` from `&self` without refactoring the entire `&self` method chain.

- **Zero-cost for unfiltered queries**: `COUNT(*)`, hop traversals, and any query without inline property filters never call `build_for` and pay zero index I/O.

- **TextIndex**: still built eagerly (unchanged) since CONTAINS/STARTS WITH arrive via WHERE and the col_id is not known until scan time.

## Test plan

- [x] All 7 SPA-249 integration tests pass (`cargo test -p sparrowdb --test spa_249_property_index`)
- [x] All 5 `PropertyIndex` unit tests pass (`cargo test -p sparrowdb-storage -- property_index`)
- [x] Full `cargo test -p sparrowdb` passes (only pre-existing `kms_q18` failure which predates this change)
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Load property indexes only when a query needs them**

### What Changed
- Queries now build the property index only for the specific label and column they filter on, instead of scanning every column at engine startup.
- Queries without property filters, such as `COUNT(*)` and hop traversals, no longer pay the index build cost.
- Once a column is loaded, later queries reuse the same in-memory index instead of reading it from disk again.
- If a column cannot be loaded, the query still runs by falling back to a normal scan.

### Impact
`✅ Faster COUNT(*) and traversal queries`
`✅ Fewer full-column reads at startup`
`✅ Lower repeated query latency`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Faster startup by deferring property index construction until needed.
  * Query execution improved with on-demand per-column index loading, caching of loaded keys to avoid repeated I/O, and additional pre-builds for relevant property predicates to improve lookup reliability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->