### PR TITLE
fix(storage): f64::to_bits for edge property floats — closes #229

### DIFF
--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -2820,10 +2820,15 @@ impl WriteTx {
 
         // Convert HashMap<String, Value> props to (col_id, value_u64) pairs
         // using the canonical FNV-1a col_id derivation so read and write agree.
+        // SPA-229: use NodeStore::encode_value (not val.to_u64()) so that
+        // Value::Float is stored via f64::to_bits() in the heap rather than
+        // panicking with "cannot be inline-encoded".
         let encoded_props: Vec<(u32, u64)> = props
             .iter()
-            .map(|(name, val)| (col_id_of(name), val.to_u64()))
-            .collect();
+            .map(|(name, val)| -> Result<(u32, u64)> {
+                Ok((col_id_of(name), self.store.encode_value(val)?))
+            })
+            .collect::<Result<Vec<_>>>()?;
 
         // Human-readable entries for WAL schema introspection.
         let prop_entries: Vec<(String, Value)> = props.into_iter().collect();

--- a/crates/sparrowdb/tests/spa_229_edge_prop_float.rs
+++ b/crates/sparrowdb/tests/spa_229_edge_prop_float.rs
@@ -1,0 +1,135 @@
+/// SPA-229: Storing a float literal as an edge property panicked at runtime:
+///   "Value::Float cannot be inline-encoded; use NodeStore::encode_value"
+///
+/// Root cause: WriteTx::create_edge called `val.to_u64()` which panics for
+/// Value::Float.  The fix uses `NodeStore::encode_value()` (same path as node
+/// properties) which writes float bits to the heap and returns a tagged u64.
+use sparrowdb::GraphDb;
+use tempfile::tempdir;
+
+/// Basic float edge property round-trip (the exact scenario from the bug report).
+#[test]
+fn edge_float_prop_roundtrip() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+
+    db.execute("CREATE (a:Knowledge {id: 'a'})").unwrap();
+    db.execute("CREATE (b:Knowledge {id: 'b'})").unwrap();
+    db.execute(
+        "MATCH (a:Knowledge {id: 'a'}), (b:Knowledge {id: 'b'}) \
+         CREATE (a)-[:RELATED_TO {strength: 0.85}]->(b)",
+    )
+    .unwrap();
+
+    let r = db
+        .execute(
+            "MATCH (a:Knowledge)-[r:RELATED_TO]->(b:Knowledge) RETURN r.strength",
+        )
+        .unwrap();
+
+    assert_eq!(r.rows.len(), 1, "expected one edge row");
+    match &r.rows[0][0] {
+        sparrowdb_execution::Value::Float64(f) => {
+            assert!(
+                (f - 0.85_f64).abs() < 1e-10,
+                "strength round-trip failed: got {f}"
+            );
+        }
+        other => panic!("Expected Float64 for r.strength, got {:?}", other),
+    }
+}
+
+/// Multiple float props on a single edge.
+#[test]
+fn edge_multiple_float_props() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+
+    db.execute("CREATE (a:Person {name: 'alice'})").unwrap();
+    db.execute("CREATE (b:Person {name: 'bob'})").unwrap();
+    db.execute(
+        "MATCH (a:Person {name: 'alice'}), (b:Person {name: 'bob'}) \
+         CREATE (a)-[:KNOWS {weight: 0.8, score: -1.5}]->(b)",
+    )
+    .unwrap();
+
+    let r = db
+        .execute(
+            "MATCH (a:Person)-[r:KNOWS]->(b:Person) RETURN r.weight, r.score",
+        )
+        .unwrap();
+
+    assert_eq!(r.rows.len(), 1, "expected one row");
+    let row = &r.rows[0];
+
+    match &row[0] {
+        sparrowdb_execution::Value::Float64(f) => {
+            assert!(
+                (f - 0.8_f64).abs() < 1e-10,
+                "weight round-trip failed: got {f}"
+            );
+        }
+        other => panic!("Expected Float64 for r.weight, got {:?}", other),
+    }
+    match &row[1] {
+        sparrowdb_execution::Value::Float64(f) => {
+            assert!(
+                (f - (-1.5_f64)).abs() < 1e-10,
+                "score round-trip failed: got {f}"
+            );
+        }
+        other => panic!("Expected Float64 for r.score, got {:?}", other),
+    }
+}
+
+/// Storing 0.0 as an edge property must not panic.
+#[test]
+fn edge_float_zero_does_not_panic() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+
+    db.execute("CREATE (x:Node {id: 'x'})").unwrap();
+    db.execute("CREATE (y:Node {id: 'y'})").unwrap();
+    // Must not panic — SPA-229 guard.
+    db.execute(
+        "MATCH (x:Node {id: 'x'}), (y:Node {id: 'y'}) \
+         CREATE (x)-[:LINK {weight: 0.0}]->(y)",
+    )
+    .unwrap();
+}
+
+/// Mixed int and float edge properties on the same edge.
+#[test]
+fn edge_mixed_int_and_float_props() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+
+    db.execute("CREATE (u:User {id: 'u1'})").unwrap();
+    db.execute("CREATE (v:User {id: 'v1'})").unwrap();
+    db.execute(
+        "MATCH (u:User {id: 'u1'}), (v:User {id: 'v1'}) \
+         CREATE (u)-[:FOLLOWS {since: 2020, strength: 0.75}]->(v)",
+    )
+    .unwrap();
+
+    let r = db
+        .execute(
+            "MATCH (u:User)-[r:FOLLOWS]->(v:User) RETURN r.since, r.strength",
+        )
+        .unwrap();
+
+    assert_eq!(r.rows.len(), 1);
+    match &r.rows[0][0] {
+        sparrowdb_execution::Value::Int64(n) => assert_eq!(*n, 2020, "since mismatch"),
+        other => panic!("Expected Int64 for r.since, got {:?}", other),
+    }
+    match &r.rows[0][1] {
+        sparrowdb_execution::Value::Float64(f) => {
+            assert!(
+                (f - 0.75_f64).abs() < 1e-10,
+                "strength round-trip failed: got {f}"
+            );
+        }
+        other => panic!("Expected Float64 for r.strength, got {:?}", other),
+    }
+}


