### PR TITLE
perf(engine): build label_row_counts once at Engine::new() — fixes Q1 regression (closes #180)

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -521,7 +521,9 @@ impl Engine {
 
         self.ensure_degree_cache();
         let cache = self.degree_cache.borrow();
-        let cache = cache.as_ref().expect("degree_cache populated by ensure_degree_cache");
+        let cache = cache
+            .as_ref()
+            .expect("degree_cache populated by ensure_degree_cache");
 
         let mut pairs: Vec<(u64, u32)> = (0..hwm)
             .map(|slot| (slot, cache.out_degree(slot)))

--- a/crates/sparrowdb/tests/spa_272_degree_cache.rs
+++ b/crates/sparrowdb/tests/spa_272_degree_cache.rs
@@ -125,12 +125,12 @@ fn top_k_by_degree_correct_order_and_count() {
     slots.sort_unstable();
     assert_eq!(slots, vec![0u64, 1, 2, 3, 4]);
 
-    // Verify: out_degree O(1) lookup for individual slots.
-    assert_eq!(engine.degree_cache.out_degree(0), 9);
-    assert_eq!(engine.degree_cache.out_degree(1), 8);
-    assert_eq!(engine.degree_cache.out_degree(9), 0);
-    assert_eq!(engine.degree_cache.out_degree(10), 0);
-    assert_eq!(engine.degree_cache.out_degree(19), 0);
+    // Verify: out_degree O(1) lookup for individual slots via the public API.
+    assert_eq!(engine.out_degree(0), 9);
+    assert_eq!(engine.out_degree(1), 8);
+    assert_eq!(engine.out_degree(9), 0);
+    assert_eq!(engine.out_degree(10), 0);
+    assert_eq!(engine.out_degree(19), 0);
 }
 
 // ── Test 2: DegreeCache includes delta-log edges (no checkpoint) ──────────────
@@ -166,31 +166,11 @@ fn degree_cache_counts_delta_log_edges() {
     let engine = build_engine(db_path);
     let lid = label_id(db_path, "Hub");
 
-    assert_eq!(
-        engine.degree_cache.out_degree(0),
-        3,
-        "Hub 0 should have degree 3"
-    );
-    assert_eq!(
-        engine.degree_cache.out_degree(1),
-        2,
-        "Hub 1 should have degree 2"
-    );
-    assert_eq!(
-        engine.degree_cache.out_degree(2),
-        1,
-        "Hub 2 should have degree 1"
-    );
-    assert_eq!(
-        engine.degree_cache.out_degree(3),
-        0,
-        "Hub 3 should have degree 0"
-    );
-    assert_eq!(
-        engine.degree_cache.out_degree(4),
-        0,
-        "Hub 4 should have degree 0"
-    );
+    assert_eq!(engine.out_degree(0), 3, "Hub 0 should have degree 3");
+    assert_eq!(engine.out_degree(1), 2, "Hub 1 should have degree 2");
+    assert_eq!(engine.out_degree(2), 1, "Hub 2 should have degree 1");
+    assert_eq!(engine.out_degree(3), 0, "Hub 3 should have degree 0");
+    assert_eq!(engine.out_degree(4), 0, "Hub 4 should have degree 0");
 
     let top3 = engine.top_k_by_degree(lid, 3).expect("top_k");
     assert_eq!(top3.len(), 3);


### PR DESCRIPTION
## **User description**
## Problem

`label_row_counts` in `ReadSnapshot` was initialized as an empty `HashMap` and only populated via the write path (`execute_create`). Every read query therefore started with an empty map, forcing the planner to fall back to per-scan `hwm_for_label()` I/O on every execution — adding ~116µs overhead to Q1 point lookups and reversing a previous 3.1× Neo4j win.

## Root cause

`Engine::new()` constructed `ReadSnapshot` with `label_row_counts: HashMap::new()`. The map was designed to cache live node counts per label, but was never seeded from existing on-disk state at open time.

## Fix

`Engine::new()` now eagerly seeds `label_row_counts` by calling `catalog.list_labels()` + `store.hwm_for_label()` once per label at engine-open time. This is O(n_labels) cheap I/O, not O(n_nodes). The write path (`execute_create`) continues to increment the counts on each node creation so the map stays accurate within a session.

## Expected improvement

Q1: ~560µs → ~444µs (restoring pre-regression performance from the ~116µs overhead added by per-query empty-map behavior)

## Test plan
- [x] `cargo check -p sparrowdb-execution` — clean
- [x] `cargo test -p sparrowdb` — 13/14 pass; `check_14_fulltext_search` is a **pre-existing** parser failure unrelated to this change (confirmed by running it against `main` before this patch)
- [x] Pre-existing failure verified by `git stash` + re-run

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Build label counts at startup and delay degree data loading until needed**

### What Changed
- Read queries now start with label counts already filled in, so they no longer fall back to repeated label count reads during execution.
- Degree data is now loaded only when a degree-based query runs for the first time, which removes startup work for queries that do not use degree ranking or degree lookups.
- Point lookups, full scans, and hop traversals no longer pay the cost of preparing degree data they never use.

### Impact
`✅ Faster point lookups`
`✅ Fewer query-time label count reads`
`✅ Lower startup cost for non-degree queries`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
