### PR TITLE
perf(engine): LIMIT pushdown into node scan — early exit after k matches (closes #198)

### DIFF
--- a/crates/sparrowdb-execution/src/engine.rs
+++ b/crates/sparrowdb-execution/src/engine.rs
@@ -3846,6 +3846,20 @@ impl Engine {
                 Box::new(0..hwm)
             };
 
+        // SPA-198: LIMIT pushdown — compute an early-exit cap so we can break
+        // out of the scan loop once we have enough rows.  This is only safe
+        // when there is no aggregation, no ORDER BY, and no DISTINCT (all of
+        // which require the full result set before they can operate).
+        let scan_cap: usize = if !use_eval_path && !m.distinct && m.order_by.is_empty() {
+            match (m.skip, m.limit) {
+                (Some(s), Some(l)) => (s as usize).saturating_add(l as usize),
+                (None, Some(l)) => l as usize,
+                _ => usize::MAX,
+            }
+        } else {
+            usize::MAX
+        };
+
         for slot in slot_iter {
             // SPA-254: check per-query deadline at every slot boundary.
             self.check_deadline()?;
@@ -3954,6 +3968,10 @@ impl Engine {
                     &self.snapshot.store,
                 );
                 rows.push(row);
+                // SPA-198: early exit when we have enough rows for SKIP+LIMIT.
+                if rows.len() >= scan_cap {
+                    break;
+                }
             }
         }
 

--- a/crates/sparrowdb/tests/spa_198_limit_pushdown.rs
+++ b/crates/sparrowdb/tests/spa_198_limit_pushdown.rs
@@ -1,0 +1,151 @@
+//! Tests for LIMIT pushdown into node scan (SPA-198 / issue #198).
+//!
+//! Verifies that `MATCH (n:Label) WHERE … RETURN … LIMIT k` stops scanning
+//! after k matching rows instead of collecting all results and truncating.
+
+use sparrowdb::open;
+use sparrowdb_execution::types::Value;
+
+fn make_db() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+/// Create 100 User nodes with sequential uid and age values.
+fn seed_users(db: &sparrowdb::GraphDb) {
+    for i in 1..=100i64 {
+        db.execute(&format!(
+            "CREATE (n:User {{uid: {i}, age: {i}, city: 'City{i}'}})"
+        ))
+        .unwrap_or_else(|e| panic!("seed failed for i={i}: {e}"));
+    }
+}
+
+// ── Basic LIMIT returns exactly k rows ──────────────────────────────────────
+
+#[test]
+fn limit_returns_exact_count() {
+    let (_dir, db) = make_db();
+    seed_users(&db);
+
+    let result = db
+        .execute("MATCH (n:User) RETURN n.uid LIMIT 10")
+        .expect("LIMIT 10 must succeed");
+
+    assert_eq!(result.rows.len(), 10, "LIMIT 10 should return exactly 10 rows");
+}
+
+// ── LIMIT with WHERE clause ─────────────────────────────────────────────────
+
+#[test]
+fn limit_with_where_returns_exact_count() {
+    let (_dir, db) = make_db();
+    seed_users(&db);
+
+    // age > 30 matches users 31..=100 (70 users), LIMIT 5 should return 5.
+    let result = db
+        .execute("MATCH (n:User) WHERE n.age > 30 RETURN n.uid, n.city LIMIT 5")
+        .expect("WHERE + LIMIT must succeed");
+
+    assert_eq!(result.rows.len(), 5, "WHERE + LIMIT 5 should return exactly 5 rows");
+}
+
+// ── LIMIT larger than result set returns all matching rows ──────────────────
+
+#[test]
+fn limit_larger_than_result_set() {
+    let (_dir, db) = make_db();
+    seed_users(&db);
+
+    // age > 95 matches users 96..=100 (5 users), LIMIT 50 should return all 5.
+    let result = db
+        .execute("MATCH (n:User) WHERE n.age > 95 RETURN n.uid LIMIT 50")
+        .expect("LIMIT > result size must succeed");
+
+    assert_eq!(result.rows.len(), 5, "LIMIT 50 with 5 matches should return 5 rows");
+}
+
+// ── No LIMIT still returns all matching rows ────────────────────────────────
+
+#[test]
+fn no_limit_returns_all_rows() {
+    let (_dir, db) = make_db();
+    seed_users(&db);
+
+    let result = db
+        .execute("MATCH (n:User) WHERE n.age > 90 RETURN n.uid")
+        .expect("no LIMIT must succeed");
+
+    assert_eq!(result.rows.len(), 10, "no LIMIT should return all 10 matching rows");
+}
+
+// ── SKIP + LIMIT combination ────────────────────────────────────────────────
+
+#[test]
+fn skip_and_limit_combination() {
+    let (_dir, db) = make_db();
+    seed_users(&db);
+
+    // No ORDER BY, so order is scan order (slot order = insertion order).
+    // SKIP 5 LIMIT 3 should return 3 rows.
+    let result = db
+        .execute("MATCH (n:User) RETURN n.uid SKIP 5 LIMIT 3")
+        .expect("SKIP + LIMIT must succeed");
+
+    assert_eq!(result.rows.len(), 3, "SKIP 5 LIMIT 3 should return exactly 3 rows");
+}
+
+// ── LIMIT with ORDER BY must not use pushdown (correctness) ─────────────────
+
+#[test]
+fn limit_with_order_by_returns_correct_results() {
+    let (_dir, db) = make_db();
+    seed_users(&db);
+
+    // ORDER BY n.uid DESC LIMIT 3 must return the top 3 uids: 100, 99, 98.
+    let result = db
+        .execute("MATCH (n:User) RETURN n.uid ORDER BY n.uid DESC LIMIT 3")
+        .expect("ORDER BY + LIMIT must succeed");
+
+    assert_eq!(result.rows.len(), 3);
+    assert_eq!(result.rows[0][0], Value::Int64(100));
+    assert_eq!(result.rows[1][0], Value::Int64(99));
+    assert_eq!(result.rows[2][0], Value::Int64(98));
+}
+
+// ── LIMIT with DISTINCT must not use pushdown (correctness) ─────────────────
+
+#[test]
+fn limit_with_distinct_returns_correct_count() {
+    let (_dir, db) = make_db();
+    // Create nodes with duplicate city values.
+    for i in 1..=20i64 {
+        let city = if i <= 10 { "Alpha" } else { "Beta" };
+        db.execute(&format!(
+            "CREATE (n:Place {{name: 'Place{i}', city: '{city}'}})"
+        ))
+        .expect("seed");
+    }
+
+    let result = db
+        .execute("MATCH (n:Place) RETURN DISTINCT n.city LIMIT 5")
+        .expect("DISTINCT + LIMIT must succeed");
+
+    // Only 2 distinct cities exist, LIMIT 5 should return 2.
+    assert_eq!(result.rows.len(), 2, "DISTINCT should yield 2 unique cities");
+}
+
+// ── LIMIT 0 returns no rows ────────────────────────────────────────────────
+
+#[test]
+fn limit_zero_returns_empty() {
+    let (_dir, db) = make_db();
+    seed_users(&db);
+
+    let result = db
+        .execute("MATCH (n:User) RETURN n.uid LIMIT 0")
+        .expect("LIMIT 0 must succeed");
+
+    assert_eq!(result.rows.len(), 0, "LIMIT 0 should return 0 rows");
+}


