### PR TITLE
feat(api): delete_edge — removes a specific directed edge

### DIFF
--- a/crates/sparrowdb-storage/src/edge_store.rs
+++ b/crates/sparrowdb-storage/src/edge_store.rs
@@ -335,6 +335,53 @@ impl EdgeStore {
         Ok(())
     }
 
+    /// Remove the first delta-log record matching `(src, dst)` from this store.
+    ///
+    /// The delta log is rewritten in-place with the matching record excised.
+    /// Returns [`Error::InvalidArgument`] if no such record exists.
+    ///
+    /// This is an O(n) operation proportional to the current delta log size.
+    /// For bulk deletions, prefer a CHECKPOINT after all deletions are staged.
+    pub fn delete_edge(&mut self, src: NodeId, dst: NodeId) -> Result<()> {
+        let mut records = self.read_delta()?;
+
+        // Find the first record that matches (src, dst); rel_id is implicit from
+        // the store's own rel_table_id.
+        let pos = records
+            .iter()
+            .position(|r| r.src == src && r.dst == dst)
+            .ok_or_else(|| {
+                Error::InvalidArgument(format!(
+                    "edge {src:?} → {dst:?} not found in rel_table {:?}",
+                    self.rel_table_id
+                ))
+            })?;
+
+        records.remove(pos);
+
+        // Rewrite the entire delta log without the removed record.
+        // Write to a temp file then rename for crash-safety.
+        let tmp_path = self.rel_dir.join("delta.log.tmp");
+        {
+            use std::io::Write as IoWrite;
+            let mut f = fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&tmp_path)
+                .map_err(Error::Io)?;
+            for r in &records {
+                f.write_all(&r.encode()).map_err(Error::Io)?;
+            }
+            f.flush().map_err(Error::Io)?;
+        }
+        fs::rename(&tmp_path, self.delta_path()).map_err(Error::Io)?;
+
+        // Update the in-memory counter to reflect the new record count.
+        self.next_edge_id = records.len() as u64;
+        Ok(())
+    }
+
     /// Open the CSR forward file written by [`checkpoint`].
     pub fn open_fwd(&self) -> Result<CsrForward> {
         CsrForward::open(&self.fwd_path())

--- a/crates/sparrowdb-storage/src/wal/codec.rs
+++ b/crates/sparrowdb-storage/src/wal/codec.rs
@@ -61,6 +61,8 @@ pub enum WalRecordKind {
     NodeDelete = 0x12,
     /// Create a new edge (Phase 7 mutation).
     EdgeCreate = 0x13,
+    /// Delete an existing edge (Phase 7 mutation).
+    EdgeDelete = 0x14,
 }
 
 impl WalRecordKind {
@@ -76,6 +78,7 @@ impl WalRecordKind {
             0x11 => Ok(Self::NodeUpdate),
             0x12 => Ok(Self::NodeDelete),
             0x13 => Ok(Self::EdgeCreate),
+            0x14 => Ok(Self::EdgeDelete),
             other => Err(Error::Corruption(format!(
                 "unknown WAL record kind: {other:#x}"
             ))),
@@ -138,6 +141,8 @@ pub enum WalPayload {
         rel_type: String,
         props: Vec<WalProp>,
     },
+    /// Phase 7 — a specific directed edge was deleted.
+    EdgeDelete { src: u64, dst: u64, rel_type: String },
 }
 
 // ── Payload encoding helpers ──────────────────────────────────────────────────
@@ -265,6 +270,13 @@ impl WalPayload {
                 buf
             }
             WalPayload::NodeDelete { node_id } => node_id.to_le_bytes().to_vec(),
+            WalPayload::EdgeDelete { src, dst, rel_type } => {
+                let mut buf = Vec::new();
+                buf.extend_from_slice(&src.to_le_bytes());
+                buf.extend_from_slice(&dst.to_le_bytes());
+                buf.extend_from_slice(&encode_str(rel_type));
+                buf
+            }
             WalPayload::EdgeCreate {
                 edge_id,
                 src,
@@ -317,7 +329,8 @@ impl WalPayload {
             WalRecordKind::NodeCreate
             | WalRecordKind::NodeUpdate
             | WalRecordKind::NodeDelete
-            | WalRecordKind::EdgeCreate => Self::decode_plaintext(kind, bytes),
+            | WalRecordKind::EdgeCreate
+            | WalRecordKind::EdgeDelete => Self::decode_plaintext(kind, bytes),
         }
     }
 
@@ -432,6 +445,16 @@ impl WalPayload {
                     rel_type,
                     props,
                 })
+            }
+            WalRecordKind::EdgeDelete => {
+                // src(8) + dst(8) + rel_type(variable)
+                if bytes.len() < 16 {
+                    return Err(Error::Corruption("EdgeDelete payload too short".into()));
+                }
+                let src = u64::from_le_bytes(bytes[0..8].try_into().unwrap());
+                let dst = u64::from_le_bytes(bytes[8..16].try_into().unwrap());
+                let (rel_type, _) = decode_str(bytes, 16)?;
+                Ok(WalPayload::EdgeDelete { src, dst, rel_type })
             }
         }
     }

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -202,6 +202,8 @@ enum WalMutation {
         dst: NodeId,
         rel_type: String,
     },
