### PR TITLE
fix(wal): backward-compat read for CRC32 v2 WAL (0.1.2 databases)

### DIFF
--- a/crates/sparrowdb-storage/Cargo.toml
+++ b/crates/sparrowdb-storage/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["database", "filesystem"]
 [dependencies]
 sparrowdb-common  = { workspace = true }
 crc32c            = { workspace = true }
+crc32fast         = { workspace = true }
 chacha20poly1305  = { workspace = true }
 rand              = { workspace = true }
 tracing           = { workspace = true }

--- a/crates/sparrowdb-storage/src/wal/codec.rs
+++ b/crates/sparrowdb-storage/src/wal/codec.rs
@@ -31,9 +31,16 @@ use sparrowdb_common::{Error, Lsn, Result, TxnId};
 ///
 /// | Version | Checksum algorithm |
 /// |---------|--------------------|
-/// | 1       | CRC32 (IEEE 802.3) |
-/// | 2       | CRC32C (Castagnoli) — current |
+/// | 1       | CRC32 (IEEE 802.3) — retired |
+/// | 2       | CRC32C (Castagnoli) — current write format |
+/// | 21      | CRC32 (IEEE 802.3) — legacy 0.1.2 write format, read-only compat |
 pub const WAL_FORMAT_VERSION: u8 = 2;
+
+/// Legacy WAL format version byte written by SparrowDB 0.1.2.
+///
+/// Segments with this version byte use CRC32 (IEEE 802.3) checksums.
+/// The current code accepts them for reading (replay/scan) but never writes them.
+pub const WAL_FORMAT_VERSION_LEGACY: u8 = 21;
 
 // ── Record kind byte values ──────────────────────────────────────────────────
 
@@ -588,6 +595,83 @@ impl WalRecord {
             total_record_len,
         ))
     }
+
+    /// Decode a WAL record from the start of `bytes`, selecting the checksum
+    /// algorithm based on the segment's `wal_version` header byte.
+    ///
+    /// - `WAL_FORMAT_VERSION` (2) → CRC32C (Castagnoli) — current format.
+    /// - `WAL_FORMAT_VERSION_LEGACY` (21) → CRC32 (IEEE 802.3) — legacy 0.1.2 format.
+    ///
+    /// This is the read-path entry point used by replay and schema-scan when
+    /// opening databases that may have been written by an older SparrowDB release.
+    /// The write path always uses [`WalRecord::encode`] which emits CRC32C.
+    pub fn decode_with_version(bytes: &[u8], wal_version: u8) -> Result<(Self, usize)> {
+        if bytes.len() < HEADER_LEN {
+            return Err(Error::Corruption(format!(
+                "WAL record too short: {} bytes (need at least {})",
+                bytes.len(),
+                HEADER_LEN
+            )));
+        }
+
+        // length field
+        let length_val = u32::from_le_bytes(bytes[0..4].try_into().unwrap()) as usize;
+
+        if length_val < 21 {
+            return Err(Error::Corruption(format!(
+                "WAL record length field too small: {length_val} (minimum 21)"
+            )));
+        }
+
+        let total_record_len = 4 + length_val;
+
+        if bytes.len() < total_record_len {
+            return Err(Error::Corruption(format!(
+                "WAL record truncated: have {} bytes, need {}",
+                bytes.len(),
+                total_record_len
+            )));
+        }
+
+        // kind
+        let kind = WalRecordKind::from_byte(bytes[4])?;
+
+        // lsn
+        let lsn = u64::from_le_bytes(bytes[5..13].try_into().unwrap());
+
+        // txn_id
+        let txn_id = u64::from_le_bytes(bytes[13..21].try_into().unwrap());
+
+        // payload bytes = everything between txn_id end and crc
+        let payload_end = total_record_len - CRC_LEN;
+        let payload_bytes = &bytes[21..payload_end];
+
+        // crc
+        let stored_crc =
+            u32::from_le_bytes(bytes[payload_end..payload_end + 4].try_into().unwrap());
+
+        // Select checksum algorithm based on segment version.
+        // CRC covers [kind + lsn + txn_id + payload] = bytes[4..payload_end].
+        let computed_crc = match wal_version {
+            WAL_FORMAT_VERSION_LEGACY => compute_crc32_ieee(&bytes[4..payload_end]),
+            _ => compute_crc32c(&bytes[4..payload_end]),
+        };
+        if computed_crc != stored_crc {
+            return Err(Error::ChecksumMismatch);
+        }
+
+        let payload = WalPayload::decode(kind, payload_bytes)?;
+
+        Ok((
+            WalRecord {
+                lsn: Lsn(lsn),
+                txn_id: TxnId(txn_id),
+                kind,
+                payload,
+            },
+            total_record_len,
+        ))
+    }
 }
 
 // ── CRC32C helper ────────────────────────────────────────────────────────────
