### PR TITLE
fix(fulltext): YIELD score + keyword token in CALL proc name (kms_q18)

### DIFF
--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -2188,10 +2188,13 @@ impl Parser {
         self.expect_tok(&Token::Call)?;
 
         // Parse dotted procedure name: ident (. ident)*
-        let mut proc_name = self.expect_ident()?;
+        // Use advance_as_prop_name for all segments so that keyword tokens like
+        // `index` (Token::Index) are accepted within the dotted path
+        // (e.g. `db.index.fulltext.queryNodes`).
+        let mut proc_name = self.advance_as_prop_name()?;
         while matches!(self.peek(), Token::Dot) {
             self.advance(); // consume '.'
-            let part = self.expect_ident()?;
+            let part = self.advance_as_prop_name()?;
             proc_name.push('.');
             proc_name.push_str(&part);
         }

--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -490,7 +490,6 @@ impl Engine {
         // Open the fulltext index (read-only; no flush on this path).
         // `FulltextIndex::open` validates the name for path traversal.
         let index = FulltextIndex::open(&self.snapshot.db_root, &index_name)?;
-        let node_ids = index.search(&query);
 
         // Determine which column names to project.
         // Default to ["node"] when no YIELD clause was specified.
@@ -500,18 +499,30 @@ impl Engine {
             c.yield_columns.clone()
         };
 
-        // Validate YIELD columns — only "node" is defined for this procedure.
-        if let Some(bad_col) = yield_cols.iter().find(|c| c.as_str() != "node") {
+        // Validate YIELD columns — "node" and "score" are supported.
+        if let Some(bad_col) = yield_cols
+            .iter()
+            .find(|c| c.as_str() != "node" && c.as_str() != "score")
+        {
             return Err(sparrowdb_common::Error::InvalidArgument(format!(
                 "unsupported YIELD column for db.index.fulltext.queryNodes: {bad_col}"
             )));
         }
 
         // Build result rows: one per matching node.
+        // Use search_with_scores so we can populate the `score` YIELD column.
+        let node_ids_with_scores = index.search_with_scores(&query);
         let mut rows: Vec<Vec<Value>> = Vec::new();
-        for raw_id in node_ids {
+        for (raw_id, score) in node_ids_with_scores {
             let node_id = sparrowdb_common::NodeId(raw_id);
-            let row: Vec<Value> = yield_cols.iter().map(|_| Value::NodeRef(node_id)).collect();
+            let row: Vec<Value> = yield_cols
+                .iter()
+                .map(|col| match col.as_str() {
+                    "node" => Value::NodeRef(node_id),
+                    "score" => Value::Float64(score),
+                    _ => Value::Null,
+                })
+                .collect();
             rows.push(row);
         }
 


### PR DESCRIPTION
## **User description**
## Summary

Fixes two pre-existing failures in `kms_q18_fulltext_search_call_procedure` and `kms_q18b_fulltext_search_yield_node_only`.

**Root cause 1 — Parser (both tests)**
`parse_call()` used `expect_ident()` for each segment of the dotted procedure name. This rejects keyword tokens: `db.index.fulltext` fails because `index` is lexed as `Token::Index`. Fix: switch all segments to `advance_as_prop_name()`, which already accepts keyword tokens in property-name position — no new token cases needed.

**Root cause 2 — Engine (kms_q18 only)**
`call_fulltext_query_nodes()` only accepted `node` as a valid YIELD column, returning `InvalidArgument` for `score`. The storage layer already implemented `search_with_scores() -> Vec<(u64, f64)>`. Fix: accept `score` in YIELD validation and return it as `Value::Float64` via `search_with_scores()`.

## Test plan

- [x] `kms_q18_fulltext_search_call_procedure` — was FAILED, now passes
- [x] `kms_q18b_fulltext_search_yield_node_only` — was FAILED, now passes
- [x] `kms_q19_fulltext_search_no_results` — still passes (no regression)
- [x] Full `spa_151_kms_query_validation` suite: 36 pass, 1 pre-existing failure (kms_q32 MERGE ON CREATE/MATCH), 7 ignored (documented gaps)
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Allow full-text calls with keyword procedure names and score output**

### What Changed
- Full-text `CALL` procedures now accept dotted names that include keywords like `index`, so queries such as `db.index.fulltext.queryNodes` run correctly.
- `YIELD score` is now supported for full-text searches and returns a numeric relevance score alongside each matched node.
- Requests with unsupported `YIELD` columns still fail with a clear error.

### Impact
`✅ Fewer failed full-text queries`
`✅ Works with full-text procedures that use keyword names`
`✅ Search results can include relevance scores`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
