### PR TITLE
fix(storage): seek+read in string heap — eliminates full-file load OOM (closes #208)

### DIFF
--- a/crates/sparrowdb-storage/src/node_store.rs
+++ b/crates/sparrowdb-storage/src/node_store.rs
@@ -245,7 +245,12 @@ impl NodeStore {
 
     /// Read string bytes from the overflow heap given an `TAG_BYTES_OVERFLOW`
     /// tagged `u64` produced by [`append_to_string_heap`].
+    ///
+    /// Uses `seek + read_exact` to load only the `len` bytes at `offset`,
+    /// avoiding a full file load regardless of `strings.bin` size (SPA-208).
     fn read_from_string_heap(&self, tagged: u64) -> Result<Vec<u8>> {
+        use std::io::{Read, Seek, SeekFrom};
+
         let arr = tagged.to_le_bytes();
         debug_assert_eq!(arr[7], TAG_BYTES_OVERFLOW, "not an overflow pointer");
 
@@ -258,16 +263,20 @@ impl NodeStore {
         let len = arr[5] as usize | ((arr[6] as usize) << 8);
 
         let path = self.strings_bin_path();
-        let file_bytes = fs::read(&path).map_err(Error::Io)?;
-        let end = offset as usize + len;
-        if file_bytes.len() < end {
-            return Err(Error::Corruption(format!(
-                "string heap too short: need {} bytes, have {}",
-                end,
-                file_bytes.len()
-            )));
-        }
-        Ok(file_bytes[offset as usize..end].to_vec())
+        let mut file = fs::File::open(&path).map_err(Error::Io)?;
+        file.seek(SeekFrom::Start(offset)).map_err(|e| {
+            Error::Corruption(format!(
+                "string heap seek failed (offset={offset}): {e}"
+            ))
+        })?;
+        let mut buf = vec![0u8; len];
+        file.read_exact(&mut buf).map_err(|e| {
+            Error::Corruption(format!(
+                "string heap too short: need {} bytes at offset {offset}: {e}",
+                len
+            ))
+        })?;
+        Ok(buf)
     }
 
     // ── Value encode / decode with overflow support ───────────────────────────

--- a/crates/sparrowdb/tests/spa_208_string_heap.rs
+++ b/crates/sparrowdb/tests/spa_208_string_heap.rs
@@ -1,0 +1,146 @@
+//! Regression tests for GitHub issue #208 / SPA-208: read_from_string_heap
+//! must not load the entire strings.bin into RAM.
+//!
+//! The original implementation used `fs::read(path)` which loads the full heap
+//! file into memory. The fix replaces this with `File::seek + read_exact` so
+//! only the `len` bytes at `offset` are loaded, regardless of heap size.
+//!
+//! These tests verify the fix is functionally correct end-to-end by exercising
+//! the Cypher interface (which routes through `encode_value` / `decode_raw_value`
+//! and ultimately `read_from_string_heap` for any overflow string).
+
+use sparrowdb::open;
+use sparrowdb_execution::types::Value;
+
+fn make_db() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+/// Basic round-trip: write a short overflow string (> 7 bytes) and read it back.
+#[test]
+fn string_roundtrip_basic() {
+    let (_dir, db) = make_db();
+    db.execute("CREATE (n:Thing {name: 'HelloWorld'})").unwrap();
+    let result = db
+        .execute("MATCH (n:Thing) RETURN n.name")
+        .expect("MATCH RETURN");
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(
+        result.rows[0][0],
+        Value::String("HelloWorld".to_string()),
+        "10-byte overflow string must round-trip intact (SPA-208)"
+    );
+}
+
+/// A string stored at heap offset 0 must be read correctly (no off-by-one on zero).
+#[test]
+fn string_zero_value_not_confused() {
+    let (_dir, db) = make_db();
+    // This is the first string written, so it will land at offset 0 in strings.bin.
+    db.execute("CREATE (n:First {val: 'OffsetZeroTest'})").unwrap();
+    let result = db
+        .execute("MATCH (n:First) RETURN n.val")
+        .expect("MATCH RETURN");
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(
+        result.rows[0][0],
+        Value::String("OffsetZeroTest".to_string()),
+        "String at heap offset 0 must round-trip correctly (SPA-208)"
+    );
+}
+
+/// Write 100 distinct overflow strings; read them back in insertion order.
+/// This exercises multiple heap entries without full-file loads per read.
+#[test]
+fn multiple_strings_independent() {
+    let (_dir, db) = make_db();
+
+    // Write 100 distinct strings that all exceed the 7-byte inline limit.
+    for i in 0u32..100 {
+        db.execute(&format!(
+            "CREATE (n:Item {{id: {i}, label: 'overflow-string-{i:04}'}})"
+        ))
+        .unwrap();
+    }
+
+    let result = db
+        .execute("MATCH (n:Item) RETURN n.id, n.label ORDER BY n.id")
+        .expect("MATCH RETURN");
+    assert_eq!(
+        result.rows.len(),
+        100,
+        "All 100 nodes must be returned (SPA-208)"
+    );
+    for (i, row) in result.rows.iter().enumerate() {
+        let expected_label = format!("overflow-string-{i:04}");
+        assert_eq!(
+            row[1],
+            Value::String(expected_label.clone()),
+            "Row {i}: expected '{expected_label}', got {:?} (SPA-208)",
+            row[1]
+        );
+    }
+}
+
+/// A string written after many others lives at a high heap offset; it must
+/// still be read back correctly (seek to arbitrary offsets, not just the start).
+#[test]
+fn long_string_seek_not_full_load() {
+    let (_dir, db) = make_db();
+
+    // Push a bunch of strings into the heap first to advance the write pointer.
+    for i in 0u32..50 {
+        db.execute(&format!(
+            "CREATE (n:Filler {{val: 'filler-data-padding-{i:04}'}})"
+        ))
+        .unwrap();
+    }
+
+    // Write the target string that lands deep in the heap.
+    db.execute("CREATE (n:Target {val: 'DeepHeapOffsetValue'})")
+        .unwrap();
+
+    let result = db
+        .execute("MATCH (n:Target) RETURN n.val")
+        .expect("MATCH RETURN");
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(
+        result.rows[0][0],
+        Value::String("DeepHeapOffsetValue".to_string()),
+        "String at high heap offset must be read correctly via seek (SPA-208)"
+    );
+}
+
+/// An empty string (0 bytes) stored as an overflow value must round-trip as an
+/// empty string without corrupting adjacent heap entries.
+#[test]
+fn empty_string_roundtrip() {
+    let (_dir, db) = make_db();
+
+    // Empty strings are inline (0 bytes < 7-byte limit), so pair with a real
+    // overflow string before and after to exercise heap adjacency.
+    db.execute("CREATE (n:Before {val: 'before-boundary'})").unwrap();
+    db.execute("CREATE (n:Empty  {val: ''})").unwrap();
+    db.execute("CREATE (n:After  {val: 'after-boundary-ok'})").unwrap();
+
+    let before = db
+        .execute("MATCH (n:Before) RETURN n.val")
+        .expect("before");
+    assert_eq!(before.rows[0][0], Value::String("before-boundary".into()));
+
+    let empty = db
+        .execute("MATCH (n:Empty) RETURN n.val")
+        .expect("empty");
+    assert_eq!(
+        empty.rows[0][0],
+        Value::String(String::new()),
+        "Empty string must round-trip as empty (SPA-208)"
+    );
+
+    let after = db
+        .execute("MATCH (n:After) RETURN n.val")
+        .expect("after");
+    assert_eq!(after.rows[0][0], Value::String("after-boundary-ok".into()));
+}


### PR DESCRIPTION
## **User description**
## Problem
`read_from_string_heap` called `fs::read(path)` loading the entire `strings.bin` into RAM. On a 10 GB heap, every string property access would OOM.

## Fix
Replace with `File::seek(SeekFrom::Start(offset)) + read_exact` — reads only the `len` bytes for the requested string, regardless of heap file size. The (offset: u40, len: u16) metadata was already encoded in the tagged `u64` pointer; no storage format changes needed.

## Test plan
- [x] `string_roundtrip_basic` — write and read back a short overflow string
- [x] `string_zero_value_not_confused` — string at heap offset 0 works correctly
- [x] `multiple_strings_independent` — write 100 strings, read them all back in order
- [x] `long_string_seek_not_full_load` — string written after many others (high offset) reads correctly
- [x] `empty_string_roundtrip` — empty string handled, heap adjacency not corrupted

All 5 tests pass. Full `sparrowdb-storage` test suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Read long stored strings without loading the whole file into memory**

### What Changed
- Reading a stored string now pulls only that string’s bytes from disk, instead of loading the entire string heap file first
- Large databases can return stored strings without running out of memory
- Added regression tests for short strings, strings at the start of the heap, many stored strings, high-offset strings, and empty strings

### Impact
`✅ Fewer out-of-memory failures when reading large stored strings`
`✅ Reliable access to strings in large databases`
`✅ Safer string read behavior across edge cases`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized string data retrieval to reduce memory usage and improve efficiency.

* **Bug Fixes**
  * Enhanced error detection and handling for corrupted storage data.

* **Tests**
  * Added comprehensive regression tests for string storage and retrieval accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->