### PR TITLE
perf(bfs): hoist delta read + node_label map out of per-source BFS loop (SPA-275)

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -4330,6 +4330,7 @@ impl Engine {
     ///   Bug B — `results.insert` is gated behind the `visited.insert` guard so a
     ///            self-loop cannot insert the source back into results.
     ///   Bug C — when `min_hops == 0` the source node is pre-seeded in results.
+    #[allow(clippy::too_many_arguments)]
     fn execute_variable_hops(
         &self,
         src_slot: u64,


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause**: `execute_variable_hops` called `read_delta_all()` and rebuilt the `node_label` HashMap on every invocation. For 1,000 source nodes this produced 1,000 delta file reads and ~1M HashMap insertions per query.
- **Fix**: Hoist `read_delta_all()` and the `node_label`/`all_label_ids` build into `execute_variable_length`, above the source-node loop — done once per query, passed as references to `execute_variable_hops`.
- **Bonus**: Changed the per-frontier-node `HashMap<(u64,u32),()>` in `get_node_neighbors_labeled` to a `&mut HashSet<(u64,u32)>` passed from the caller and cleared with `.clear()` between frontier nodes, eliminating heap reallocation per BFS step. Also changed `node_label` type from `HashMap` to `HashSet` (removes unused `()` values).

## Changes

- `execute_variable_length`: calls `read_delta_all()` once, builds `node_label: HashSet<(u64,u32)>` and `all_label_ids: Vec<u32>` once, allocates a single `neighbors_buf: HashSet<(u64,u32)>` reused across all BFS iterations.
- `execute_variable_hops`: signature extended with `delta_all`, `node_label`, `all_label_ids`, `neighbors_buf` — no longer performs any allocation of its own for these structures.
- `get_node_neighbors_labeled`: `node_label` parameter changed from `&HashMap<(u64,u32),()>` to `&HashSet<(u64,u32)>`; `out` parameter changed from a locally-allocated `HashMap` to a caller-provided `&mut HashSet` that is cleared on entry.

## Test plan

- [x] `cargo build -p sparrowdb-execution` — clean compile, no warnings
- [x] `cargo test -p sparrowdb --test spa_268_bfs_bugs` — all 5 SPA-268 BFS regression tests pass
- [x] `cargo test -p sparrowdb` — all tests pass (pre-existing `kms_q18_fulltext_search_call_procedure` failure is unrelated to this change, confirmed present on `main`)
- [x] `cargo fmt --check` — no formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Reuse BFS data across source nodes to reduce repeated graph traversal work**

### What Changed
- The graph search now reads the change log once per query instead of once for every source node
- The list of known node labels is built once and reused while scanning all source nodes
- A single neighbor buffer is reused during traversal instead of creating a new one for each step
- The search still returns the same reachable nodes and labels, including zero-hop matches

### Impact
`✅ Faster multi-source graph searches`
`✅ Lower query latency on large traversals`
`✅ Fewer repeated reads during BFS`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
