### PR TITLE
perf(storage): PageStore pread/pwrite — SPA-209

### DIFF
--- a/crates/sparrowdb-storage/src/lib.rs
+++ b/crates/sparrowdb-storage/src/lib.rs
@@ -27,9 +27,8 @@ pub mod text_index;
 /// Edge delta log and CSR rebuild on checkpoint.
 pub mod edge_store;
 
-use std::io::{Read as IoRead, Seek, SeekFrom, Write as IoWrite};
+use std::os::unix::fs::FileExt;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
 
 use sparrowdb_common::{Error, PageId, Result};
 
@@ -100,7 +99,11 @@ pub fn crc32_zeroed_at(
 /// accidentally decoded as raw pages (sizes won't align).
 pub struct PageStore {
     /// The backing data file.
-    file: Mutex<std::fs::File>,
+    ///
+    /// `pread`/`pwrite` (`FileExt::read_exact_at` / `write_all_at`) are
+    /// used for all I/O so the file descriptor is never mutated (no seek
+    /// cursor movement).  This makes concurrent reads safe without a mutex.
+    file: std::fs::File,
     /// Logical page size in bytes (plaintext).
     page_size: usize,
     /// The encryption context — passthrough if no key was provided.
@@ -142,7 +145,7 @@ impl PageStore {
             .truncate(false)
             .open(path)?;
         Ok(PageStore {
-            file: Mutex::new(file),
+            file,
             page_size,
             enc,
             _path: path.to_path_buf(),
@@ -185,10 +188,7 @@ impl PageStore {
         };
 
         let mut on_disk_buf = vec![0u8; on_disk_size];
-        let mut file = self.file.lock().expect("page store lock poisoned");
-        file.seek(SeekFrom::Start(offset))?;
-        file.read_exact(&mut on_disk_buf)?;
-        drop(file);
+        self.file.read_exact_at(&mut on_disk_buf, offset)?;
 
         if self.enc.is_encrypted() {
             let plaintext = self.enc.decrypt_page(id.0, &on_disk_buf)?;
@@ -223,16 +223,13 @@ impl PageStore {
         };
 
         let offset = self.page_offset(id);
-        let mut file = self.file.lock().expect("page store lock poisoned");
-        file.seek(SeekFrom::Start(offset))?;
-        file.write_all(&on_disk_data)?;
+        self.file.write_all_at(&on_disk_data, offset)?;
         Ok(())
     }
 
     /// Flush and fsync the backing file to durable storage.
     pub fn fsync(&self) -> Result<()> {
-        let file = self.file.lock().expect("page store lock poisoned");
-        file.sync_all()?;
+        self.file.sync_all()?;
         Ok(())
     }
 }


### PR DESCRIPTION
## **User description**
## Summary

- Removes `Mutex<File>` from `PageStore`; the file field is now a bare `std::fs::File`
- Replaces all `seek + read_exact` calls with `FileExt::read_exact_at` (pread64)
- Replaces all `seek + write_all` calls with `FileExt::write_all_at` (pwrite64)
- `fsync` now calls `sync_all` directly on the bare `File` without acquiring a lock

Because `pread`/`pwrite` never move the file-descriptor cursor, concurrent reads
from multiple threads are safe without any serialisation — eliminating per-page
lock contention on the hot read path.

Closes #209

## Test plan

- [x] `cargo check -p sparrowdb` — zero errors
- [x] `cargo test -p sparrowdb-storage` — all 15 tests pass (page store roundtrips, encryption, WAL, crash failpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Remove page-store lock contention during reads and writes**

### What Changed
- Page reads and writes no longer take a shared lock, so multiple threads can access pages at the same time
- File flushes now run directly on the open file without waiting on the old lock
- Page data still uses the same encrypted or plain storage format

### Impact
`✅ Faster multi-threaded page reads`
`✅ Lower write delays under load`
`✅ Fewer storage lock stalls`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
