### PR TITLE
perf(storage): batch column writes per transaction — closes #212

### DIFF
--- a/crates/sparrowdb-storage/src/node_store.rs
+++ b/crates/sparrowdb-storage/src/node_store.rs
@@ -780,6 +780,227 @@ impl NodeStore {
         Ok(NodeId((label_id as u64) << 32 | slot as u64))
     }
 
+    /// Batch-write column data for multiple nodes created in a single transaction
+    /// commit (SPA-212 write-amplification fix).
+    ///
+    /// # Why this exists
+    ///
+    /// The naive path calls `create_node_at_slot` per node, which opens and
+    /// closes every column file once per node.  For a transaction that creates
+    /// `N` nodes each with `C` columns, that is `O(N × C)` file-open/close
+    /// syscalls.
+    ///
+    /// This method instead:
+    /// 1. Accepts pre-encoded `(label_id, col_id, slot, raw_value, is_present)`
+    ///    tuples from the caller (value encoding happens in `commit()` before
+    ///    the call).
+    /// 2. Sorts by `(label_id, col_id)` so all writes to the same column file
+    ///    are contiguous.
+    /// 3. Opens each `(label_id, col_id)` file exactly **once**, writes all
+    ///    slots for that column, then closes it — reducing file opens to
+    ///    `O(labels × cols)`.
+    /// 4. Updates each null-bitmap file once per `(label_id, col_id)` group.
+    ///
+    /// HWM advances are applied for every `(label_id, slot)` in `node_slots`,
+    /// exactly as `create_node_at_slot` would do them.  `node_slots` must
+    /// include **all** created nodes — including those with zero properties —
+    /// so that the HWM is advanced even for property-less nodes.
+    ///
+    /// # Rollback
+    ///
+    /// On I/O failure the method truncates every file that was opened back to
+    /// its pre-call size, matching the rollback contract of
+    /// `create_node_at_slot`.
+    pub fn batch_write_node_creates(
+        &mut self,
+        // (label_id, col_id, slot, raw_u64, is_present)
+        mut writes: Vec<(u32, u32, u32, u64, bool)>,
+        // All (label_id, slot) pairs for every created node, including those
+        // with zero properties.
+        node_slots: &[(u32, u32)],
+    ) -> Result<()> {
+        use std::io::{Seek, SeekFrom, Write};
+
+        if writes.is_empty() && node_slots.is_empty() {
+            return Ok(());
+        }
+
+        // Sort by (label_id, col_id, slot) so all writes to the same file are
+        // contiguous.
+        writes.sort_unstable_by_key(|&(lid, cid, slot, _, _)| (lid, cid, slot));
+
+        // Snapshot original sizes for rollback.  We only need one entry per
+        // (label_id, col_id) pair.
+        let mut original_sizes: Vec<(u32, u32, PathBuf, u64)> = Vec::new();
+        {
+            let mut prev_key: Option<(u32, u32)> = None;
+            for &(lid, cid, _, _, _) in &writes {
+                let key = (lid, cid);
+                if prev_key == Some(key) {
+                    continue;
+                }
+                prev_key = Some(key);
+                let path = self.col_path(lid, cid);
+                let original = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+                original_sizes.push((lid, cid, path, original));
+            }
+        }
+        // Also snapshot null-bitmap files (one per col group).
+        let mut bitmap_originals: Vec<(u32, u32, PathBuf, u64)> = Vec::new();
+        {
+            let mut prev_key: Option<(u32, u32)> = None;
+            for &(lid, cid, _, _, is_present) in &writes {
+                if !is_present {
+                    continue;
+                }
+                let key = (lid, cid);
+                if prev_key == Some(key) {
+                    continue;
+                }
+                prev_key = Some(key);
+                let path = self.null_bitmap_path(lid, cid);
+                let original = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+                bitmap_originals.push((lid, cid, path, original));
+            }
+        }
+
+        let write_result = (|| -> Result<()> {
+            let mut i = 0;
+            while i < writes.len() {
+                let (lid, cid, _, _, _) = writes[i];
+
+                // Find the end of this (label_id, col_id) group.
+                let group_start = i;
+                while i < writes.len() && writes[i].0 == lid && writes[i].1 == cid {
+                    i += 1;
+                }
+                let group = &writes[group_start..i];
+
+                // ── Column file ──────────────────────────────────────────────
+                let path = self.col_path(lid, cid);
+                if let Some(parent) = path.parent() {
+                    fs::create_dir_all(parent).map_err(Error::Io)?;
+                }
+                let mut file = fs::OpenOptions::new()
+                    .create(true)
+                    .truncate(false)
+                    .read(true)
+                    .write(true)
+                    .open(&path)
+                    .map_err(Error::Io)?;
+
+                let mut current_len = file.seek(SeekFrom::End(0)).map_err(Error::Io)?;
+
+                for &(_, _, slot, raw_value, _) in group {
+                    let expected_offset = slot as u64 * 8;
+                    // Pad with zeros for any skipped slots.
+                    if current_len < expected_offset {
+                        file.seek(SeekFrom::Start(current_len)).map_err(Error::Io)?;
+                        const CHUNK: usize = 65536;
+                        let zeros = [0u8; CHUNK];
+                        let mut remaining = (expected_offset - current_len) as usize;
+                        while remaining > 0 {
+                            let n = remaining.min(CHUNK);
+                            file.write_all(&zeros[..n]).map_err(Error::Io)?;
+                            remaining -= n;
+                        }
+                        current_len = expected_offset;
+                    }
+                    // Seek to exact slot and write.
+                    file.seek(SeekFrom::Start(expected_offset))
+                        .map_err(Error::Io)?;
+                    file.write_all(&raw_value.to_le_bytes()).map_err(Error::Io)?;
+                    // Advance current_len to reflect what we wrote.
+                    let after = expected_offset + 8;
+                    if after > current_len {
+                        current_len = after;
+                    }
+                }
+
+                // ── Null bitmap (one read-modify-write per col group) ────────
+                let present_slots: Vec<u32> = group
+                    .iter()
+                    .filter(|&&(_, _, _, _, is_present)| is_present)
+                    .map(|&(_, _, slot, _, _)| slot)
+                    .collect();
+
+                if !present_slots.is_empty() {
+                    let bmap_path = self.null_bitmap_path(lid, cid);
+                    if let Some(parent) = bmap_path.parent() {
+                        fs::create_dir_all(parent).map_err(Error::Io)?;
+                    }
+                    let mut bits = if bmap_path.exists() {
+                        fs::read(&bmap_path).map_err(Error::Io)?
+                    } else {
+                        vec![]
+                    };
+                    for slot in present_slots {
+                        let byte_idx = (slot / 8) as usize;
+                        let bit_idx = slot % 8;
+                        if bits.len() <= byte_idx {
+                            bits.resize(byte_idx + 1, 0);
+                        }
+                        bits[byte_idx] |= 1 << bit_idx;
+                    }
+                    fs::write(&bmap_path, &bits).map_err(Error::Io)?;
+                }
+            }
+            Ok(())
+        })();
+
+        if let Err(e) = write_result {
+            // Roll back column files.
+            for (_, _, path, original_size) in &original_sizes {
+                if path.exists() {
+                    if let Err(rollback_err) = fs::OpenOptions::new()
+                        .write(true)
+                        .open(path)
+                        .and_then(|f| f.set_len(*original_size))
+                    {
+                        eprintln!(
+                            "CRITICAL: Failed to roll back column file {} to size {}: {}. Data may be corrupt.",
+                            path.display(),
+                            original_size,
+                            rollback_err
+                        );
+                    }
+                }
+            }
+            // Roll back null bitmap files.
+            for (_, _, path, original_size) in &bitmap_originals {
+                if path.exists() {
+                    if let Err(rollback_err) = fs::OpenOptions::new()
+                        .write(true)
+                        .open(path)
+                        .and_then(|f| f.set_len(*original_size))
+                    {
+                        eprintln!(
+                            "CRITICAL: Failed to roll back null bitmap file {} to size {}: {}. Data may be corrupt.",
+                            path.display(),
+                            original_size,
+                            rollback_err
+                        );
+                    }
+                }
+            }
+            return Err(e);
+        }
+
+        // Advance HWMs using the explicit node_slots list so that nodes with
+        // zero properties also advance the HWM, matching the contract of
+        // create_node_at_slot.
+        for &(lid, slot) in node_slots {
+            let new_hwm = slot as u64 + 1;
+            let mem_hwm = self.hwm.get(&lid).copied().unwrap_or(0);
+            if new_hwm > mem_hwm {
+                self.hwm.insert(lid, new_hwm);
+            }
+            self.hwm_dirty.insert(lid);
+        }
+
+        Ok(())
+    }
+
     /// Create a new node in `label_id` with the given properties.
     ///
     /// Returns the new [`NodeId`] packed as `(label_id << 32) | slot`.

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -3027,6 +3027,17 @@ impl WriteTx {
 
         // Step 5: Apply buffered structural operations to disk (SPA-181).
         // WAL is already durable at this point; a crash here is safe.
+        //
+        // SPA-212 (write-amplification fix): NodeCreate ops are collected into a
+        // single batch and written via `batch_write_node_creates`, which opens
+        // each (label_id, col_id) file only once regardless of how many nodes
+        // share that column.  This reduces file-open syscalls from O(nodes×cols)
+        // to O(labels×cols) per transaction commit.
+        let mut col_writes: Vec<(u32, u32, u32, u64, bool)> = Vec::new();
+        // All (label_id, slot) pairs for created nodes — needed for HWM
+        // advancement, even when a node has zero properties.
+        let mut node_slots: Vec<(u32, u32)> = Vec::new();
+
         for op in self.pending_ops.drain(..) {
             match op {
                 PendingOp::NodeCreate {
@@ -3034,7 +3045,14 @@ impl WriteTx {
                     slot,
                     props,
                 } => {
-                    self.store.create_node_at_slot(label_id, slot, &props)?;
+                    // Track this node's (label_id, slot) for HWM advancement.
+                    node_slots.push((label_id, slot));
+                    // Encode each property value and push (label_id, col_id,
+                    // slot, raw_u64, is_present) into the batch buffer.
+                    for (col_id, ref val) in props {
+                        let raw = self.store.encode_value(val)?;
+                        col_writes.push((label_id, col_id, slot, raw, true));
+                    }
                 }
                 PendingOp::NodeDelete { node_id } => {
                     self.store.tombstone_node(node_id)?;
@@ -3063,14 +3081,18 @@ impl WriteTx {
             }
         }
 
+        // Flush all NodeCreate column writes in one batched call.
+        // O(labels × cols) file opens instead of O(nodes × cols).
+        self.store.batch_write_node_creates(col_writes, &node_slots)?;
+
         // Step 5b: Persist HWMs for all labels that received new nodes in Step 5.
         //
-        // create_node_at_slot() only advances the in-memory HWM and marks the
-        // label as dirty (hwm_dirty).  We flush all dirty HWMs here — once per
-        // commit — instead of once per node, avoiding an fsync storm during bulk
-        // imports (SPA-217 regression fix).  Crash safety is preserved: the WAL
-        // record written in Step 4 is already durable; on crash-recovery, the
-        // WAL replayer re-applies all NodeCreate ops and re-advances the HWM.
+        // batch_write_node_creates() advances the in-memory HWM and marks
+        // labels dirty (hwm_dirty).  We flush all dirty HWMs here — once per
+        // commit — avoiding an fsync storm during bulk imports (SPA-217
+        // regression fix).  Crash safety is preserved: the WAL record written
+        // in Step 4 is already durable; on crash-recovery, the WAL replayer
+        // re-applies all NodeCreate ops and re-advances the HWM.
         self.store.flush_hwms()?;
 
         // Step 6: Flush property updates to disk.


### PR DESCRIPTION
## **User description**
## Summary

- Adds `batch_write_node_creates` to `NodeStore` that accepts all `(label_id, col_id, slot, raw_u64, is_present)` tuples for a transaction, sorts by `(label_id, col_id)`, and writes each column file exactly **once** per commit
- Modifies `WriteTx::commit` to collect all `NodeCreate` column data into a batch buffer and flush via the new method — `O(labels × cols)` file opens instead of `O(nodes × cols)`
- Null bitmaps also updated once per `(label, col)` group instead of once per `(node, col)`
- Explicit `node_slots` list passed to the batch method ensures HWM advances for property-less nodes (avoids the bug where empty-prop nodes would not advance the HWM)
- Rollback on partial I/O failure truncates all touched column and bitmap files to pre-call size — same crash-safety contract as `create_node_at_slot`

## Test plan

- [x] `cargo check -p sparrowdb` — zero errors
- [x] Full `cargo test -p sparrowdb` — all tests pass; only 2 pre-existing failures in `spa_168_degree_cache_wiring` which also fail on `main`
- [ ] SparrowTest import benchmark — notified via AgentBus after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Speed up node creation during bulk writes**

### What Changed
- Node creations are now written in batches, so shared column files are opened once per transaction instead of once per node
- Nodes with no properties still advance their position correctly, avoiding gaps or missing entries
- If a write fails partway through, the affected files are rolled back to their previous sizes

### Impact
`✅ Faster bulk imports`
`✅ Fewer write-related slowdowns`
`✅ Safer recovery after failed writes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized bulk node creation by batching multiple write operations into a single efficient write cycle, reducing disk I/O overhead and improving throughput for large-scale operations.
  * Enhanced reliability with automatic rollback mechanisms that restore data integrity when write operations encounter failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->