### PR TITLE
fix(storage): hwm fsync only at commit — fixes 140× bulk import regression

### DIFF
--- a/crates/sparrowdb-storage/src/node_store.rs
+++ b/crates/sparrowdb-storage/src/node_store.rs
@@ -26,7 +26,7 @@
 //!
 //! Upper 32 bits are `label_id`, lower 32 bits are the within-label slot number.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -165,6 +165,9 @@ pub struct NodeStore {
     root: PathBuf,
     /// In-memory high-water marks per label.  Loaded lazily from disk.
     hwm: HashMap<u32, u64>,
+    /// Labels whose in-memory HWM has been advanced but not yet persisted to
+    /// `hwm.bin`.  Flushed atomically by [`flush_hwms`] at transaction commit.
+    hwm_dirty: HashSet<u32>,
 }
 
 impl NodeStore {
@@ -173,6 +176,7 @@ impl NodeStore {
         Ok(NodeStore {
             root: db_root.to_path_buf(),
             hwm: HashMap::new(),
+            hwm_dirty: HashSet::new(),
         })
     }
 
@@ -536,6 +540,27 @@ impl NodeStore {
         self.label_dir(label_id).join("hwm.bin.tmp")
     }
 
+    /// Persist all dirty in-memory HWMs to disk atomically.
+    ///
+    /// Called **once per transaction commit** rather than once per node creation,
+    /// so that bulk imports do not incur one fsync per node (SPA-217 regression fix).
+    ///
+    /// Each dirty label's HWM is written via the same tmp+fsync+rename strategy
+    /// used by [`save_hwm`], preserving the SPA-211 crash-safety guarantee.
+    /// After all writes succeed the dirty set is cleared.
+    pub fn flush_hwms(&mut self) -> Result<()> {
+        let dirty: Vec<u32> = self.hwm_dirty.iter().copied().collect();
+        for label_id in dirty {
+            let hwm = match self.hwm.get(&label_id) {
+                Some(&v) => v,
+                None => continue,
+            };
+            self.save_hwm(label_id, hwm)?;
+        }
+        self.hwm_dirty.clear();
+        Ok(())
+    }
+
     /// Append a `u64` value to a column file.
     fn append_col(&self, label_id: u32, col_id: u32, slot: u32, value: u64) -> Result<()> {
         use std::io::{Seek, SeekFrom, Write};
@@ -729,40 +754,27 @@ impl NodeStore {
             return Err(e);
         }
 
-        // Advance the on-disk HWM to at least slot + 1.
-        // Always write to disk; in-memory HWM may have been speculatively
-        // advanced by peek_next_slot but the disk HWM may be lower.
+        // Advance the in-memory HWM to at least slot + 1 and mark the label
+        // dirty so that flush_hwms() will persist it at commit boundary.
+        //
+        // We do NOT call save_hwm here.  The caller (WriteTx::commit) is
+        // responsible for calling flush_hwms() once after all PendingOp::NodeCreate
+        // entries have been applied.  This avoids one fsync per node during bulk
+        // imports (SPA-217 regression fix) while preserving crash-safety: the WAL
+        // record is already durable at this point, so recovery can reconstruct the
+        // HWM if we crash before flush_hwms() completes.
+        //
+        // NOTE: peek_next_slot() may have already advanced self.hwm to slot+1,
+        // so new_hwm > mem_hwm might be false.  We mark the label dirty
+        // unconditionally so that flush_hwms() always writes through to disk.
         let new_hwm = slot as u64 + 1;
-        let disk_hwm = self.load_hwm(label_id)?;
-        if new_hwm > disk_hwm {
-            if let Err(e) = self.save_hwm(label_id, new_hwm) {
-                // Column bytes were already written; roll them back to preserve
-                // the atomicity guarantee (SPA-181).
-                for (col_id, original_size) in &original_sizes {
-                    let path = self.col_path(label_id, *col_id);
-                    if path.exists() {
-                        if let Err(rollback_err) = fs::OpenOptions::new()
-                            .write(true)
-                            .open(&path)
-                            .and_then(|f| f.set_len(*original_size))
-                        {
-                            eprintln!(
-                                "CRITICAL: Failed to roll back column file {} to size {}: {}. Data may be corrupt.",
-                                path.display(),
-                                original_size,
-                                rollback_err
-                            );
-                        }
-                    }
-                }
-                return Err(e);
-            }
-        }
-        // Keep in-memory HWM at least as high as new_hwm.
         let mem_hwm = self.hwm.get(&label_id).copied().unwrap_or(0);
         if new_hwm > mem_hwm {
             self.hwm.insert(label_id, new_hwm);
         }
+        // Always mark dirty — flush_hwms() must write the post-commit HWM even
+        // if peek_next_slot already set mem HWM == new_hwm.
+        self.hwm_dirty.insert(label_id);
 
         Ok(NodeId((label_id as u64) << 32 | slot as u64))
     }

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -2898,6 +2898,16 @@ impl WriteTx {
             }
         }
 
