### PR TITLE
feat(db): storage sizing via GraphDb::stats() (SPA-171)

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -563,6 +563,15 @@ impl Engine {
     }
 
     /// Implementation of `CALL db.stats()` (SPA-171).
+    ///
+    /// Returns metric/value rows for `total_bytes`, `wal_bytes`, `edge_count`,
+    /// and per-label `nodes.<Label>` and `label_bytes.<Label>`.
+    ///
+    /// `nodes.<Label>` reports the per-label high-water mark (HWM), not the
+    /// live-node count.  Tombstoned slots are included until compaction runs.
+    ///
+    /// Filesystem entries that cannot be read are silently skipped; values may
+    /// be lower bounds when the database directory is partially inaccessible.
     fn call_db_stats(&self, c: &CallStatement) -> Result<QueryResult> {
         if !c.args.is_empty() {
             return Err(sparrowdb_common::Error::InvalidArgument(

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -68,7 +68,10 @@ pub struct DbStats {
     pub total_bytes: u64,
     /// Bytes consumed by node column files for each label.
     pub bytes_per_label: std::collections::HashMap<String, u64>,
-    /// Number of live nodes per label (high-water mark).
+    /// High-water mark (HWM) per label — the highest slot index allocated for
+    /// that label, plus one.  Soft-deleted nodes whose slots have not yet been
+    /// reclaimed by compaction are still included in this count.  The value
+    /// converges to the true live-node count once compaction / GC runs.
     pub node_count_per_label: std::collections::HashMap<String, u64>,
     /// Total edges across all relationship types (delta log + CSR).
     pub edge_count: u64,
@@ -435,6 +438,14 @@ impl GraphDb {
     /// Return a storage-size snapshot for this database (SPA-171).
     ///
     /// Pure read — no locks acquired, no writes performed.
+    ///
+    /// # Best-effort semantics
+    ///
+    /// Filesystem entries that cannot be read (missing directories, permission
+    /// errors, partially corrupt files) are silently skipped.  The returned
+    /// snapshot may therefore undercount bytes or edges if the database
+    /// directory is in an inconsistent state.  Callers that need exact
+    /// accounting should treat the reported values as a lower bound.
     pub fn stats(&self) -> Result<DbStats> {
         let db_root = &self.inner.path;
         let catalog = Catalog::open(db_root)?;


### PR DESCRIPTION
## **User description**
## Summary

- Adds `GraphDb::stats()` returning a `DbStats` struct with total disk bytes, per-label node counts and column-file bytes, total edge count (delta log + CSR), and WAL segment bytes
- Wires `CALL db.stats()` Cypher procedure returning `["metric", "value"]` rows for `total_bytes`, `wal_bytes`, `edge_count`, `nodes.<Label>`, and `label_bytes.<Label>`
- Pure read operation — no locks, no writes
- Fixes DeltaRecord size constant (20 bytes: src:8 + dst:8 + rel_id:4, not 24)

## Test plan

- [x] `stats_empty_db` — empty database returns zero counts and no WAL bytes
- [x] `stats_after_writes` — node count, edge count, WAL bytes, and label bytes all reflect committed data
- [x] `call_db_stats_cypher` — `CALL db.stats() YIELD metric, value` returns expected metric keys and non-zero total_bytes
- [x] `stats_edge_count_after_checkpoint` — edge count is consistent before and after CHECKPOINT (delta log vs CSR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add database storage stats and a Cypher command to view them**

### What Changed
- Added a database stats snapshot that reports total disk usage, WAL size, edge count, and per-label node and storage sizes.
- Added `CALL db.stats()` so users can query these metrics from Cypher and receive them as `metric` / `value` rows.
- Fixed edge counting so stored relationship records are counted with the correct size, keeping the reported edge total accurate.

### Impact
`✅ Easier database size checks`
`✅ Clearer storage usage reporting`
`✅ Accurate edge counts after writes and checkpoints`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