+    /// A specific directed edge was deleted.
+    EdgeDelete { src: NodeId, dst: NodeId, rel_type: String },
 }
 
 // ── Pending structural operations (SPA-181 buffering) ────────────────────────
@@ -228,6 +230,12 @@ enum PendingOp {
     NodeDelete { node_id: NodeId },
     /// Create an edge: append to the edge delta log.
     EdgeCreate {
+        src: NodeId,
+        dst: NodeId,
+        rel_table_id: RelTableId,
+    },
+    /// Delete an edge: rewrite the delta log excluding this record.
+    EdgeDelete {
         src: NodeId,
         dst: NodeId,
         rel_table_id: RelTableId,
@@ -2181,6 +2189,22 @@ impl GraphDb {
         dot.push_str("}\n");
         Ok(dot)
     }
+
+    /// Convenience wrapper: remove the directed edge `src → dst` of `rel_type`.
+    ///
+    /// Opens a single-operation write transaction, calls
+    /// [`WriteTx::delete_edge`], and commits.  Suitable for callers that need
+    /// to remove a specific edge without managing a transaction explicitly.
+    ///
+    /// Returns [`Error::WriterBusy`] if another write transaction is already
+    /// active; returns [`Error::InvalidArgument`] if the rel type or edge is
+    /// not found.
+    pub fn delete_edge(&self, src: NodeId, dst: NodeId, rel_type: &str) -> Result<()> {
+        let mut tx = self.begin_write()?;
+        tx.delete_edge(src, dst, rel_type)?;
+        tx.commit()?;
+        Ok(())
+    }
 }
 
 /// Convenience wrapper — equivalent to [`GraphDb::open`].
@@ -2667,6 +2691,78 @@ impl WriteTx {
         Ok(edge_id)
     }
 
+    /// Delete the directed edge `src → dst` with the given relationship type.
+    ///
+    /// Resolves the relationship type to a `RelTableId` via the catalog, then
+    /// buffers an `EdgeDelete` operation.  At commit time the edge is excised
+    /// from the on-disk delta log.
+    ///
+    /// Returns [`Error::InvalidArgument`] if the relationship type is not
+    /// registered in the catalog, or if no matching edge record exists in the
+    /// delta log for the resolved table.
+    ///
+    /// Unblocks `SparrowOntology::init(force=true)` which needs to remove all
+    /// existing edges before re-seeding the ontology graph.
+    ///
+    /// [`commit`]: WriteTx::commit
+    pub fn delete_edge(&mut self, src: NodeId, dst: NodeId, rel_type: &str) -> Result<()> {
+        let src_label_id = (src.0 >> 32) as u16;
+        let dst_label_id = (dst.0 >> 32) as u16;
+
+        // Resolve the rel type in the catalog.  We do not create a new entry —
+        // deleting a non-existent rel type is always an error.
+        // The catalog's RelTableId is u64; EdgeStore's is RelTableId(u32).
+        let catalog_rel_id = self
+            .catalog
+            .get_rel_table(src_label_id, dst_label_id, rel_type)?
+            .ok_or_else(|| {
+                Error::InvalidArgument(format!(
+                    "relationship type '{}' not found in catalog for labels ({src_label_id}, {dst_label_id})",
+                    rel_type
+                ))
+            })?;
+        let rel_table_id = RelTableId(catalog_rel_id as u32);
+
+        // If the edge was created in this same transaction (not yet committed),
+        // cancel the create rather than scheduling a delete.
+        let buffered_pos = self.pending_ops.iter().position(|op| {
+            matches!(
+                op,
+                PendingOp::EdgeCreate {
+                    src: os,
+                    dst: od,
+                    rel_table_id: ort,
+                } if *os == src && *od == dst && *ort == rel_table_id
+            )
+        });
+
+        if let Some(pos) = buffered_pos {
+            // Remove the buffered create and its corresponding WAL mutation.
+            self.pending_ops.remove(pos);
+            // The WalMutation vec is parallel to pending_ops only for structural
+            // ops; find and remove the matching EdgeCreate entry.
+            if let Some(wpos) = self.wal_mutations.iter().position(|m| {
+                matches!(m, WalMutation::EdgeCreate { src: ms, dst: md, .. } if *ms == src && *md == dst)
+            }) {
+                self.wal_mutations.remove(wpos);
+            }
+            return Ok(());
+        }
+
+        // Edge is on disk — schedule the deletion for commit time.
+        self.pending_ops.push(PendingOp::EdgeDelete {
+            src,
+            dst,
+            rel_table_id,
+        });
+        self.wal_mutations.push(WalMutation::EdgeDelete {
+            src,
+            dst,
+            rel_type: rel_type.to_string(),
+        });
+        Ok(())
+    }
+
     // ── MVCC conflict detection (SPA-128) ────────────────────────────────────
 
     /// Check for write-write conflicts before committing.
@@ -2790,6 +2886,14 @@ impl WriteTx {
                 } => {
                     let mut es = EdgeStore::open(&self.inner.path, rel_table_id)?;
                     es.create_edge(src, rel_table_id, dst)?;
+                }
+                PendingOp::EdgeDelete {
+                    src,
+                    dst,
+                    rel_table_id,
+                } => {
+                    let mut es = EdgeStore::open(&self.inner.path, rel_table_id)?;
+                    es.delete_edge(src, dst)?;
                 }
             }
         }