### PR DESCRIPTION
## **User description**
## Summary

- Thread LIMIT count into `execute_scan()` so it breaks early once `skip + limit` rows have been collected
- Pushdown is gated: only activates when there is no aggregation, no ORDER BY, and no DISTINCT
- For Q2-shaped queries (`MATCH (n:Label) WHERE … RETURN … LIMIT k`), this avoids scanning all nodes when only k matches are needed (target: 141ms → ~3ms)

## Test plan

- [x] 8 new e2e tests in `spa_198_limit_pushdown.rs` covering:
  - Basic LIMIT returns exact count
  - LIMIT with WHERE clause
  - LIMIT larger than result set (returns all)
  - No LIMIT returns all rows
  - SKIP + LIMIT combination
  - ORDER BY + LIMIT correctness (must not use pushdown)
  - DISTINCT + LIMIT correctness (must not use pushdown)
  - LIMIT 0 returns empty
- [ ] Full test suite passes (`cargo test -p sparrowdb`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Stop scanning once enough matching rows have been found for LIMIT queries**

### What Changed
- Queries with `LIMIT` now stop reading nodes as soon as they have collected enough rows, instead of scanning the full label and trimming the result afterward
- `SKIP + LIMIT` queries also stop early once the skipped rows and requested rows have been collected
- Early stop is not used when the query needs the full result set, such as with `ORDER BY`, `DISTINCT`, or aggregation
- Added coverage for plain `LIMIT`, `WHERE + LIMIT`, `SKIP + LIMIT`, `ORDER BY + LIMIT`, `DISTINCT + LIMIT`, and `LIMIT 0`

### Impact
`✅ Faster label scans for small LIMIT queries`
`✅ Lower query latency for LIMIT with filters`
`✅ Fewer full-table scans for pagination queries`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved query performance for LIMIT operations in select query patterns.

* **Tests**
  * Added comprehensive test coverage for LIMIT behavior, including basic LIMIT queries, LIMIT with filtering, SKIP+LIMIT combinations, and edge cases like LIMIT 0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->