### PR TITLE
feat(db): GraphDump export/import for cross-version migration

### DIFF
--- a/crates/sparrowdb/src/export.rs
+++ b/crates/sparrowdb/src/export.rs
@@ -1,0 +1,429 @@
+//! Graph export / import tooling for cross-version migration (SPA-XXX).
+//!
+//! Provides [`GraphDump`], [`NodeDump`], and [`EdgeDump`] for serialising the
+//! full contents of a [`super::GraphDb`] to JSON, and re-importing that JSON
+//! into a (possibly new / freshly-opened) database.
+//!
+//! ## Workflow
+//!
+//! ```text
+//! // Old version
+//! let json = old_db.export_json()?;
+//!
+//! // New version (fresh directory)
+//! let new_db = GraphDb::open(new_path)?;
+//! new_db.import_json(&json)?;
+//! ```
+
+use std::collections::HashMap;
+
+use sparrowdb_common::col_id_of;
+
+use crate::{GraphDb, Result};
+
+// ── Public dump types ─────────────────────────────────────────────────────────
+
+/// A single node extracted from the database during export.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct NodeDump {
+    /// The node's internal ID in the *source* database.
+    pub node_id: u64,
+    /// The node's label (single label per node in SparrowDB).
+    pub label: String,
+    /// All stored properties, keyed by property name.
+    pub properties: HashMap<String, serde_json::Value>,
+}
+
+/// A single directed edge extracted from the database during export.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct EdgeDump {
+    /// Internal node ID of the source node (from the *source* database).
+    pub src_id: u64,
+    /// Internal node ID of the destination node (from the *source* database).
+    pub dst_id: u64,
+    /// Relationship type name (e.g. `"KNOWS"`).
+    pub rel_type: String,
+    /// Edge properties (currently empty; reserved for future use).
+    pub properties: HashMap<String, serde_json::Value>,
+}
+
+/// A complete serialisable snapshot of a SparrowDB graph.
+///
+/// Produced by [`GraphDb::export`] and consumed by [`GraphDb::import`].
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct GraphDump {
+    /// The SparrowDB crate version that produced this dump.
+    pub sparrowdb_version: String,
+    /// Unix timestamp (seconds since epoch) when the dump was created.
+    pub exported_at: u64,
+    /// All nodes in the graph.
+    pub nodes: Vec<NodeDump>,
+    /// All directed edges in the graph.
+    pub edges: Vec<EdgeDump>,
+}
+
+// ── Export ────────────────────────────────────────────────────────────────────
+
+impl GraphDb {
+    /// Export all nodes and edges to a [`GraphDump`].
+    ///
+    /// The dump is a point-in-time snapshot: it captures all data committed
+    /// at or before the moment of the call.  Concurrent writers may cause the
+    /// node and edge sets to be slightly inconsistent; for a fully consistent
+    /// snapshot call [`GraphDb::checkpoint`] first.
+    pub fn export(&self) -> Result<GraphDump> {
+        // ── 1. Collect schema: label_name → [prop_names] ──────────────────
+        let schema_result = self.execute("CALL db.schema()")?;
+
+        // Build: label_name → Vec<prop_name>
+        let mut label_props: HashMap<String, Vec<String>> = HashMap::new();
+        for row in &schema_result.rows {
+            use sparrowdb_execution::types::Value;
+            let kind = match &row[0] {
+                Value::String(s) => s.as_str(),
+                _ => continue,
+            };
+            if kind != "node" {
+                continue;
+            }
+            let label = match &row[1] {
+                Value::String(s) => s.clone(),
+                _ => continue,
+            };
+            let props: Vec<String> = match &row[2] {
+                Value::List(items) => items
+                    .iter()
+                    .filter_map(|v| {
+                        if let Value::String(s) = v {
+                            Some(s.clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect(),
+                _ => vec![],
+            };
+            label_props.insert(label, props);
+        }
+
+        // Build reverse lookup: col_id (u32) → prop_name, per label.
+        // Since col_id = FNV(prop_name), we compute the mapping once globally
+        // (collisions across labels are theoretically possible but vanishingly
+        // rare in practice — the FNV hash space is 2^32).
+        let mut col_id_to_name: HashMap<u32, String> = HashMap::new();
+        for props in label_props.values() {
+            for prop_name in props {
+                let cid = col_id_of(prop_name);
+                col_id_to_name.insert(cid, prop_name.clone());
+            }
+        }
+
+        // ── 2. Export all labels listed in the catalog ────────────────────
+        let catalog = self.catalog_snapshot();
+        let all_labels = catalog.list_labels()?;
+
+        let mut nodes: Vec<NodeDump> = Vec::new();
+
+        for (_label_id, label_name) in &all_labels {
+            // Skip the internal __SparrowSid migration label if present.
+            if label_name.starts_with("__Sparrow") {
+                continue;
+            }
+
+            let query = format!("MATCH (n:{label_name}) RETURN id(n), n");
+            let result = match self.execute(&query) {
+                Ok(r) => r,
+                Err(_) => continue, // skip labels with no nodes
+            };
+
+            for row in &result.rows {
+                use sparrowdb_execution::types::Value;
+
+                let node_id = match &row[0] {
+                    Value::Int64(i) => *i as u64,
+                    _ => continue,
+                };
+
+                // row[1] is a Value::Map with "col_{col_id}" keys.
+                let props_map = match &row[1] {
+                    Value::Map(entries) => entries,
+                    _ => {
+                        // Node with no properties — still export it.
+                        nodes.push(NodeDump {
+                            node_id,
+                            label: label_name.clone(),
+                            properties: HashMap::new(),
+                        });
+                        continue;
+                    }
+                };
+
+                let mut properties: HashMap<String, serde_json::Value> = HashMap::new();
+                for (col_key, val) in props_map {
+                    // col_key is "col_{col_id}", e.g. "col_3735928559"
+                    let prop_name = if let Some(suffix) = col_key.strip_prefix("col_") {
+                        if let Ok(cid) = suffix.parse::<u32>() {
+                            col_id_to_name
+                                .get(&cid)
+                                .cloned()
+                                .unwrap_or_else(|| col_key.clone())
+                        } else {
+                            col_key.clone()
+                        }
+                    } else {
+                        col_key.clone()
+                    };
+
+                    let json_val = execution_value_to_json(val);
+                    if json_val != serde_json::Value::Null {
+                        properties.insert(prop_name, json_val);
+                    }
+                }
+
+                nodes.push(NodeDump {
+                    node_id,
+                    label: label_name.clone(),
+                    properties,
+                });
+            }
+        }
+
+        // ── 3. Export edges from storage (delta log + CSR) ────────────────
+        // This mirrors the approach used in `to_dot` to avoid Cypher engine
+        // limitations around id(a) / id(b) in hop patterns.
+        let path = &self.inner.path;
+        let rel_tables = catalog.list_rel_tables_with_ids();
+        let mut edges: Vec<EdgeDump> = Vec::new();
+        // Deduplicate: delta log edges may also appear in CSR after checkpoint.
+        let mut seen: std::collections::HashSet<(u64, u64, String)> =
+            std::collections::HashSet::new();
+
+        for (catalog_id, src_label_id, dst_label_id, rel_type) in &rel_tables {
+            let storage_rel_id =
+                sparrowdb_storage::edge_store::RelTableId(*catalog_id as u32);
+
+            if let Ok(store) =
+                sparrowdb_storage::edge_store::EdgeStore::open(path, storage_rel_id)
+            {
+                // Delta log — stores full NodeId pairs (label_id << 32 | slot).
+                if let Ok(records) = store.read_delta() {
+                    for rec in records {
+                        let key = (rec.src.0, rec.dst.0, rel_type.clone());
+                        if seen.insert(key) {
+                            edges.push(EdgeDump {
+                                src_id: rec.src.0,
+                                dst_id: rec.dst.0,
+                                rel_type: rel_type.clone(),
+                                properties: HashMap::new(),
+                            });
+                        }
+                    }
+                }
+
+                // CSR — (src_slot, dst_slot) relative to their label IDs.
+                if let Ok(csr) = store.open_fwd() {
+                    let n_nodes = csr.n_nodes();
+                    for src_slot in 0..n_nodes {
+                        let src_id = (*src_label_id as u64) << 32 | src_slot;
+                        for &dst_slot in csr.neighbors(src_slot) {
+                            let dst_id = (*dst_label_id as u64) << 32 | dst_slot;
+                            let key = (src_id, dst_id, rel_type.clone());
+                            if seen.insert(key) {
+                                edges.push(EdgeDump {
+                                    src_id,
+                                    dst_id,
+                                    rel_type: rel_type.clone(),
+                                    properties: HashMap::new(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let exported_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        Ok(GraphDump {
+            sparrowdb_version: env!("CARGO_PKG_VERSION").to_owned(),
+            exported_at,
+            nodes,
+            edges,
+        })
+    }
+
+    /// Serialize the full graph to a pretty-printed JSON string.
+    ///
+    /// Convenience wrapper around [`export`](Self::export) +
+    /// [`serde_json::to_string_pretty`].
+    pub fn export_json(&self) -> Result<String> {
+        let dump = self.export()?;
+        serde_json::to_string_pretty(&dump)
+            .map_err(|e| sparrowdb_common::Error::InvalidArgument(e.to_string()))
+    }
+
+    /// Re-create all nodes and edges from a [`GraphDump`].
+    ///
+    /// This is the inverse of [`export`](Self::export).  It is safe to call on
+    /// a non-empty database — imported nodes will be **added** to any existing
+    /// data (no deduplication is performed).
+    ///
+    /// ## Node identity during import
+    ///
+    /// Because SparrowDB auto-assigns node IDs, the original `node_id` values
+    /// from the dump cannot be preserved.  A temporary property
+    /// `_sparrow_export_id` is written to each node during import to allow
+    /// edges to be wired correctly, and is **left in place** after import.
+    /// Callers may remove it at the application layer if desired (e.g. with a
+    /// future `REMOVE` Cypher clause once that is supported).
+    pub fn import(&self, dump: &GraphDump) -> Result<()> {
+        // ── 1. Build a label lookup from the node list ────────────────────
+        // Maps original node_id → label name (needed when wiring edges).
+        let mut node_label: HashMap<u64, String> = HashMap::new();
+        for n in &dump.nodes {
+            node_label.insert(n.node_id, n.label.clone());
+        }
+
+        // ── 2. Create all nodes ───────────────────────────────────────────
+        for node in &dump.nodes {
+            let props_cypher = build_props_cypher(&node.properties, Some(node.node_id));
+            let label = cypher_escape_label(&node.label);
+            let query = format!("CREATE (n:{label} {{{props_cypher}}})");
+            self.execute(&query)?;
+        }
+
+        // ── 3. Wire edges ─────────────────────────────────────────────────
+        // Look up source and destination nodes by the temporary `_sparrow_export_id`
+        // property we stamped during node creation.
+        for edge in &dump.edges {
+            let src_label = match node_label.get(&edge.src_id) {
+                Some(l) => cypher_escape_label(l),
+                None => continue, // orphan edge — skip
+            };
+            let dst_label = match node_label.get(&edge.dst_id) {
+                Some(l) => cypher_escape_label(l),
+                None => continue,
+            };
+            let rel_type = cypher_escape_label(&edge.rel_type);
+            let src_sid = edge.src_id;
+            let dst_sid = edge.dst_id;
+            let query = format!(
+                "MATCH (a:{src_label} {{_sparrow_export_id: '{src_sid}'}}), \
+                 (b:{dst_label} {{_sparrow_export_id: '{dst_sid}'}}) \
+                 CREATE (a)-[:{rel_type}]->(b)"
+            );
+            self.execute(&query)?;
+        }
+
+        Ok(())
+    }
+
+    /// Deserialise a [`GraphDump`] from JSON and import it.
+    ///
+    /// Convenience wrapper around [`import`](Self::import) +
+    /// [`serde_json::from_str`].
+    pub fn import_json(&self, json: &str) -> Result<()> {
+        let dump: GraphDump = serde_json::from_str(json)
+            .map_err(|e| sparrowdb_common::Error::InvalidArgument(e.to_string()))?;
+        self.import(&dump)
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Convert an execution-layer [`Value`] to a [`serde_json::Value`].
+fn execution_value_to_json(val: &sparrowdb_execution::types::Value) -> serde_json::Value {
+    use sparrowdb_execution::types::Value;
+    match val {
+        Value::Null => serde_json::Value::Null,
+        Value::Int64(i) => serde_json::json!(*i),
+        Value::Float64(f) => serde_json::json!(*f),
+        Value::Bool(b) => serde_json::json!(*b),
+        Value::String(s) => serde_json::json!(s),
+        Value::NodeRef(nid) => serde_json::json!(nid.0),
+        Value::EdgeRef(eid) => serde_json::json!(eid.0),
+        Value::List(items) => {
+            serde_json::Value::Array(items.iter().map(execution_value_to_json).collect())
+        }
+        Value::Map(entries) => {
+            let obj: serde_json::Map<String, serde_json::Value> = entries
+                .iter()
+                .map(|(k, v)| (k.clone(), execution_value_to_json(v)))
+                .collect();
+            serde_json::Value::Object(obj)
+        }
+    }
+}
+
+/// Build the inline properties string for a Cypher `CREATE` statement.
+///
+/// Always injects `_sparrow_export_id` set to the original node_id so that
+/// edges can be wired during import.
+fn build_props_cypher(
+    props: &HashMap<String, serde_json::Value>,
+    sid: Option<u64>,
+) -> String {
+    let mut parts: Vec<String> = Vec::new();
+
+    if let Some(id) = sid {
+        parts.push(format!("_sparrow_export_id: '{id}'"));
+    }
+
+    for (key, val) in props {
+        // Skip the migration key if the source already had it.
+        if key == "_sparrow_export_id" {
+            continue;
+        }
+        let esc_key = cypher_escape_identifier(key);
+        let val_str = json_val_to_cypher_literal(val);
+        parts.push(format!("{esc_key}: {val_str}"));
+    }
+
+    parts.join(", ")
+}
+
+/// Render a JSON value as a Cypher inline literal.
+fn json_val_to_cypher_literal(val: &serde_json::Value) -> String {
+    match val {
+        serde_json::Value::Null => "null".to_owned(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::String(s) => {
+            // Escape single quotes inside the string.
+            let escaped = s.replace('\\', "\\\\").replace('\'', "\\'");
+            format!("'{escaped}'")
+        }
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
+            // Nested collections: serialise as a JSON string and store as string.
+            let s = val.to_string();
+            let escaped = s.replace('\\', "\\\\").replace('\'', "\\'");
+            format!("'{escaped}'")
+        }
+    }
+}
+
+/// Escape a label or relationship type name for use in a Cypher query.
+/// Backtick-quotes the name if it contains special characters.
+fn cypher_escape_label(name: &str) -> String {
+    if name.chars().all(|c| c.is_alphanumeric() || c == '_') {
+        name.to_owned()
+    } else {
+        format!("`{}`", name.replace('`', "``"))
+    }
+}
+
+/// Escape a property key identifier.
+fn cypher_escape_identifier(name: &str) -> String {
+    if name
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '_')
+        && !name.is_empty()
+    {
+        name.to_owned()
+    } else {
+        format!("`{}`", name.replace('`', "``"))
+    }
+}

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -35,6 +35,10 @@ use sparrowdb_catalog::catalog::Catalog;
 use sparrowdb_common::{col_id_of, TxnId};
 use sparrowdb_execution::Engine;
 
+// ── Export / import module ────────────────────────────────────────────────────
+pub mod export;
+pub use export::{EdgeDump, GraphDump, NodeDump};
+
 // ── Public re-exports ─────────────────────────────────────────────────────────
 //
 // Re-export the types that consumers of the top-level `sparrowdb` crate need

--- a/crates/sparrowdb/tests/export_import.rs
+++ b/crates/sparrowdb/tests/export_import.rs
@@ -1,0 +1,204 @@
+//! Integration tests for GraphDb::export_json / import_json — SPA-XXX.
+//!
+//! Verifies that a graph snapshot can be serialised to JSON and re-imported
+//! into a fresh database with full fidelity for nodes and edges.
+
+use sparrowdb::{open, GraphDump};
+use sparrowdb_execution::Value;
+
+fn make_db() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 1: Export produces valid JSON with correct structure
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `export_json()` must return valid JSON that deserialises into a `GraphDump`
+/// with the right node/edge counts and metadata fields.
+#[test]
+fn export_json_produces_valid_structure() {
+    let (_dir, db) = make_db();
+
+    // Create 2 Person nodes and 1 Company node.
+    db.execute("CREATE (n:Person {name: 'Alice', age: 30})")
+        .expect("CREATE Alice");
+    db.execute("CREATE (n:Person {name: 'Bob', age: 25})")
+        .expect("CREATE Bob");
+    db.execute("CREATE (n:Company {name: 'Acme'})")
+        .expect("CREATE Acme");
+
+    // Create 2 directed edges.
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) \
+         CREATE (a)-[:KNOWS]->(b)",
+    )
+    .expect("CREATE KNOWS");
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (c:Company {name: 'Acme'}) \
+         CREATE (a)-[:WORKS_AT]->(c)",
+    )
+    .expect("CREATE WORKS_AT");
+
+    // Export.
+    let json = db.export_json().expect("export_json must succeed");
+    assert!(!json.is_empty(), "JSON must not be empty");
+
+    // Deserialise and validate structure.
+    let dump: GraphDump = serde_json::from_str(&json).expect("must deserialise to GraphDump");
+
+    assert_eq!(
+        dump.sparrowdb_version,
+        env!("CARGO_PKG_VERSION"),
+        "version must match current crate version"
+    );
+    assert!(dump.exported_at > 0, "exported_at must be a non-zero timestamp");
+    assert_eq!(dump.nodes.len(), 3, "must export 3 nodes; got: {:?}", dump.nodes.len());
+    assert_eq!(dump.edges.len(), 2, "must export 2 edges; got: {:?}", dump.edges.len());
+
+    // Check node properties are present.
+    let alice = dump
+        .nodes
+        .iter()
+        .find(|n| n.label == "Person" && n.properties.get("name") == Some(&serde_json::json!("Alice")))
+        .expect("Alice node must be in dump");
+    assert_eq!(
+        alice.properties.get("age"),
+        Some(&serde_json::json!(30i64)),
+        "Alice age must be 30"
+    );
+
+    // Check edge types are present.
+    let edge_types: Vec<&str> = dump.edges.iter().map(|e| e.rel_type.as_str()).collect();
+    assert!(
+        edge_types.contains(&"KNOWS"),
+        "KNOWS edge must be present; edges: {:?}",
+        dump.edges
+    );
+    assert!(
+        edge_types.contains(&"WORKS_AT"),
+        "WORKS_AT edge must be present; edges: {:?}",
+        dump.edges
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 2: Full round-trip — export then import into fresh DB
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// After `import_json(export_json())`, the new database must contain the same
+/// 3 nodes (with labels and properties) and 2 edges (with rel types).
+#[test]
+fn round_trip_export_import() {
+    // ── Source database ───────────────────────────────────────────────────
+    let (_src_dir, src_db) = make_db();
+
+    src_db
+        .execute("CREATE (n:Person {name: 'Alice', score: 42})")
+        .expect("CREATE Alice");
+    src_db
+        .execute("CREATE (n:Person {name: 'Bob', score: 7})")
+        .expect("CREATE Bob");
+    src_db
+        .execute("CREATE (n:Company {name: 'Sparrow Inc'})")
+        .expect("CREATE Sparrow Inc");
+
+    src_db
+        .execute(
+            "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) \
+             CREATE (a)-[:KNOWS]->(b)",
+        )
+        .expect("CREATE KNOWS");
+    src_db
+        .execute(
+            "MATCH (a:Person {name: 'Bob'}), (c:Company {name: 'Sparrow Inc'}) \
+             CREATE (a)-[:WORKS_AT]->(c)",
+        )
+        .expect("CREATE WORKS_AT");
+
+    let json = src_db.export_json().expect("export_json");
+
+    // ── Destination database ──────────────────────────────────────────────
+    let (_dst_dir, dst_db) = make_db();
+    dst_db.import_json(&json).expect("import_json must succeed");
+
+    // ── Verify node count per label ───────────────────────────────────────
+    let persons = dst_db
+        .execute("MATCH (n:Person) RETURN n.name")
+        .expect("query persons");
+    assert_eq!(
+        persons.rows.len(),
+        2,
+        "must have 2 Person nodes; got: {:?}",
+        persons.rows
+    );
+
+    let companies = dst_db
+        .execute("MATCH (n:Company) RETURN n.name")
+        .expect("query companies");
+    assert_eq!(
+        companies.rows.len(),
+        1,
+        "must have 1 Company node; got: {:?}",
+        companies.rows
+    );
+
+    // ── Verify a specific property value ──────────────────────────────────
+    let alice_result = dst_db
+        .execute("MATCH (n:Person {name: 'Alice'}) RETURN n.score")
+        .expect("query Alice score");
+    assert_eq!(
+        alice_result.rows.len(),
+        1,
+        "Alice must exist in imported DB"
+    );
+    assert_eq!(
+        alice_result.rows[0][0],
+        Value::Int64(42),
+        "Alice score must be 42; got: {:?}",
+        alice_result.rows[0][0]
+    );
+
+    // ── Verify edge count and types ───────────────────────────────────────
+    let knows_edges = dst_db
+        .execute("MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN a.name, b.name")
+        .expect("query KNOWS edges");
+    assert_eq!(
+        knows_edges.rows.len(),
+        1,
+        "must have 1 KNOWS edge; got: {:?}",
+        knows_edges.rows
+    );
+
+    let works_edges = dst_db
+        .execute("MATCH (a:Person)-[:WORKS_AT]->(b:Company) RETURN a.name, b.name")
+        .expect("query WORKS_AT edges");
+    assert_eq!(
+        works_edges.rows.len(),
+        1,
+        "must have 1 WORKS_AT edge; got: {:?}",
+        works_edges.rows
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 3: Empty database exports and imports cleanly
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn empty_db_round_trip() {
+    let (_dir, db) = make_db();
+
+    let json = db.export_json().expect("export_json on empty DB must succeed");
+    let dump: GraphDump =
+        serde_json::from_str(&json).expect("empty dump must deserialise");
+
+    assert_eq!(dump.nodes.len(), 0, "empty DB must have 0 nodes");
+    assert_eq!(dump.edges.len(), 0, "empty DB must have 0 edges");
+
+    // Import into a fresh DB — must succeed without errors.
+    let (_dst_dir, dst_db) = make_db();
+    dst_db.import_json(&json).expect("import of empty dump must succeed");
+}


### PR DESCRIPTION
## **User description**
## Summary

- Adds `GraphDb::export_json()` and `import_json()` (and their underlying `export()`/`import()` methods) to serialise/restore the full graph as JSON
- Enables migration when on-disk formats change between SparrowDB versions (e.g. WAL format break in 0.1.5). Closes migration gap reported by SparrowOntology (msg #67)
- Exposes three new public types: `GraphDump`, `NodeDump`, `EdgeDump` (all `serde::Serialize + Deserialize`)

## Implementation details

- **Export nodes**: uses `CALL db.schema()` to resolve `col_{hash}` keys back to human-readable property names, then `MATCH (n:Label) RETURN id(n), n` per label
- **Export edges**: reads delta log + CSR directly (same strategy as `to_dot`), with deduplication across the two sources
- **Import nodes**: injects `_sparrow_export_id` as a temporary property to allow edge wiring without relying on preserved node IDs
- **Import edges**: uses `MATCH (a:SrcLabel {_sparrow_export_id: 'X'}), (b:DstLabel {_sparrow_export_id: 'Y'}) CREATE (a)-[:REL]->(b)`
- `cargo check -p sparrowdb` produces zero errors

## Test plan

- [ ] `cargo test --test export_import` — 3 tests, all green
  - `empty_db_round_trip` — export/import of empty database
  - `export_json_produces_valid_structure` — validates JSON metadata, node count, edge count, property values
  - `round_trip_export_import` — full fidelity check: 3 nodes (2 labels), 2 edges, specific property values verified in destination DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add JSON export and import for full graph migration**

### What Changed
- You can now export an entire graph to JSON and import it into a fresh database
- Export includes all nodes, edges, labels, properties, and dump metadata such as version and export time
- Import restores the graph structure and keeps edges connected after reloading, even across database versions
- Empty databases now export and import cleanly

### Impact
`✅ Cross-version graph migration`
`✅ Safer database upgrades`
`✅ Fewer manual rebuilds after data format changes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
