### PR TITLE
perf(db): single fsync for batch mutations — closes #223

### DIFF
--- a/crates/sparrowdb/src/export.rs
+++ b/crates/sparrowdb/src/export.rs
@@ -279,6 +279,14 @@ impl GraphDb {
     /// edges to be wired correctly, and is **left in place** after import.
     /// Callers may remove it at the application layer if desired (e.g. with a
     /// future `REMOVE` Cypher clause once that is supported).
+    ///
+    /// ## Performance (SPA-223)
+    ///
+    /// Node creation and edge wiring each use [`execute_batch`](Self::execute_batch)
+    /// so that all mutations in each phase commit with a **single WAL fsync**
+    /// rather than one fsync per node/edge.  A 100-node import therefore
+    /// requires 2 fsyncs (one for the node batch, one for the edge batch)
+    /// instead of O(N) fsyncs.
     pub fn import(&self, dump: &GraphDump) -> Result<()> {
         // ── 1. Build a label lookup from the node list ────────────────────
         // Maps original node_id → label name (needed when wiring edges).
@@ -287,35 +295,47 @@ impl GraphDb {
             node_label.insert(n.node_id, n.label.clone());
         }
 
-        // ── 2. Create all nodes ───────────────────────────────────────────
-        for node in &dump.nodes {
-            let props_cypher = build_props_cypher(&node.properties, Some(node.node_id));
-            let label = cypher_escape_label(&node.label);
-            let query = format!("CREATE (n:{label} {{{props_cypher}}})");
-            self.execute(&query)?;
+        // ── 2. Create all nodes in a single batch (one WAL fsync) ─────────
+        // SPA-223: build all CREATE queries up front and submit them via
+        // execute_batch so the entire node set is committed with one fsync.
+        if !dump.nodes.is_empty() {
+            let node_queries: Vec<String> = dump
+                .nodes
+                .iter()
+                .map(|node| {
+                    let props_cypher = build_props_cypher(&node.properties, Some(node.node_id));
+                    let label = cypher_escape_label(&node.label);
+                    format!("CREATE (n:{label} {{{props_cypher}}})")
+                })
+                .collect();
+            let node_refs: Vec<&str> = node_queries.iter().map(String::as_str).collect();
+            self.execute_batch(&node_refs)?;
         }
 
-        // ── 3. Wire edges ─────────────────────────────────────────────────
+        // ── 3. Wire edges in a single batch (one WAL fsync) ───────────────
         // Look up source and destination nodes by the temporary `_sparrow_export_id`
         // property we stamped during node creation.
-        for edge in &dump.edges {
-            let src_label = match node_label.get(&edge.src_id) {
-                Some(l) => cypher_escape_label(l),
-                None => continue, // orphan edge — skip
-            };
-            let dst_label = match node_label.get(&edge.dst_id) {
-                Some(l) => cypher_escape_label(l),
-                None => continue,
-            };
-            let rel_type = cypher_escape_label(&edge.rel_type);
-            let src_sid = edge.src_id;
-            let dst_sid = edge.dst_id;
-            let query = format!(
-                "MATCH (a:{src_label} {{_sparrow_export_id: '{src_sid}'}}), \
-                 (b:{dst_label} {{_sparrow_export_id: '{dst_sid}'}}) \
-                 CREATE (a)-[:{rel_type}]->(b)"
-            );
-            self.execute(&query)?;
+        // SPA-223: collect all valid edge queries and submit them via
+        // execute_batch so the entire edge set commits with one fsync.
+        let edge_queries: Vec<String> = dump
+            .edges
+            .iter()
+            .filter_map(|edge| {
+                let src_label = cypher_escape_label(node_label.get(&edge.src_id)?);
+                let dst_label = cypher_escape_label(node_label.get(&edge.dst_id)?);
+                let rel_type = cypher_escape_label(&edge.rel_type);
+                let src_sid = edge.src_id;
+                let dst_sid = edge.dst_id;
+                Some(format!(
+                    "MATCH (a:{src_label} {{_sparrow_export_id: '{src_sid}'}}), \
+                     (b:{dst_label} {{_sparrow_export_id: '{dst_sid}'}}) \
+                     CREATE (a)-[:{rel_type}]->(b)"
+                ))
+            })
+            .collect();
+        if !edge_queries.is_empty() {
+            let edge_refs: Vec<&str> = edge_queries.iter().map(String::as_str).collect();
+            self.execute_batch(&edge_refs)?;
         }
 
         Ok(())


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause**: `GraphDb::import()` called `self.execute()` in a loop for both node creation and edge wiring, causing one WAL `fsync` per mutation (O(N) fsyncs total)
- **Fix**: Replaced both loops with `execute_batch()` calls — all node mutations commit in one WAL fsync, all edge mutations commit in one WAL fsync
- **Result**: A 100-node/100-edge import goes from 200 fsyncs to 2 fsyncs (100× reduction for this workload)

## What changed

**`crates/sparrowdb/src/export.rs`** — `GraphDb::import()`:
- Node creation phase: builds all `CREATE` queries up-front, submits via `execute_batch()` (1 fsync)
- Edge wiring phase: builds all `MATCH … CREATE` queries up-front, submits via `execute_batch()` (1 fsync)
- Empty node/edge sets are skipped to avoid no-op batch calls

`execute_batch()` already existed and was already correctly implemented with single-fsync semantics (SPA-250 benchmark also documents this). The import path was simply not using it.

## Fsync count estimate (100-node init)

| Scenario | Before | After |
|---|---|---|
| 100 nodes, 0 edges | 100 fsyncs | 1 fsync |
| 100 nodes, 100 edges | 200 fsyncs | 2 fsyncs |
| N nodes, E edges | N+E fsyncs | ≤2 fsyncs |

## Test plan

- [x] `cargo check -p sparrowdb` — zero errors
- [x] All sparrowdb test suites pass (200+ tests across 20 test binaries)
- [x] Pre-existing compat fixture failures (`spa_119_compat_fixture`) confirmed pre-existing on main, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Import large graphs with far fewer disk writes**

### What Changed
- Import now saves all nodes in one batch and all edges in one batch, instead of writing each node or edge separately
- Empty node or edge groups are skipped, avoiding unnecessary work during import
- Import now keeps orphan edges out of the final graph, as before

### Impact
`✅ Faster graph imports`
`✅ Fewer import slowdowns on large datasets`
`✅ Less disk activity during bulk loads`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized data import performance by executing node and edge mutations as batched Cypher submissions instead of individual sequential operations. Edges are now filtered to exclude orphans before batch submission, reducing unnecessary query execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->