### PR TITLE
perf(db): persist PropertyIndex in GraphDb — eliminate per-query Engine rebuild (closes #187)

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -396,12 +396,17 @@ impl Engine {
         self
     }
 
-    /// Write back the engine's lazily-populated property index into the shared
-    /// cache so that future read queries can skip I/O for columns we already
-    /// loaded.  Called from `GraphDb` read paths after `execute_statement`.
+    /// Merge the engine's lazily-populated property index into the shared cache
+    /// so that future read queries can skip I/O for columns we already loaded.
+    ///
+    /// Uses union/merge semantics: only columns not yet present in the shared
+    /// cache are added.  This prevents last-writer-wins races when multiple
+    /// concurrent read queries write back to the shared cache simultaneously.
+    ///
+    /// Called from `GraphDb` read paths after `execute_statement`.
     pub fn write_back_prop_index(&self, shared: &std::sync::RwLock<PropertyIndex>) {
         if let Ok(mut guard) = shared.write() {
-            *guard = self.prop_index.borrow().clone();
+            guard.merge_from(&self.prop_index.borrow());
         }
     }
 

--- a/crates/sparrowdb-storage/src/property_index.rs
+++ b/crates/sparrowdb-storage/src/property_index.rs
@@ -139,6 +139,22 @@ impl PropertyIndex {
         self.loaded.clear();
     }
 
+    /// Merge column data from `other` into `self` using union semantics.
+    ///
+    /// Only columns present in `other.loaded` but absent from `self.loaded` are
+    /// incorporated — already-cached columns are left unchanged.  This avoids
+    /// last-writer-wins races when multiple concurrent reads write back to the
+    /// shared cache simultaneously.
+    pub fn merge_from(&mut self, other: &PropertyIndex) {
+        for key in &other.loaded {
+            if self.loaded.insert(*key) {
+                if let Some(btree) = other.index.get(key) {
+                    self.index.insert(*key, btree.clone());
+                }
+            }
+        }
+    }
+
     /// Lazily load the index for a single `(label_id, col_id)` pair.
     ///
     /// Reads `nodes/{label_id}/col_{col_id}.bin` and the corresponding tombstone

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -375,9 +375,11 @@ impl GraphDb {
     /// Called after every write-transaction commit so the next read query
     /// re-populates from the updated column files on disk.
     fn invalidate_prop_index(&self) {
-        if let Ok(mut guard) = self.inner.prop_index.write() {
-            guard.clear();
-        }
+        self.inner
+            .prop_index
+            .write()
+            .expect("prop_index RwLock poisoned")
+            .clear();
     }
 
     /// Open a read-only snapshot transaction.


### PR DESCRIPTION
## **User description**
## Problem
`Engine::new()` is called on every query, rebuilding `PropertyIndex` from scratch each time. This adds unnecessary overhead to Q1 point lookups, as previously-loaded column indexes are discarded and re-read from disk on every subsequent query.

## Fix
- Added `prop_index: RwLock<PropertyIndex>` to `DbInner` — shared across all read queries
- Read queries seed the Engine from the shared cache via `Engine::new_with_cached_index()` and write lazily-loaded columns back after execution
- Write transactions invalidate the cache on commit via `PropertyIndex::clear()` so the next read sees fresh data
- Added `Clone` derive and `clear()` method to `PropertyIndex`

## Expected improvement
Q1 point lookups skip redundant `build_for()` I/O for columns already loaded by prior queries. The lazy-load pattern is preserved — only columns actually queried get indexed.

## Test plan
- [x] `cargo check -p sparrowdb -p sparrowdb-execution -p sparrowdb-storage` clean
- [x] All existing tests pass (1 pre-existing parser failure in `kms_q32` unrelated)
- [x] Write followed by read sees new data (cache invalidated on commit)

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Cache property indexes across queries and refresh them after writes**

### What Changed
- Read queries now reuse loaded property index data from earlier queries instead of rebuilding it each time
- After a read query loads new columns, those columns are saved for the next query
- Any write now clears the saved index so later reads see the latest data on disk
- The same cached behavior is applied to normal queries, parameterized queries, and timeout-limited queries

### Impact
`✅ Faster repeated lookups`
`✅ Fewer repeated disk reads`
`✅ Fresh results after writes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared property-index cache now persists computed indexes across read queries.
  * Added a public way to manually invalidate the property-index cache.

* **Improvements**
  * Read executions now update the shared cache so subsequent reads are faster.
  * Cache is automatically invalidated after write transactions to avoid stale data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->