@@ -2964,6 +3068,17 @@ fn write_mutation_wal(
                         dst: dst.0,
                         rel_type: rel_type.clone(),
                         props: vec![],
+                    },
+                )?;
+            }
+            WalMutation::EdgeDelete { src, dst, rel_type } => {
+                wal.append(
+                    WalRecordKind::EdgeDelete,
+                    txn,
+                    WalPayload::EdgeDelete {
+                        src: src.0,
+                        dst: dst.0,
+                        rel_type: rel_type.clone(),
                     },
                 )?;
             }

--- a/crates/sparrowdb/tests/delete_edge.rs
+++ b/crates/sparrowdb/tests/delete_edge.rs
@@ -1,0 +1,183 @@
+//! `delete_edge` API acceptance tests.
+//!
+//! Verifies that `WriteTx::delete_edge` and `GraphDb::delete_edge` correctly
+//! remove a specific directed edge and that subsequent MATCH queries no longer
+//! return it.
+//!
+//! Unblocks `SparrowOntology::init(force=true)` which needs to remove edges
+//! before re-seeding the ontology graph.
+
+use sparrowdb::{open, GraphDb};
+use std::collections::HashMap;
+
+fn make_db() -> (tempfile::TempDir, GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+/// Helpers: count how many rows a Cypher MATCH returns.
+fn count_matches(db: &GraphDb, cypher: &str) -> usize {
+    db.execute(cypher)
+        .expect("execute")
+        .rows
+        .len()
+}
+
+// ── WriteTx::delete_edge ──────────────────────────────────────────────────────
+
+/// Create two nodes and an edge, delete the edge, verify it is gone.
+#[test]
+fn delete_edge_removes_from_delta() {
+    let (dir, db) = make_db();
+
+    // label_id=0 keeps packed NodeIds equal to their slot numbers.
+    let (a, b) = {
+        let mut tx = db.begin_write().unwrap();
+        let a = tx.create_node(0, &[]).unwrap();
+        let b = tx.create_node(0, &[]).unwrap();
+        tx.commit().unwrap();
+        (a, b)
+    };
+
+    // Create edge a → b with type "KNOWS".
+    {
+        let mut tx = db.begin_write().unwrap();
+        tx.create_edge(a, b, "KNOWS", HashMap::new())
+            .expect("create_edge");
+        tx.commit().unwrap();
+    }
+
+    // Verify the edge is visible via Cypher.
+    assert_eq!(
+        count_matches(&db, "MATCH (x)-[:KNOWS]->(y) RETURN x, y"),
+        1,
+        "edge should exist before deletion"
+    );
+
+    // Delete the edge via WriteTx.
+    {
+        let mut tx = db.begin_write().unwrap();
+        tx.delete_edge(a, b, "KNOWS").expect("delete_edge");
+        tx.commit().unwrap();
+    }
+
+    // The edge must no longer be returned by MATCH.
+    assert_eq!(
+        count_matches(&db, "MATCH (x)-[:KNOWS]->(y) RETURN x, y"),
+        0,
+        "edge must be gone after delete_edge"
+    );
+
+    drop(dir);
+}
+
+// ── GraphDb::delete_edge (convenience wrapper) ────────────────────────────────
+
+/// Verify the one-shot GraphDb::delete_edge wrapper works end-to-end.
+#[test]
+fn graphdb_delete_edge_wrapper() {
+    let (dir, db) = make_db();
+
+    let (a, b) = {
+        let mut tx = db.begin_write().unwrap();
+        let a = tx.create_node(0, &[]).unwrap();
+        let b = tx.create_node(0, &[]).unwrap();
+        tx.commit().unwrap();
+        (a, b)
+    };
+
+    {
+        let mut tx = db.begin_write().unwrap();
+        tx.create_edge(a, b, "LINKED", HashMap::new())
+            .expect("create_edge");
+        tx.commit().unwrap();
+    }
+
+    assert_eq!(
+        count_matches(&db, "MATCH (x)-[:LINKED]->(y) RETURN x, y"),
+        1,
+        "edge should exist before deletion"
+    );
+
+    // Use the convenience wrapper.
+    db.delete_edge(a, b, "LINKED").expect("GraphDb::delete_edge");
+
+    assert_eq!(
+        count_matches(&db, "MATCH (x)-[:LINKED]->(y) RETURN x, y"),
+        0,
+        "edge must be gone after GraphDb::delete_edge"
+    );
+
+    drop(dir);
+}
+
+// ── Multiple edges — only the targeted one is removed ─────────────────────────
+
+/// Create three edges and delete only the middle one.
+#[test]
+fn delete_edge_leaves_others_intact() {
+    let (dir, db) = make_db();
+
+    let (a, b, c) = {
+        let mut tx = db.begin_write().unwrap();
+        let a = tx.create_node(0, &[]).unwrap();
+        let b = tx.create_node(0, &[]).unwrap();
+        let c = tx.create_node(0, &[]).unwrap();
+        tx.commit().unwrap();
+        (a, b, c)
+    };
+
+    // Create a→b and b→c with "FOLLOWS".
+    {
+        let mut tx = db.begin_write().unwrap();
+        tx.create_edge(a, b, "FOLLOWS", HashMap::new())
+            .expect("a→b");
+        tx.create_edge(b, c, "FOLLOWS", HashMap::new())
+            .expect("b→c");
+        tx.commit().unwrap();
+    }
+
+    assert_eq!(
+        count_matches(&db, "MATCH (x)-[:FOLLOWS]->(y) RETURN x, y"),
+        2,
+        "both edges should exist"
+    );
+
+    // Delete only a→b.
+    db.delete_edge(a, b, "FOLLOWS").expect("delete a→b");
+
+    assert_eq!(
+        count_matches(&db, "MATCH (x)-[:FOLLOWS]->(y) RETURN x, y"),
+        1,
+        "only b→c should remain"
+    );
+
+    drop(dir);
+}
+
+// ── Error cases ───────────────────────────────────────────────────────────────
+
+/// Deleting a non-existent rel type returns an error.
+#[test]
+fn delete_edge_unknown_rel_type_errors() {
+    let (dir, db) = make_db();
+
+    let (a, b) = {
+        let mut tx = db.begin_write().unwrap();
+        let a = tx.create_node(0, &[]).unwrap();
+        let b = tx.create_node(0, &[]).unwrap();
+        tx.commit().unwrap();
+        (a, b)
+    };
+
+    // No edge created — rel type never registered.
+    let mut tx = db.begin_write().unwrap();
+    let result = tx.delete_edge(a, b, "NONEXISTENT");
+    assert!(
+        result.is_err(),
+        "expected error for unknown rel type, got Ok"
+    );
+
+    drop(dir);
+}


### PR DESCRIPTION
## **User description**
## Summary

- Adds `WriteTx::delete_edge(src, dst, rel_type)` and `GraphDb::delete_edge(src, dst, rel_type)` convenience wrapper
- Adds `EdgeStore::delete_edge` which rewrites the delta log in-place (crash-safe: tmp + rename) excluding the removed record
- Adds `EdgeDelete` WAL record kind (`0x14`) with full encode/decode support in the codec
- Unblocks `SparrowOntology::init(force=true)` which needs to remove existing edges before re-seeding the ontology graph (requested in agent-bus msg #65)

## Design notes

- If the target edge was buffered in the current transaction (not yet committed), the pending `EdgeCreate` and its WAL entry are cancelled in-memory rather than scheduling a disk delete — clean and avoids a round-trip
- Delta log rewrite is O(n) in the delta log size; for bulk wipe use cases a CHECKPOINT after all deletes compacts cleanly

## Test plan

- [x] `delete_edge_removes_from_delta` — basic create + delete, MATCH returns 0
- [x] `graphdb_delete_edge_wrapper` — one-shot `GraphDb::delete_edge` API
- [x] `delete_edge_leaves_others_intact` — deletes only the targeted edge from a multi-edge set
- [x] `delete_edge_unknown_rel_type_errors` — returns `Err` for unregistered rel type
- [x] `cargo check -p sparrowdb` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add support for deleting a specific directed edge

### What Changed
- Users can now remove one edge by source, target, and relationship type through both the transaction API and the one-shot database API
- Deleting an edge no longer affects other edges between the same nodes or other relationship types
- If the matching edge was just created in the same transaction, the delete cancels that pending create instead of writing a separate removal
- Attempts to delete an unknown relationship type, or a missing edge, now return a clear error

### Impact
`✅ Remove unwanted edges without recreating the graph`
`✅ Safer ontology re-seeding`
`✅ Fewer accidental edge deletions`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
