### PR TITLE
perf(engine): MATCH (n:Label) RETURN COUNT(n) → O(1) label_row_counts lookup (closes #197)

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -3076,10 +3076,8 @@ impl Engine {
                         // COUNT(f) — arg must be the destination variable.
                         if let Some(Expr::Var(v)) = args.first() {
                             if v == dst_var {
-                                count_al = item
-                                    .alias
-                                    .clone()
-                                    .or_else(|| Some(format!("COUNT({})", v)));
+                                count_al =
+                                    item.alias.clone().or_else(|| Some(format!("COUNT({})", v)));
                             } else {
                                 return Ok(None);
                             }

--- a/crates/sparrowdb/tests/spa_197_count_label_fastpath.rs
+++ b/crates/sparrowdb/tests/spa_197_count_label_fastpath.rs
@@ -73,8 +73,7 @@ fn count_with_where_falls_through() {
 
     db.execute("CREATE (:User {name: 'Alice', age: 30})")
         .unwrap();
-    db.execute("CREATE (:User {name: 'Bob', age: 25})")
-        .unwrap();
+    db.execute("CREATE (:User {name: 'Bob', age: 25})").unwrap();
     db.execute("CREATE (:User {name: 'Carol', age: 35})")
         .unwrap();
 

--- a/crates/sparrowdb/tests/spa_272_q7_count_fastpath.rs
+++ b/crates/sparrowdb/tests/spa_272_q7_count_fastpath.rs
@@ -88,7 +88,8 @@ fn q7_exact_facebook_query_shape() {
     let (_dir, db) = make_db();
 
     for i in 0..5u32 {
-        db.execute(&format!("CREATE (n:User {{uid: {i}}})")).unwrap();
+        db.execute(&format!("CREATE (n:User {{uid: {i}}})"))
+            .unwrap();
     }
 
     // uid=0 has 4 friends, uid=1 has 2, uid=2 has 1
@@ -166,10 +167,7 @@ fn q7_count_with_where_falls_through_to_normal_path() {
         .unwrap();
 
     assert_eq!(result.rows.len(), 1);
-    assert_eq!(
-        result.rows[0][1],
-        sparrowdb_execution::Value::Int64(1),
-    );
+    assert_eq!(result.rows[0][1], sparrowdb_execution::Value::Int64(1),);
 }
 
 // ── Test 5: Column order preserved ──────────────────────────────────────────


### PR DESCRIPTION
## **User description**
## Summary
- Adds `try_count_label_fastpath()` that short-circuits `MATCH (n:Label) RETURN COUNT(n)` (and `COUNT(*)`) queries to an O(1) HashMap lookup on the pre-populated `label_row_counts` map
- Avoids full node scan for simple count queries — target latency ~1us vs previous ~7.7ms
- Falls through to normal scan path when preconditions aren't met (WHERE clause, prop filters, multiple RETURN items, ORDER BY/SKIP/LIMIT, no label)

## Qualifying conditions
1. Single node pattern with exactly one label
2. No WHERE clause
3. No inline property filters
4. RETURN has exactly one item: `COUNT(*)` or `COUNT(var)` matching the node variable
5. No ORDER BY, SKIP, or LIMIT

## Test plan
- [x] `count_label_fastpath_count_var` — COUNT(n) returns correct count
- [x] `count_label_fastpath_count_star` — COUNT(*) returns correct count
- [x] `count_label_fastpath_unknown_label` — unknown label returns 0 rows
- [x] `count_with_where_falls_through` — WHERE clause bypasses fastpath
- [x] `count_no_label_falls_through` — no label bypasses fastpath

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Answer simple label counts without scanning nodes**

### What Changed
- `MATCH (n:Label) RETURN COUNT(n)` and `COUNT(*)` now return directly from stored label counts when the query is simple and unfiltered.
- Queries with a `WHERE` clause, property filters, sorting, skip/limit, multiple return items, or no label still use the normal path.
- Unknown labels return no rows, matching the existing behavior for missing data.
- Added tests covering label counts, unknown labels, and cases that must fall back to the normal scan.

### Impact
`✅ Faster label count queries`
`✅ Fewer full-node scans for simple counts`
`✅ Consistent results for empty and filtered counts`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * MATCH (n:Label) RETURN COUNT(...) queries now use a fast-path and execute significantly faster for single-label counts
  * Unknown labels correctly return COUNT = 0
  * Queries with WHERE, multiple labels, or complex patterns fall back to normal execution

* **Tests**
  * Added tests validating COUNT behavior for labeled nodes, unknown labels, WHERE fallbacks, and unlabeled counts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->