### PR TITLE
perf(engine): hoist prop-index outside hop loops — fix #232 regression

### DIFF
--- a/crates/sparrowdb-storage/src/property_index.rs
+++ b/crates/sparrowdb-storage/src/property_index.rs
@@ -114,10 +114,28 @@ pub struct IndexKey {
 /// Use [`PropertyIndex::build_for`] to load a specific column on demand, or
 /// [`PropertyIndex::build`] for an upfront full build.  Then use
 /// [`PropertyIndex::lookup`] for O(log n) equality queries.
+///
+/// ## Clone cost (SPA-232 fix)
+///
+/// The inner B-tree for each `(label_id, col_id)` is wrapped in an `Arc` so
+/// that cloning a `PropertyIndex` is O(number of indexed columns) rather than
+/// O(total index entries).  This eliminates the per-query clone overhead when
+/// the shared property-index cache is warm (e.g. after Q1 point-lookups build
+/// a large uid index that Q4/Q5/Q8 multi-hop queries don't need).
+///
+/// Mutation methods (`build_for`, `insert`, `update`, `remove`) use
+/// `Arc::make_mut` to obtain exclusive access (copy-on-write semantics):
+/// only the first mutation of a shared Arc copies the BTreeMap; subsequent
+/// mutations on the same Engine's private copy are in-place.
 #[derive(Default, Clone)]
 pub struct PropertyIndex {
-    /// `index[(label_id, col_id)][raw_value] = [slot, ...]`
-    index: std::collections::HashMap<IndexKey, BTreeMap<u64, Vec<u32>>>,
+    /// `index[(label_id, col_id)] = Arc<BTreeMap<raw_value, [slot, ...]>>`
+    ///
+    /// The `Arc` wrapper makes `Clone` O(loaded.len()) instead of
+    /// O(Σ entries per column).  `Arc::make_mut` is used for mutations to
+    /// ensure copy-on-write isolation between the shared cache and per-Engine
+    /// copies.
+    index: std::collections::HashMap<IndexKey, std::sync::Arc<BTreeMap<u64, Vec<u32>>>>,
     /// Set of `(label_id, col_id)` pairs whose column file has already been
     /// loaded into `index`.  A pair is present here even when its column file
     /// contained no indexable values, so that `build_for` can skip repeated I/O.
@@ -215,7 +233,11 @@ impl PropertyIndex {
             }
         };
 
-        let btree = self.index.entry(key).or_default();
+        // Build a fresh BTreeMap for this column (always a new key at this
+        // point since we checked `self.loaded` above and returned early on
+        // cache hit).  Insert as `Arc::new` so later clones of this
+        // `PropertyIndex` share the data without copying.
+        let mut btree: BTreeMap<u64, Vec<u32>> = BTreeMap::new();
         for (slot, raw) in raw_vals.into_iter().enumerate() {
             let slot = slot as u32;
             if raw == ABSENT || tombstone_slots.contains(&slot) {
@@ -225,6 +247,7 @@ impl PropertyIndex {
             // so that integer ordering and equality checks are consistent.
             btree.entry(sort_key(raw)).or_default().push(slot);
         }
+        self.index.insert(key, std::sync::Arc::new(btree));
 
         Ok(())
     }
@@ -283,7 +306,7 @@ impl PropertyIndex {
                     }
                 };
 
-                let btree = idx.index.entry(key).or_default();
+                let mut btree: BTreeMap<u64, Vec<u32>> = BTreeMap::new();
                 for (slot, raw) in raw_vals.into_iter().enumerate() {
                     let slot = slot as u32;
                     // Skip absent and tombstoned slots.
@@ -292,6 +315,8 @@ impl PropertyIndex {
                     }
                     btree.entry(sort_key(raw)).or_default().push(slot);
                 }
+                idx.index.insert(key, std::sync::Arc::new(btree));
+                idx.loaded.insert(key);
             }
         }
 
@@ -373,12 +398,15 @@ impl PropertyIndex {
             return;
         }
         let key = IndexKey { label_id, col_id };
-        self.index
-            .entry(key)
-            .or_default()
-            .entry(sort_key(raw_value))
-            .or_default()
-            .push(slot);
+        // `Arc::make_mut` gives us a `&mut BTreeMap` with copy-on-write
+        // semantics: if the Arc is shared (e.g. was cloned from the cache),
+        // the inner BTreeMap is cloned here; otherwise mutation is in-place.
+        let btree = std::sync::Arc::make_mut(
+            self.index
+                .entry(key)
+                .or_insert_with(|| std::sync::Arc::new(BTreeMap::new())),
+        );
+        btree.entry(sort_key(raw_value)).or_default().push(slot);
     }
 
     /// Update a slot from `old_raw` to `new_raw` after a SET operation.
@@ -387,7 +415,11 @@ impl PropertyIndex {
     /// A no-op for the absent sentinel.
     pub fn update(&mut self, label_id: u32, col_id: u32, slot: u32, old_raw: u64, new_raw: u64) {
         let key = IndexKey { label_id, col_id };
-        let btree = self.index.entry(key).or_default();
+        let btree = std::sync::Arc::make_mut(
+            self.index
+                .entry(key)
+                .or_insert_with(|| std::sync::Arc::new(BTreeMap::new())),
+        );
 
         // Remove slot from old bucket.
         if old_raw != ABSENT {
@@ -414,7 +446,8 @@ impl PropertyIndex {
         }
         let sk = sort_key(raw_value);
         let key = IndexKey { label_id, col_id };
-        if let Some(btree) = self.index.get_mut(&key) {
+        if let Some(arc_btree) = self.index.get_mut(&key) {
+            let btree = std::sync::Arc::make_mut(arc_btree);
             if let Some(slots) = btree.get_mut(&sk) {
                 slots.retain(|&s| s != slot);
                 if slots.is_empty() {


### PR DESCRIPTION
## **User description**
## Summary

- PR #231's value index was rebuilt on every query execution — including multi-hop traversal queries (Q4/Q5/Q8) that don't need property filters
- Root cause: `PropertyIndex` was deep-cloned at Engine construction (O(N) BTreeMap allocation where N = total indexed entries). After Q1 warms the shared cache with 4K uid entries, every Q4/Q5/Q8 query paid the clone cost
- Fix: wrap inner `BTreeMap<u64, Vec<u32>>` in `Arc` — clone is now O(indexed columns) via refcount; `insert`/`update`/`remove` use `Arc::make_mut` for copy-on-write isolation

## Changes

- `crates/sparrowdb-storage/src/property_index.rs`: Change `HashMap<IndexKey, BTreeMap<...>>` to `HashMap<IndexKey, Arc<BTreeMap<...>>>` with COW mutation semantics

## Test plan

- [x] `cargo check -p sparrowdb` — zero errors
- [x] All previously-passing tests still pass (2 pre-existing failures in `spa_168_degree_cache_wiring` unchanged)
- [x] `match_create_edge_oi_performance` runs faster with this change (5.18s vs 5.48s on main) — confirms fix direction
- [ ] SparrowTest to re-run Q4/Q5/Q8 benchmarks against SNAP Facebook dataset

Closes #232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Avoid rebuilding the property index on every query**

### What Changed
- Multi-hop queries now reuse shared property-index data instead of copying every indexed value when a query starts
- Property-index changes for creates, updates, and deletes still stay isolated to the current engine copy
- Queries that do use property filters keep the same lookup behavior

### Impact
`✅ Faster multi-hop queries after a warm cache`
`✅ Fewer query slowdowns on large property indexes`
`✅ Lower per-query memory copying`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal data structure and memory management for property indexing operations to enhance performance and resource efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->