+        // Step 5b: Persist HWMs for all labels that received new nodes in Step 5.
+        //
+        // create_node_at_slot() only advances the in-memory HWM and marks the
+        // label as dirty (hwm_dirty).  We flush all dirty HWMs here — once per
+        // commit — instead of once per node, avoiding an fsync storm during bulk
+        // imports (SPA-217 regression fix).  Crash safety is preserved: the WAL
+        // record written in Step 4 is already durable; on crash-recovery, the
+        // WAL replayer re-applies all NodeCreate ops and re-advances the HWM.
+        self.store.flush_hwms()?;
+
         // Step 6: Flush property updates to disk.
         // Use `upsert_node_col` so that columns added by `set_property` (which
         // may not have been initialised during `create_node`) are created and


### PR DESCRIPTION
## Summary

- PR #217 introduced atomic `save_hwm` (tmp+fsync+rename) for crash safety (SPA-211), but `create_node_at_slot` called it on **every node creation** inside `WriteTx::commit`'s pending-ops loop
- A batch import of N nodes in one transaction fired N fsyncs instead of 1 — causing the 140× slowdown (Facebook dataset: 3 min → 2.3 hrs)
- Fix: `create_node_at_slot` now marks the label dirty in a new `hwm_dirty: HashSet<u32>` field and only updates the in-memory HWM; `WriteTx::commit` calls `flush_hwms()` **once** after all `PendingOp::NodeCreate` entries are applied

## Root Cause

`peek_next_slot()` (called during `WriteTx::create_node`) advances the in-memory HWM speculatively. Then at commit, `create_node_at_slot` was calling `load_hwm` (disk read) + `save_hwm` (tmp+fsync+rename) for every node even though the WAL was already durable.

## What Changed

- `/crates/sparrowdb-storage/src/node_store.rs`: Added `hwm_dirty: HashSet<u32>` to `NodeStore`; replaced per-node `save_hwm` in `create_node_at_slot` with dirty-marking; added `pub fn flush_hwms()` that saves all dirty labels in a single pass
- `/crates/sparrowdb/src/lib.rs`: Added Step 5b in `WriteTx::commit` to call `self.store.flush_hwms()` once after the pending-ops loop

## Crash Safety

Preserved: the WAL record is durable before column data is written (Step 4 of commit). On crash recovery the WAL replayer re-applies all `NodeCreate` ops and re-advances the HWM. The tmp+fsync+rename strategy in `save_hwm` is unchanged.

## Test plan

- [x] `cargo check -p sparrowdb` — clean
- [x] `spa_211_hwm_crash_safety` — all 3 tests pass (corrupted hwm, tmp recovery, happy-path round-trip)
- [x] Full `cargo test -p sparrowdb` — all pass except 2 pre-existing `spa_119_compat_fixture` failures that exist on `main` (WAL CRC32 vs CRC32C format mismatch, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the transaction commit process by optimizing when and how data persistence occurs during write operations, reducing unnecessary disk I/O overhead and improving system reliability. Transaction processing now consolidates multiple persistence operations into fewer, more efficient disk writes while maintaining complete data consistency, durability guarantees, and overall improved database performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->