@@ -598,6 +682,15 @@ impl WalRecord {
 /// available via the `crc32c` crate.
 pub(crate) fn compute_crc32c(data: &[u8]) -> u32 {
     crc32c::crc32c(data)
+}
+
+/// Compute CRC32 (IEEE 802.3) checksum over `data`.
+///
+/// Used only for backward-compatible reads of legacy WAL segments
+/// written by SparrowDB 0.1.2 (version byte = [`WAL_FORMAT_VERSION_LEGACY`]).
+/// Never used in the write path.
+pub(crate) fn compute_crc32_ieee(data: &[u8]) -> u32 {
+    crc32fast::hash(data)
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────

--- a/crates/sparrowdb-storage/src/wal/replay.rs
+++ b/crates/sparrowdb-storage/src/wal/replay.rs
@@ -25,7 +25,9 @@ use std::{
 
 use sparrowdb_common::{Error, Lsn, Result};
 
-use super::codec::{WalPayload, WalRecord, WalRecordKind, WAL_FORMAT_VERSION};
+use super::codec::{
+    WalPayload, WalRecord, WalRecordKind, WAL_FORMAT_VERSION, WAL_FORMAT_VERSION_LEGACY,
+};
 use super::writer::segment_path;
 use crate::encryption::EncryptionContext;
 
@@ -106,11 +108,14 @@ impl WalReplayer {
             }
 
             // Validate the 1-byte version header.
+            // Accept both the current format (WAL_FORMAT_VERSION = 2, CRC32C) and
+            // the legacy format written by SparrowDB 0.1.2 (WAL_FORMAT_VERSION_LEGACY = 21, CRC32).
             let version = data[0];
-            if version != WAL_FORMAT_VERSION {
+            if version != WAL_FORMAT_VERSION && version != WAL_FORMAT_VERSION_LEGACY {
                 return Err(Error::Corruption(format!(
-                    "WAL segment {seg_no} version mismatch: found {version}, expected {WAL_FORMAT_VERSION}. \
-                     This segment was written with an incompatible WAL format."
+                    "WAL segment {seg_no} has unrecognised version byte {version}. \
+                     Supported versions: {WAL_FORMAT_VERSION} (current), \
+                     {WAL_FORMAT_VERSION_LEGACY} (legacy 0.1.2)."
                 )));
             }
 
@@ -121,7 +126,7 @@ impl WalReplayer {
                 if data[offset..].iter().all(|&b| b == 0) {
                     break;
                 }
-                match WalRecord::decode(&data[offset..]) {
+                match WalRecord::decode_with_version(&data[offset..], version) {
                     Ok((rec, consumed)) => {
                         all_records.insert(rec.lsn.0, rec);
                         offset += consumed;
@@ -272,11 +277,13 @@ impl WalReplayer {
                 continue;
             }
             // Validate the 1-byte version header.
+            // Accept both current (2, CRC32C) and legacy 0.1.2 (21, CRC32) formats.
             let version = data[0];
-            if version != WAL_FORMAT_VERSION {
+            if version != WAL_FORMAT_VERSION && version != WAL_FORMAT_VERSION_LEGACY {
                 return Err(Error::Corruption(format!(
-                    "WAL segment {seg_no} version mismatch: found {version}, expected {WAL_FORMAT_VERSION}. \
-                     This segment was written with an incompatible WAL format."
+                    "WAL segment {seg_no} has unrecognised version byte {version}. \
+                     Supported versions: {WAL_FORMAT_VERSION} (current), \
+                     {WAL_FORMAT_VERSION_LEGACY} (legacy 0.1.2)."
                 )));
             }
             // Records start at byte 1 (after the version header byte).
@@ -285,7 +292,7 @@ impl WalReplayer {
                 if data[offset..].iter().all(|&b| b == 0) {
                     break;
                 }
-                match WalRecord::decode(&data[offset..]) {
+                match WalRecord::decode_with_version(&data[offset..], version) {
                     Ok((rec, consumed)) => {
                         all_records.insert(rec.lsn.0, rec);
                         offset += consumed;

--- a/crates/sparrowdb-storage/src/wal/writer.rs
+++ b/crates/sparrowdb-storage/src/wal/writer.rs
@@ -29,7 +29,9 @@ use std::{
 
 use sparrowdb_common::{Lsn, Result, TxnId};
 
-use super::codec::{WalPayload, WalRecord, WalRecordKind, WAL_FORMAT_VERSION};
+use super::codec::{
+    WalPayload, WalRecord, WalRecordKind, WAL_FORMAT_VERSION, WAL_FORMAT_VERSION_LEGACY,
+};
 use crate::encryption::EncryptionContext;
 
 /// 64 MiB per segment.
@@ -154,11 +156,14 @@ impl WalWriter {
         }
 
         // Validate the version header byte.
+        // Accept both the current format (WAL_FORMAT_VERSION = 2, CRC32C) and
+        // the legacy format written by SparrowDB 0.1.2 (WAL_FORMAT_VERSION_LEGACY = 21, CRC32).
         let version = data[0];
-        if version != WAL_FORMAT_VERSION {
+        if version != WAL_FORMAT_VERSION && version != WAL_FORMAT_VERSION_LEGACY {
             return Err(sparrowdb_common::Error::Corruption(format!(
-                "WAL segment version mismatch: found version {version}, expected {WAL_FORMAT_VERSION}. \
-                 This database was written with an incompatible WAL format (CRC32 vs CRC32C). \
+                "WAL segment has unrecognised version byte {version}. \
+                 Supported versions: {WAL_FORMAT_VERSION} (current CRC32C), \
+                 {WAL_FORMAT_VERSION_LEGACY} (legacy 0.1.2 CRC32). \
                  The database cannot be opened."
             )));
         }
@@ -168,7 +173,7 @@ impl WalWriter {
         let mut offset = 1usize;
         let mut max_lsn = 0u64;
         while offset < data.len() {
-            match WalRecord::decode(&data[offset..]) {
+            match WalRecord::decode_with_version(&data[offset..], version) {
                 Ok((rec, consumed)) => {
                     if rec.lsn.0 > max_lsn {
                         max_lsn = rec.lsn.0;


### PR DESCRIPTION
## **User description**
## Summary

- Adds `WAL_FORMAT_VERSION_LEGACY = 21` constant to identify 0.1.2-era WAL segments
- Adds `WalRecord::decode_with_version(bytes, wal_version)` read-path method that dispatches to CRC32 (IEEE 802.3) for version-21 segments and CRC32C for version-2 segments
- Adds `compute_crc32_ieee()` helper backed by the `crc32fast` crate (already in workspace)
- Updates `replay.rs` and `writer.rs` read paths to accept both version bytes and pass version through to `decode_with_version`
- Write path is **unchanged** — new segments always emit version 2 / CRC32C

Databases created with SparrowDB 0.1.2 (WAL version byte 21, CRC32) now open transparently. Fixes the 2 pre-existing `spa_119_compat_fixture` failures.

## Test plan

- [x] `cargo check -p sparrowdb` — zero errors
- [x] `cargo test -p sparrowdb --test spa_119_compat_fixture` — 2/2 tests now pass (were failing)
- [x] `cargo test -p sparrowdb` — full suite passes
- [x] `cargo test -p sparrowdb-storage` — all WAL unit and integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Open databases written by SparrowDB 0.1.2 again**

### What Changed
- WAL files written with the older version byte 21 now open, replay, and scan without manual conversion
- Current WAL files still use the newer format; new writes are unchanged
- Version mismatches now show a clearer message that lists the supported WAL versions

### Impact
`✅ Fewer database-open failures after upgrade`
`✅ Legacy WAL files stay readable`
`✅ Clearer WAL compatibility errors`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading legacy write-ahead log format versions, ensuring backward compatibility with older database files while maintaining the current format for new operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->