### PR DESCRIPTION
## **User description**
## Summary

- Edge properties stored floats using `val.to_u64()` which panics with _"Value::Float cannot be inline-encoded; use NodeStore::encode_value"_
- Fix uses `NodeStore::encode_value()` for all edge property values — the same path used by node property writes — which stores `f64` bits in the overflow heap via `f64::to_bits()` and returns a tagged `u64` for lossless round-trip
- Adds `spa_229_edge_prop_float.rs` integration tests: basic float round-trip, multiple floats per edge, `0.0` edge case (no panic), mixed int+float on same edge

## What was panicking

In `WriteTx::create_edge` at `crates/sparrowdb/src/lib.rs`:
```rust
// BEFORE — panics for Value::Float
.map(|(name, val)| (col_id_of(name), val.to_u64()))

// AFTER — uses heap storage for floats, same as node props
.map(|(name, val)| -> Result<(u32, u64)> {
    Ok((col_id_of(name), self.store.encode_value(val)?))
})
.collect::<Result<Vec<_>>>()?
```

## Test plan
- [x] `cargo check -p sparrowdb` — zero errors
- [x] `cargo test --test spa_229_edge_prop_float` — 4/4 tests pass
- [x] Reproduces exact scenario from issue: `CREATE (a)-[:RELATED_TO {strength: 0.85}]->(b)` no longer panics

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Allow float edge properties to be saved without crashing**

### What Changed
- Creating an edge with a float property no longer fails at runtime
- Float edge values now round-trip correctly when read back, including `0.0`, negative floats, and mixed int/float properties on the same edge
- Added coverage for the bug report scenario and related edge cases

### Impact
`✅ Float relationships no longer crash`
`✅ Safer graph writes with numeric edge properties`
`✅ Clearer confidence in edge property reads`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in edge property encoding to properly surface and propagate encoding failures during transaction processing, ensuring more reliable behavior.

* **Tests**
  * Added integration tests for edge property float encoding, verifying correct round-tripping of float values, handling of zero values, and support for mixed-type properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->