### PR TITLE
perf(engine): lazy-init rel_degree_stats to fix Q3/Q4 regression from PR #177

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -165,11 +165,55 @@ pub struct ReadSnapshot {
     pub label_row_counts: HashMap<LabelId, usize>,
     /// Per-relationship-type out-degree statistics (SPA-273).
     ///
-    /// Keyed by `RelTableId` (u32).  Built eagerly at engine open time from
-    /// CSR forward files.  Used by future join-order heuristics to estimate
-    /// how many neighbor hops a traversal on a given relationship type will
-    /// produce.
-    pub rel_degree_stats: HashMap<u32, DegreeStats>,
+    /// Keyed by `RelTableId` (u32).  Initialized **lazily** on first access
+    /// via [`ReadSnapshot::rel_degree_stats`].  Simple traversal queries
+    /// (Q3, Q4) that never consult the planner heuristics pay zero CSR-scan
+    /// cost.  The scan is only triggered when a query actually needs degree
+    /// statistics (e.g. join-order planning).
+    ///
+    /// `OnceLock` is used instead of `OnceCell` so that `ReadSnapshot` remains
+    /// `Sync` and can safely be shared across parallel BFS threads.
+    rel_degree_stats: std::sync::OnceLock<HashMap<u32, DegreeStats>>,
+}
+
+impl ReadSnapshot {
+    /// Return per-relationship-type out-degree statistics, computing them on
+    /// first call and caching the result for all subsequent calls.
+    ///
+    /// The CSR forward scan is only triggered once per `ReadSnapshot` instance,
+    /// and only when a caller actually needs degree statistics.  Queries that
+    /// never access this (e.g. simple traversals Q3/Q4) pay zero overhead.
+    pub fn rel_degree_stats(&self) -> &HashMap<u32, DegreeStats> {
+        self.rel_degree_stats.get_or_init(|| {
+            self.csrs
+                .iter()
+                .map(|(&rel_table_id, csr)| {
+                    let mut stats = DegreeStats::default();
+                    let mut first = true;
+                    for slot in 0..csr.n_nodes() {
+                        let deg = csr.neighbors(slot).len() as u32;
+                        if deg > 0 {
+                            if first {
+                                stats.min = deg;
+                                stats.max = deg;
+                                first = false;
+                            } else {
+                                if deg < stats.min {
+                                    stats.min = deg;
+                                }
+                                if deg > stats.max {
+                                    stats.max = deg;
+                                }
+                            }
+                            stats.total += deg as u64;
+                            stats.count += 1;
+                        }
+                    }
+                    (rel_table_id, stats)
+                })
+                .collect()
+        })
+    }
 }
 
 /// The execution engine holds references to the storage layer.
@@ -274,44 +318,16 @@ impl Engine {
             })
             .collect();
 
-        // SPA-273: build per-rel-type degree stats from CSR forward files.
-        // For each relationship type (CSR), iterate every source slot and
-        // accumulate min/max/total/count statistics.
-        let rel_degree_stats: HashMap<u32, DegreeStats> = csrs
-            .iter()
-            .map(|(&rel_table_id, csr)| {
-                let mut stats = DegreeStats::default();
-                let mut first = true;
-                for slot in 0..csr.n_nodes() {
-                    let deg = csr.neighbors(slot).len() as u32;
-                    if deg > 0 {
-                        if first {
-                            stats.min = deg;
-                            stats.max = deg;
-                            first = false;
-                        } else {
-                            if deg < stats.min {
-                                stats.min = deg;
-                            }
-                            if deg > stats.max {
-                                stats.max = deg;
-                            }
-                        }
-                        stats.total += deg as u64;
-                        stats.count += 1;
-                    }
-                }
-                (rel_table_id, stats)
-            })
-            .collect();
-
+        // SPA-273 (lazy): rel_degree_stats is now computed on first access via
+        // ReadSnapshot::rel_degree_stats().  Simple traversal queries (Q3/Q4)
+        // that never consult degree statistics pay zero CSR-scan overhead here.
         let snapshot = ReadSnapshot {
             store,
             catalog,
             csrs,
             db_root: db_root.to_path_buf(),
             label_row_counts,
-            rel_degree_stats,
+            rel_degree_stats: std::sync::OnceLock::new(),
         };
 
         Engine {

--- a/crates/sparrowdb/tests/spa_273_planner_stats.rs
+++ b/crates/sparrowdb/tests/spa_273_planner_stats.rs
@@ -77,7 +77,7 @@ fn rel_degree_stats_field_is_accessible() {
     db.checkpoint().expect("checkpoint");
 
     let engine = build_engine(dir.path());
-    let stats = &engine.snapshot.rel_degree_stats;
+    let stats = engine.snapshot.rel_degree_stats();
 
     // After a checkpoint with at least one edge, the stats map must be non-empty.
     assert!(
@@ -126,7 +126,7 @@ fn rel_degree_stats_populated_after_checkpoint() {
     db.checkpoint().expect("checkpoint");
 
     let engine = build_engine(dir.path());
-    let stats = &engine.snapshot.rel_degree_stats;
+    let stats = engine.snapshot.rel_degree_stats();
 
     assert!(
         !stats.is_empty(),


### PR DESCRIPTION
## **User description**
## Problem

PR #177 (SPA-273) added eager CSR scanning for `rel_degree_stats` at every `Engine::new()`. This scans every source slot in every CSR forward file to compute min/max/total/count degree statistics. This work happens unconditionally — even for simple traversal queries (Q3, Q4) that never consult degree statistics, causing a measurable benchmark regression.

## Fix

- Change `rel_degree_stats: HashMap<u32, DegreeStats>` → `rel_degree_stats: std::sync::OnceLock<HashMap<u32, DegreeStats>>` in `ReadSnapshot`.
- Add `ReadSnapshot::rel_degree_stats() -> &HashMap<u32, DegreeStats>` getter that runs the CSR scan **on first call only** via `OnceLock::get_or_init`.
- Remove the eager build block from `Engine::new()`; initialize with `OnceLock::new()` (zero-cost).
- `OnceLock` (not `OnceCell`) preserves `ReadSnapshot: Sync` for parallel BFS threads (SPA-268).
- Update the single direct field access in `spa_273_planner_stats.rs` to call the getter method.

## Impact

Queries that never access degree statistics (Q1, Q3, Q4, Q5, simple traversals) now pay **zero CSR-scan cost** at engine open time. Planner heuristics that do call `rel_degree_stats()` still get the full statistics on the first request, then hit the `OnceLock` cache on every subsequent call within the same engine instance.

## Test plan

- [x] All 6 `spa_273_planner_stats` tests pass (including `rel_degree_stats_field_is_accessible`)
- [x] `cargo check -p sparrowdb-execution -p sparrowdb` clean
- [x] `cargo fmt --all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Delay relationship degree stats until they are actually needed**

### What Changed
- The engine no longer scans all relationship data when it starts up just to build degree statistics.
- Degree statistics are now computed the first time a query asks for them, then reused for the rest of that engine session.
- Simple traversal queries that do not use these statistics avoid the extra startup work.
- The test for degree stats access now uses the new on-demand lookup path.

### Impact
`✅ Faster engine startup`
`✅ Shorter Q3/Q4 query warm-up`
`✅ Fewer unnecessary CSR scans`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted relationship statistics computation in the database engine. The functionality remains unchanged while the internal execution approach has been modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->