### PR TITLE
perf(storage): O(K) sorted slot reads for hop queries — closes #200

### DIFF
--- a/crates/sparrowdb-storage/src/node_store.rs
+++ b/crates/sparrowdb-storage/src/node_store.rs
@@ -28,6 +28,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fs;
+use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 use sparrowdb_common::{Error, NodeId, Result};
@@ -1118,10 +1119,82 @@ impl NodeStore {
         Ok(out)
     }
 
-    /// Batch-read multiple slots from multiple columns — one fs::read() per column.
+    /// Selective sorted-slot read — O(K) seeks instead of O(N) reads.
+    ///
+    /// For each column, opens the file once and reads only the `slots` needed,
+    /// in slot-ascending order (for sequential-ish I/O).  This is the hot path
+    /// for hop queries where K neighbor slots ≪ N total nodes.
+    ///
+    /// `slots` **must** be pre-sorted ascending by the caller.
+    /// Returns a `Vec` indexed parallel to `slots`; each inner `Vec` is indexed
+    /// parallel to `col_ids`.  Out-of-range or missing-file slots return 0.
+    ///
+    /// SPA-200: replaces full O(N) column loads with O(K) per-column seeks.
+    fn read_col_slots_sorted(
+        &self,
+        label_id: u32,
+        slots: &[u32],
+        col_ids: &[u32],
+    ) -> Result<Vec<Vec<u64>>> {
+        if slots.is_empty() || col_ids.is_empty() {
+            // Return a row of empty vecs parallel to slots
+            return Ok(slots.iter().map(|_| vec![0u64; col_ids.len()]).collect());
+        }
+
+        // result[slot_idx][col_idx]
+        let mut result: Vec<Vec<u64>> = slots.iter().map(|_| vec![0u64; col_ids.len()]).collect();
+
+        for (col_idx, &col_id) in col_ids.iter().enumerate() {
+            let path = self.col_path(label_id, col_id);
+            let mut file = match fs::File::open(&path) {
+                Ok(f) => f,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    // Column file doesn't exist — all slots stay 0
+                    continue;
+                }
+                Err(e) => return Err(Error::Io(e)),
+            };
+
+            let file_len = file
+                .seek(SeekFrom::End(0))
+                .map_err(Error::Io)?;
+            // Reset to start for sequential reads
+            file.seek(SeekFrom::Start(0)).map_err(Error::Io)?;
+
+            let mut buf = [0u8; 8];
+            let mut current_pos: u64 = 0;
+
+            for (slot_idx, &slot) in slots.iter().enumerate() {
+                let target_pos = slot as u64 * 8;
+                if target_pos + 8 > file_len {
+                    // Slot beyond end of file — leave as 0
+                    continue;
+                }
+                if target_pos != current_pos {
+                    file.seek(SeekFrom::Start(target_pos)).map_err(Error::Io)?;
+                    current_pos = target_pos;
+                }
+                file.read_exact(&mut buf).map_err(Error::Io)?;
+                current_pos += 8;
+                result[slot_idx][col_idx] = u64::from_le_bytes(buf);
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Batch-read multiple slots from multiple columns.
+    ///
+    /// Chooses between two strategies based on the K/N ratio:
+    /// - **Sorted-slot reads** (SPA-200): when K ≪ N, seeks to each slot
+    ///   offset — O(K × C) I/O instead of O(N × C).  Slots are sorted
+    ///   ascending before the read so seeks are sequential.
+    /// - **Full-column load**: when K is close to N (>50% of column), reading
+    ///   the whole file is cheaper than many random seeks.
+    ///
     /// All `slots` must belong to `label_id`.
-    /// Returns Vec indexed parallel to `slots`; inner Vec indexed parallel to `col_ids`.
-    /// Missing/out-of-range slots return 0 (null sentinel).
+    /// Returns a `Vec` indexed parallel to `slots`; inner `Vec` indexed
+    /// parallel to `col_ids`.  Missing/out-of-range slots return 0.
     pub fn batch_read_node_props(
         &self,
         label_id: u32,
@@ -1131,24 +1204,47 @@ impl NodeStore {
         if slots.is_empty() {
             return Ok(vec![]);
         }
-        // Load each column once into memory
-        let col_data: Vec<Vec<u64>> = col_ids
-            .iter()
-            .map(|&col_id| self.read_col_all(label_id, col_id))
-            .collect::<Result<_>>()?;
-        // Index by slot for each requested node
-        Ok(slots
-            .iter()
-            .map(|&slot| {
-                col_ids
-                    .iter()
-                    .enumerate()
-                    .map(|(ci, _)| {
-                        col_data[ci].get(slot as usize).copied().unwrap_or(0)
-                    })
-                    .collect()
-            })
-            .collect())
+
+        // Determine the column high-water mark (total node count for this label).
+        let hwm = self.hwm_for_label(label_id).unwrap_or(0) as usize;
+
+        // Use sorted-slot reads when K < 50% of N.  For K=100, N=4039 that is
+        // a ~40× reduction in bytes read per column.  The HWM=0 guard handles
+        // labels that have no nodes yet (shouldn't reach here, but be safe).
+        let use_sorted = hwm == 0 || slots.len() * 2 < hwm;
+
+        if use_sorted {
+            // Sort slots ascending for sequential I/O; keep a permutation index
+            // so we can return results in the original caller order.
+            let mut order: Vec<usize> = (0..slots.len()).collect();
+            order.sort_unstable_by_key(|&i| slots[i]);
+            let sorted_slots: Vec<u32> = order.iter().map(|&i| slots[i]).collect();
+
+            let sorted_result = self.read_col_slots_sorted(label_id, &sorted_slots, col_ids)?;
+
+            // Re-order back to the original slot order expected by the caller.
+            let mut result = vec![vec![0u64; col_ids.len()]; slots.len()];
+            for (sorted_idx, orig_idx) in order.into_iter().enumerate() {
+                result[orig_idx] = sorted_result[sorted_idx].clone();
+            }
+            Ok(result)
+        } else {
+            // Fall back to full column load when most slots are needed anyway.
+            let col_data: Vec<Vec<u64>> = col_ids
+                .iter()
+                .map(|&col_id| self.read_col_all(label_id, col_id))
+                .collect::<Result<_>>()?;
+            Ok(slots
+                .iter()
+                .map(|&slot| {
+                    col_ids
+                        .iter()
+                        .enumerate()
+                        .map(|(ci, _)| col_data[ci].get(slot as usize).copied().unwrap_or(0))
+                        .collect()
+                })
+                .collect())
+        }
     }
 }
 

--- a/crates/sparrowdb/tests/spa_200_batch_hop_perf.rs
+++ b/crates/sparrowdb/tests/spa_200_batch_hop_perf.rs
@@ -233,6 +233,92 @@ fn two_hop_returns_valid_names() {
     }
 }
 
+// ── test 5: sorted-slot reads — performance + correctness at scale ────────────
+
+/// SPA-200 real fix: sorted O(K) slot reads instead of O(N) full-column loads.
+///
+/// Creates 1 000 "Person" nodes each connected to exactly 50 "Friend" nodes
+/// (50 000 edges total, but we query from a single source so K=50, N=1000).
+/// The sorted-slot path should read only 50 entries per column instead of
+/// 1 000 — a 20× reduction. We verify correctness (row count + values) and
+/// that the query completes within a reasonable time bound.
+#[test]
+fn sorted_slot_reads_correct_and_fast() {
+    let (_dir, db) = make_db();
+
+    // Create 1 000 Friend destination nodes.
+    const N_FRIENDS: u32 = 1_000;
+    const SRC_IDX: u32 = 9999;
+    const K_NEIGHBORS: u32 = 50; // first 50 friends connected to src
+
+    for j in 1..=N_FRIENDS {
+        db.execute(&format!(
+            "CREATE (n:Friend {{name: 'friend_{j}', idx: {j}}})"
+        ))
+        .unwrap_or_else(|e| panic!("CREATE friend_{j} failed: {e}"));
+    }
+
+    // Create one source node.
+    db.execute(&format!(
+        "CREATE (n:Src {{name: 'source', idx: {SRC_IDX}}})"
+    ))
+    .unwrap();
+
+    // Connect source to the first K_NEIGHBORS friends.
+    for j in 1..=K_NEIGHBORS {
+        db.execute(&format!(
+            "MATCH (a:Src {{idx: {SRC_IDX}}}), (b:Friend {{idx: {j}}}) CREATE (a)-[:KNOWS]->(b)"
+        ))
+        .unwrap_or_else(|e| panic!("CREATE edge src->friend_{j} failed: {e}"));
+    }
+
+    let start = std::time::Instant::now();
+    let result = db
+        .execute("MATCH (a:Src)-[:KNOWS]->(b:Friend) RETURN b.name, b.idx")
+        .expect("sorted-slot hop query must succeed");
+    let elapsed = start.elapsed();
+
+    // Correctness: exactly K_NEIGHBORS rows.
+    assert_eq!(
+        result.rows.len(),
+        K_NEIGHBORS as usize,
+        "expected {K_NEIGHBORS} rows, got {}",
+        result.rows.len()
+    );
+
+    // Every returned name must match "friend_N" and idx must be 1..=K_NEIGHBORS.
+    for row in &result.rows {
+        match &row[0] {
+            Value::String(s) => {
+                assert!(
+                    s.starts_with("friend_"),
+                    "unexpected name: {s:?}"
+                );
+            }
+            other => panic!("expected String for name, got {other:?}"),
+        }
+        match &row[1] {
+            Value::Int64(n) => {
+                assert!(
+                    *n >= 1 && *n <= K_NEIGHBORS as i64,
+                    "idx {n} out of expected range 1..={K_NEIGHBORS}"
+                );
+            }
+            other => panic!("expected Int64 for idx, got {other:?}"),
+        }
+    }
+
+    // Performance gate: should complete in under 5 seconds in debug mode.
+    assert!(
+        elapsed.as_secs() < 5,
+        "sorted-slot hop query took {elapsed:?} — expected < 5s (performance regression?)"
+    );
+
+    eprintln!(
+        "sorted_slot_reads_correct_and_fast: K={K_NEIGHBORS}/N={N_FRIENDS} elapsed={elapsed:?}"
+    );
+}
+
 // ── test 4: batch-read does not mix properties across slots ──────────────────
 
 /// The integer `idx` property must match the node it was assigned to — verifies


### PR DESCRIPTION
## **User description**
## Summary

- `batch_read_node_props` was calling `read_col_all` per column, reading **all N nodes** to project **K neighbors' properties** — O(N×C) I/O regardless of how few neighbors a hop query returns.
- New `read_col_slots_sorted` opens each column file once and seeks to `slot * 8` for each needed slot (ascending order for sequential-ish I/O) — **O(K×C) I/O**.
- `batch_read_node_props` selects the strategy based on K/N ratio: sorted reads when K < 50% of N, full-column load otherwise.
- No changes to engine.rs callers — the optimization is entirely within `NodeStore`.

**Expected improvement**: proportional to N/K ratio. For Q3/Q4 with 4039 nodes and 100 neighbors returned: **~40× fewer bytes read per column per hop query**.

## What changed

- `crates/sparrowdb-storage/src/node_store.rs`: Added `read_col_slots_sorted` (new private method) and updated `batch_read_node_props` to use it when K < N/2.
- `crates/sparrowdb/tests/spa_200_batch_hop_perf.rs`: Added `sorted_slot_reads_correct_and_fast` test — 1000 Friend nodes, src connected to 50 (K/N=5%), verifies row count + property values + completes <5s in debug mode.

## Test plan

- [x] `cargo check -p sparrowdb` — zero errors
- [x] `cargo test --test spa_200_batch_hop_perf` — 5/5 pass (including new perf test)
- [x] `cargo test -p sparrowdb` — all tests pass; only pre-existing `spa_168_degree_cache_wiring` failures remain (unrelated, present on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Speed up hop queries by reading only the needed node properties

### What Changed
- Hop queries now read just the requested neighbor slots when only a small part of a label is needed, instead of loading every node in the column
- When most nodes are needed, the query still uses the full-column path
- Added a test that checks the new path returns the right rows and finishes within a reasonable time

### Impact
`✅ Faster hop queries on large graphs`
`✅ Fewer bytes read for small neighbor sets`
`✅ Lower query latency when only a few matches are returned`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced query execution efficiency with optimized data access patterns for large-scale graph traversals.

* **Tests**
  * Added performance regression test to validate query execution speed and correctness for multi-hop graph operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->