### PR TITLE
feat(cypher): CREATE INDEX and UNIQUE constraint bodies (SPA-235, SPA-234)

### DIFF
--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -682,6 +682,12 @@ impl GraphDb {
         // even before any nodes of this label exist.  Subsequent CREATE
         // statements look up the label_id from the persisted catalog and compare
         // against the same unique_constraints set.
+        //
+        // Acquire the writer lock so that catalog mutations here cannot race
+        // with an active WriteTx that also holds an open Catalog handle.
+        // Both paths derive next_label_id from their own in-memory counter, so
+        // concurrent catalog writes without this guard can assign duplicate IDs.
+        let _guard = WriteGuard::try_acquire(&self.inner).ok_or(Error::WriterBusy)?;
         let mut catalog = sparrowdb_catalog::catalog::Catalog::open(&self.inner.path)?;
         let label_id: u32 = match catalog.get_label(label)? {
             Some(id) => id as u32,
@@ -789,6 +795,12 @@ impl GraphDb {
             // handles produces two different raw u64 values.  Decoding each
             // stored raw u64 back to Value and comparing is correct for all
             // value types (inline integers/short strings AND heap-overflow strings).
+            //
+            // We check both the committed on-disk values (via check_store) AND
+            // nodes already buffered in tx.pending_ops (but not yet committed).
+            // Without the pending-ops check, two nodes with the same constrained
+            // value in one CREATE statement would both pass the on-disk check and
+            // then be committed together, violating the constraint.
             {
                 let constraints = self.inner.unique_constraints.read().unwrap();
                 if !constraints.is_empty() {
@@ -796,17 +808,31 @@ impl GraphDb {
                     for (prop_name, val) in &named_props {
                         let col_id = sparrowdb_common::col_id_of(prop_name);
                         if constraints.contains(&(label_id, col_id)) {
-                            // ABSENT = 0 (never written); TOMBSTONE = u64::MAX (deleted).
-                            let existing_raws = check_store
-                                .read_col_all(label_id, col_id)
-                                .unwrap_or_default();
-                            let conflict = existing_raws.iter().any(|&raw| {
+                            // Check committed on-disk values.
+                            // Propagate I/O errors — silencing them would disable
+                            // the constraint check on read failure.
+                            let existing_raws = check_store.read_col_all(label_id, col_id)?;
+                            let conflict_on_disk = existing_raws.iter().any(|&raw| {
                                 if raw == 0 || raw == u64::MAX {
                                     return false;
                                 }
                                 check_store.decode_raw_value(raw) == *val
                             });
-                            if conflict {
+                            // Check nodes buffered earlier in this same statement.
+                            let conflict_in_tx = tx.pending_ops.iter().any(|op| match op {
+                                PendingOp::NodeCreate {
+                                    label_id: pending_label_id,
+                                    props,
+                                    ..
+                                } => {
+                                    *pending_label_id == label_id
+                                        && props.iter().any(|(existing_col_id, existing_val)| {
+                                            *existing_col_id == col_id && *existing_val == *val
+                                        })
+                                }
+                                _ => false,
+                            });
+                            if conflict_on_disk || conflict_in_tx {
                                 return Err(sparrowdb_common::Error::InvalidArgument(format!(
                                     "UNIQUE constraint violation: label \"{label}\" already has a node with {prop_name} = {:?}", val
                                 )));

--- a/crates/sparrowdb/tests/spa_235_234_create_index_constraint.rs
+++ b/crates/sparrowdb/tests/spa_235_234_create_index_constraint.rs
@@ -8,6 +8,8 @@
 //! 3. Constraint applies only to the constrained label — another label with the
 //!    same property value is unaffected.
 //! 4. Different property values on the same constrained label are each allowed.
+//! 5. Two nodes with the same constrained value in a single CREATE statement are
+//!    rejected (catches the pending-ops gap in the uniqueness check).
 
 use sparrowdb::GraphDb;
 use sparrowdb_execution::types::Value;
@@ -117,6 +119,33 @@ fn unique_constraint_is_label_scoped() {
     // A different label with the same property value must be allowed.
     db.execute("CREATE (:Admin {email: 'carol@example.com'})")
         .expect("same value on a different label must not violate the constraint");
+}
+
+// ── SPA-234 Test 5b: Duplicate in same CREATE statement is rejected ───────────
+//
+// Before the pending-ops fix, two nodes in a single `CREATE (a),(b)` statement
+// both passed the on-disk uniqueness check (neither was committed yet), so the
+// duplicate would be silently committed.
+
+#[test]
+fn unique_constraint_rejects_duplicate_within_same_statement() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    db.execute("CREATE CONSTRAINT ON (n:Item) ASSERT n.sku IS UNIQUE")
+        .unwrap();
+
+    // Both nodes share the same sku — should fail even though neither is on disk
+    // at the time the second node's uniqueness check runs.
+    let err = db
+        .execute("CREATE (:Item {sku: 'X1'}), (:Item {sku: 'X1'})")
+        .expect_err("duplicate in one CREATE statement must fail");
+
+    let msg = format!("{err:?}").to_lowercase();
+    assert!(
+        msg.contains("unique") || msg.contains("constraint") || msg.contains("violation"),
+        "error message should mention constraint violation, got: {msg}"
+    );
 }
 
 // ── SPA-234 Test 6: Different values on constrained label all pass ─────────────


### PR DESCRIPTION
## **User description**
## Summary

- **SPA-235**: `CREATE INDEX ON :Label(property)` — fully implemented; parser was already wired, `execute_create_index` builds the `PropertyIndex` and is dispatched correctly
- **SPA-234**: `CREATE CONSTRAINT ON (n:Label) ASSERT n.property IS UNIQUE` — two bugs fixed in the existing stub

## Bugs Fixed

### Bug 1 — Constraint never registered when label doesn't exist yet (SPA-234)

`register_unique_constraint` returned early with `Ok` when `get_label()` returned `None`, silently dropping the constraint. Any constraint issued before the first node of that label was written was lost.

**Fix**: call `catalog.create_label(label)` on `None` so the label_id is persisted and the `(label_id, col_id)` pair is inserted into `self.inner.unique_constraints`.

### Bug 2 — Duplicate detection using heap-pointer raw u64 values (SPA-234)

The uniqueness check built a fresh `PropertyIndex`, then called `check_store.encode_value(val)` to produce a raw u64 lookup key. For strings > 7 bytes (`TAG_BYTES_OVERFLOW`), `encode_value` writes a new entry to the string heap and returns a pointer to that new location. The existing node's raw u64 points to a different heap offset, so `PropertyIndex::lookup` never finds a match.

**Fix**: read existing raw column values via `NodeStore::read_col_all`, decode each with `decode_raw_value`, and compare the decoded `Value` directly — correct for all types (integers, short inline strings, and heap-overflow long strings).

## Test Plan

New integration test file `crates/sparrowdb/tests/spa_235_234_create_index_constraint.rs`:

- [x] `create_index_supports_equality_lookup` — index built on pre-existing data, equality MATCH uses it
- [x] `create_index_on_missing_label_is_noop` — no error when label absent
- [x] `unique_constraint_allows_first_insert` — first CREATE succeeds
- [x] `unique_constraint_rejects_duplicate` — second CREATE with same value errors (was failing)
- [x] `unique_constraint_is_label_scoped` — same value on different label is allowed
- [x] `unique_constraint_allows_different_values` — distinct values all pass

Note: `check_14_fulltext_search` in `acceptance.rs` is a pre-existing failure on `main` (unrelated CALL parser issue) and is not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**CREATE INDEX and UNIQUE constraints now work as expected**

### What Changed
- Creating an index now makes equality searches return matching rows, including data that existed before the index was added
- Creating an index on a label that does not exist no longer fails
- Unique constraints now block duplicate values on the same label, while still allowing the first insert
- The same value can still be used on a different label, and different values on the constrained label are allowed
- Added coverage for index creation and unique-constraint behavior

### Impact
`✅ Fewer duplicate-record insertions`
`✅ Reliable index-backed lookups`
`✅ Fewer errors when creating indexes on empty labels`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
