### PR TITLE
fix(engine): edge props return correct values after CHECKPOINT — closes #240

### DIFF
--- a/crates/sparrowdb-execution/src/engine/hop.rs
+++ b/crates/sparrowdb-execution/src/engine/hop.rs
@@ -150,40 +150,32 @@ impl Engine {
                 edge_store.and_then(|s| s.read_delta()).unwrap_or_default()
             };
 
-            // SPA-178: Build (src_slot, dst_slot) → edge_id map for delta edges.
-            // This lets us look up which edge a (src, dst) pair corresponds to
-            // when reading edge properties.
-            let delta_edge_id_map: std::collections::HashMap<(u64, u64), u64> =
-                delta_records_all
-                    .iter()
-                    .enumerate()
-                    .map(|(idx, r)| {
-                        let s = r.src.0 & 0xFFFF_FFFF;
-                        let d = r.dst.0 & 0xFFFF_FFFF;
-                        ((s, d), idx as u64)
-                    })
-                    .collect();
-
-            // SPA-178: Pre-read all edge props for this rel table if any edge
+            // SPA-240: Pre-read all edge props for this rel table if any edge
             // property access is needed (inline filter or projection).
+            //
+            // edge_props.bin is now keyed by (src_slot, dst_slot) rather than by
+            // the transient delta-log edge_id.  This makes lookups correct for
+            // both pre- and post-checkpoint databases; previously the lookup via
+            // delta_edge_id_map always returned None after CHECKPOINT because the
+            // delta log is truncated on checkpoint.
             let needs_edge_props = !rel_pat.props.is_empty()
                 || (!rel_pat.var.is_empty()
                     && column_names.iter().any(|c| {
                         c.split_once('.')
                             .map_or(false, |(v, _)| v == rel_pat.var.as_str())
                     }));
-            let all_edge_props_raw: Vec<(u64, u32, u64)> = if needs_edge_props {
+            let all_edge_props_raw: Vec<(u64, u64, u32, u64)> = if needs_edge_props {
                 EdgeStore::open(&self.snapshot.db_root, storage_rel_id)
                     .and_then(|s| s.read_all_edge_props())
                     .unwrap_or_default()
             } else {
                 vec![]
             };
-            // Group by edge_id: last-write-wins per col_id.
-            let mut edge_props_by_id: std::collections::HashMap<u64, Vec<(u32, u64)>> =
+            // Group by (src_slot, dst_slot): last-write-wins per col_id.
+            let mut edge_props_by_slots: std::collections::HashMap<(u64, u64), Vec<(u32, u64)>> =
                 std::collections::HashMap::new();
-            for (edge_id, col_id, value) in &all_edge_props_raw {
-                let entry = edge_props_by_id.entry(*edge_id).or_default();
+            for (src_s, dst_s, col_id, value) in &all_edge_props_raw {
+                let entry = edge_props_by_slots.entry((*src_s, *dst_s)).or_default();
                 if let Some(existing) = entry.iter_mut().find(|(c, _)| *c == *col_id) {
                     existing.1 = *value;
                 } else {
@@ -326,11 +318,13 @@ impl Engine {
                         continue;
                     }
 
-                    // SPA-178: look up edge props for this (src_slot, dst_slot) pair.
+                    // SPA-240: look up edge props for this (src_slot, dst_slot) pair.
+                    // Works for both delta-only and checkpointed edges because
+                    // edge_props.bin is now keyed by (src_slot, dst_slot).
                     let current_edge_props: Vec<(u32, u64)> =
                         if needs_edge_props {
-                            let eid = delta_edge_id_map.get(&(src_slot, dst_slot)).copied();
-                            eid.and_then(|id| edge_props_by_id.get(&id))
+                            edge_props_by_slots
+                                .get(&(src_slot, dst_slot))
                                 .cloned()
                                 .unwrap_or_default()
                         } else {

--- a/crates/sparrowdb-storage/src/edge_store.rs
+++ b/crates/sparrowdb-storage/src/edge_store.rs
@@ -392,23 +392,32 @@ impl EdgeStore {
         CsrBackward::open(&self.bwd_path())
     }
 
-    // ── Edge property storage (SPA-178) ───────────────────────────────────────
+    // ── Edge property storage (SPA-178 / SPA-240) ────────────────────────────
 
     fn edge_props_path(&self) -> PathBuf {
         self.rel_dir.join("edge_props.bin")
     }
 
-    /// Append a single property record for `edge_id`.
+    /// Append a single property record for the edge identified by `(src_slot, dst_slot)`.
     ///
-    /// Record format: `edge_id (u64 LE) + col_id (u32 LE) + value (u64 LE)` = 20 bytes.
+    /// Record format (28 bytes):
+    /// ```text
+    /// [src_slot: u64 LE][dst_slot: u64 LE][col_id: u32 LE][value: u64 LE]
+    /// ```
     ///
-    /// The file is append-only; multiple calls for the same `(edge_id, col_id)`
-    /// result in multiple records — the last written value wins on read-back.
-    pub fn set_edge_prop(&self, edge_id: u64, col_id: u32, value: u64) -> Result<()> {
-        let mut buf = [0u8; 20];
-        buf[0..8].copy_from_slice(&edge_id.to_le_bytes());
-        buf[8..12].copy_from_slice(&col_id.to_le_bytes());
-        buf[12..20].copy_from_slice(&value.to_le_bytes());
+    /// The file is append-only; multiple calls for the same `(src_slot, dst_slot,
+    /// col_id)` result in multiple records — the last written value wins on read-back.
+    ///
+    /// Keying by `(src_slot, dst_slot)` instead of by the transient `edge_id`
+    /// (delta-log position) means that properties survive `CHECKPOINT`, which
+    /// truncates the delta log and resets all edge IDs to zero.  A lookup by
+    /// node slots works correctly for both delta and CSR edges.
+    pub fn set_edge_prop(&self, src_slot: u64, dst_slot: u64, col_id: u32, value: u64) -> Result<()> {
+        let mut buf = [0u8; 28];
+        buf[0..8].copy_from_slice(&src_slot.to_le_bytes());
+        buf[8..16].copy_from_slice(&dst_slot.to_le_bytes());
+        buf[16..20].copy_from_slice(&col_id.to_le_bytes());
+        buf[20..28].copy_from_slice(&value.to_le_bytes());
 
         let mut file = fs::OpenOptions::new()
             .create(true)
@@ -419,31 +428,32 @@ impl EdgeStore {
         Ok(())
     }
 
-    /// Read all properties for the given `edge_id`.
+    /// Read all properties for the edge identified by `(src_slot, dst_slot)`.
     ///
     /// Performs a linear scan of `edge_props.bin`.  Returns a `Vec<(col_id, value)>`
-    /// containing the last-written value for each `col_id` seen for this `edge_id`.
-    pub fn get_edge_props(&self, edge_id: u64) -> Result<Vec<(u32, u64)>> {
+    /// containing the last-written value for each `col_id` seen for this edge.
+    pub fn get_edge_props(&self, src_slot: u64, dst_slot: u64) -> Result<Vec<(u32, u64)>> {
         let path = self.edge_props_path();
         if !path.exists() {
             return Ok(vec![]);
         }
         let bytes = fs::read(&path).map_err(Error::Io)?;
-        if bytes.len() % 20 != 0 {
+        if bytes.len() % 28 != 0 {
             return Err(Error::Corruption(format!(
-                "edge_props.bin size {} is not a multiple of 20",
+                "edge_props.bin size {} is not a multiple of 28",
                 bytes.len()
             )));
         }
         // Collect last-written value for each col_id (later writes win).
         let mut result: Vec<(u32, u64)> = Vec::new();
-        for chunk in bytes.chunks_exact(20) {
-            let eid = u64::from_le_bytes(chunk[0..8].try_into().unwrap());
-            if eid != edge_id {
+        for chunk in bytes.chunks_exact(28) {
+            let s = u64::from_le_bytes(chunk[0..8].try_into().unwrap());
+            let d = u64::from_le_bytes(chunk[8..16].try_into().unwrap());
+            if s != src_slot || d != dst_slot {
                 continue;
             }
-            let col_id = u32::from_le_bytes(chunk[8..12].try_into().unwrap());
-            let value = u64::from_le_bytes(chunk[12..20].try_into().unwrap());
+            let col_id = u32::from_le_bytes(chunk[16..20].try_into().unwrap());
+            let value = u64::from_le_bytes(chunk[20..28].try_into().unwrap());
             // Update or insert — last write wins.
             if let Some(entry) = result.iter_mut().find(|(c, _)| *c == col_id) {
                 entry.1 = value;
@@ -454,29 +464,31 @@ impl EdgeStore {
         Ok(result)
     }
 
-    /// Read ALL edge properties from `edge_props.bin` and return them grouped
-    /// by `edge_id` as a `Vec<(edge_id, col_id, value)>`.
+    /// Read ALL edge properties from `edge_props.bin` and return them as
+    /// `Vec<(src_slot, dst_slot, col_id, value)>`.
     ///
     /// Used by the query engine to load all edge props in one pass, then index
-    /// by `edge_id` for O(1) per-edge lookup during result projection.
-    pub fn read_all_edge_props(&self) -> Result<Vec<(u64, u32, u64)>> {
+    /// by `(src_slot, dst_slot)` for O(1) per-edge lookup during result projection.
+    /// This lookup works for both delta-only edges and checkpointed CSR edges.
+    pub fn read_all_edge_props(&self) -> Result<Vec<(u64, u64, u32, u64)>> {
         let path = self.edge_props_path();
         if !path.exists() {
             return Ok(vec![]);
         }
         let bytes = fs::read(&path).map_err(Error::Io)?;
-        if bytes.len() % 20 != 0 {
+        if bytes.len() % 28 != 0 {
             return Err(Error::Corruption(format!(
-                "edge_props.bin size {} is not a multiple of 20",
+                "edge_props.bin size {} is not a multiple of 28",
                 bytes.len()
             )));
         }
-        let mut result = Vec::with_capacity(bytes.len() / 20);
-        for chunk in bytes.chunks_exact(20) {
-            let edge_id = u64::from_le_bytes(chunk[0..8].try_into().unwrap());
-            let col_id = u32::from_le_bytes(chunk[8..12].try_into().unwrap());
-            let value = u64::from_le_bytes(chunk[12..20].try_into().unwrap());
-            result.push((edge_id, col_id, value));
+        let mut result = Vec::with_capacity(bytes.len() / 28);
+        for chunk in bytes.chunks_exact(28) {
+            let src_slot = u64::from_le_bytes(chunk[0..8].try_into().unwrap());
+            let dst_slot = u64::from_le_bytes(chunk[8..16].try_into().unwrap());
+            let col_id = u32::from_le_bytes(chunk[16..20].try_into().unwrap());
+            let value = u64::from_le_bytes(chunk[20..28].try_into().unwrap());
+            result.push((src_slot, dst_slot, col_id, value));
         }
         Ok(result)
     }

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -3064,10 +3064,15 @@ impl WriteTx {
                     props,
                 } => {
                     let mut es = EdgeStore::open(&self.inner.path, rel_table_id)?;
-                    let edge_id = es.create_edge(src, rel_table_id, dst)?;
-                    // Persist edge properties after writing the edge record.
-                    for (col_id, value) in &props {
-                        es.set_edge_prop(edge_id.0, *col_id, *value)?;
+                    es.create_edge(src, rel_table_id, dst)?;
+                    // Persist edge properties keyed by (src_slot, dst_slot) so
+                    // that reads work correctly after CHECKPOINT (SPA-240).
+                    if !props.is_empty() {
+                        let src_slot = src.0 & 0xFFFF_FFFF;
+                        let dst_slot = dst.0 & 0xFFFF_FFFF;
+                        for (col_id, value) in &props {
+                            es.set_edge_prop(src_slot, dst_slot, *col_id, *value)?;
+                        }
                     }
                 }
                 PendingOp::EdgeDelete {

--- a/crates/sparrowdb/tests/spa_178_edge_properties.rs
+++ b/crates/sparrowdb/tests/spa_178_edge_properties.rs
@@ -5,6 +5,10 @@
 //!  2. Edge property filter (match): [r:KNOWS {since:2020}] returns matching node
 //!  3. Edge property filter (no match): [r:KNOWS {since:1999}] returns nothing
 //!  4. Multiple edge properties: {weight: 5, active: 1}, RETURN r.weight, r.active
+//!  5. (SPA-240) Edge props survive CHECKPOINT — int property
+//!  6. (SPA-240) Edge props survive CHECKPOINT — float property
+//!  7. (SPA-240) Edge props survive CHECKPOINT — string property
+//!  8. (SPA-240) Edge prop filter works after CHECKPOINT
 
 use sparrowdb::{open, GraphDb};
 use sparrowdb_execution::Value;
@@ -109,5 +113,109 @@ fn test_edge_prop_multiple_props() {
         result.rows[0],
         vec![Value::Int64(5), Value::Int64(1)],
         "r.weight=5, r.active=1"
+    );
+}
+
+// ── SPA-240 regression tests: edge props must survive CHECKPOINT ──────────────
+
+/// Test 5 (SPA-240): integer edge property is readable after CHECKPOINT.
+///
+/// Before the fix, CHECKPOINT truncated the delta log which caused the
+/// (src_slot, dst_slot) → edge_id map in the hop engine to be empty, so all
+/// edge property reads returned null post-checkpoint.
+#[test]
+fn test_edge_prop_int_survives_checkpoint() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (a:P {n:1})-[:K {score:42}]->(b:P {n:2})")
+        .expect("create");
+    db.checkpoint().expect("checkpoint");
+
+    let result = db
+        .execute("MATCH (a:P)-[r:K]->(b:P) RETURN r.score")
+        .expect("match after checkpoint");
+
+    assert_eq!(result.rows.len(), 1, "expected one edge after checkpoint");
+    assert_eq!(
+        result.rows[0],
+        vec![Value::Int64(42)],
+        "r.score must be 42 after checkpoint (SPA-240)"
+    );
+}
+
+/// Test 6 (SPA-240): float edge property is readable after CHECKPOINT.
+#[test]
+fn test_edge_prop_float_survives_checkpoint() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (a:P {n:1})-[:K {rating:3.14}]->(b:P {n:2})")
+        .expect("create");
+    db.checkpoint().expect("checkpoint");
+
+    let result = db
+        .execute("MATCH (a:P)-[r:K]->(b:P) RETURN r.rating")
+        .expect("match after checkpoint");
+
+    assert_eq!(result.rows.len(), 1, "expected one edge after checkpoint");
+    match &result.rows[0][0] {
+        Value::Float64(v) => assert!(
+            (*v - 3.14_f64).abs() < 1e-9,
+            "r.rating must be ~3.14 after checkpoint, got {v}"
+        ),
+        other => panic!("expected Float64, got {other:?}"),
+    }
+}
+
+/// Test 7 (SPA-240): string edge property is readable after CHECKPOINT.
+#[test]
+fn test_edge_prop_string_survives_checkpoint() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (a:P {n:1})-[:K {label:\"hello\"}]->(b:P {n:2})")
+        .expect("create");
+    db.checkpoint().expect("checkpoint");
+
+    let result = db
+        .execute("MATCH (a:P)-[r:K]->(b:P) RETURN r.label")
+        .expect("match after checkpoint");
+
+    assert_eq!(result.rows.len(), 1, "expected one edge after checkpoint");
+    assert_eq!(
+        result.rows[0],
+        vec![Value::String("hello".to_string())],
+        "r.label must be 'hello' after checkpoint (SPA-240)"
+    );
+}
+
+/// Test 8 (SPA-240): edge prop inline filter works after CHECKPOINT.
+///
+/// MATCH (a)-[r:K {score:42}]->(b) must return the edge; MATCH with
+/// score:99 must return nothing.
+#[test]
+fn test_edge_prop_filter_survives_checkpoint() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (a:P {n:1})-[:K {score:42}]->(b:P {n:2})")
+        .expect("create");
+    db.checkpoint().expect("checkpoint");
+
+    // Matching filter — should return one row.
+    let hit = db
+        .execute("MATCH (a:P)-[r:K {score:42}]->(b:P) RETURN b.n")
+        .expect("match hit after checkpoint");
+    assert_eq!(
+        hit.rows.len(),
+        1,
+        "filter score=42 must match after checkpoint"
+    );
+
+    // Non-matching filter — should return no rows.
+    let miss = db
+        .execute("MATCH (a:P)-[r:K {score:99}]->(b:P) RETURN b.n")
+        .expect("match miss after checkpoint");
+    assert_eq!(
+        miss.rows.len(),
+        0,
+        "filter score=99 must not match after checkpoint"
     );
 }


### PR DESCRIPTION
## **User description**
## Summary

- Edge properties (int, float, string) were returning `null` on all reads after `CHECKPOINT` was called
- Node properties were unaffected
- Discovered via MovieLens import: 100,836 RATED edges with `{rating: float, timestamp: int}` — all null on read

## Root Cause

`edge_props.bin` was keyed by **transient delta-log `edge_id`** (the record's position index in `delta.log`). `CHECKPOINT` truncates the delta log to zero and resets `next_edge_id = 0`. The hop engine built a `delta_edge_id_map: HashMap<(src_slot, dst_slot), edge_id>` from the current delta records — but after checkpoint the delta is empty, so this map is always empty and all edge prop lookups return `None` → null.

## Fix

Changed `edge_props.bin` record format from **20 bytes** `(edge_id:u64, col_id:u32, value:u64)` to **28 bytes** `(src_slot:u64, dst_slot:u64, col_id:u32, value:u64)`. Keying by node slots works correctly for both delta-only and post-checkpoint CSR edges.

The hop engine now indexes `edge_props_by_slots: HashMap<(src_slot, dst_slot), Vec<(col_id, value)>>` directly, eliminating the now-unnecessary `delta_edge_id_map` indirection entirely.

## Files Changed

- `crates/sparrowdb-storage/src/edge_store.rs` — new record format, updated `set_edge_prop` / `get_edge_props` / `read_all_edge_props` signatures
- `crates/sparrowdb/src/lib.rs` — write path passes `(src_slot, dst_slot)` instead of `edge_id`
- `crates/sparrowdb-execution/src/engine/hop.rs` — read path keys by slots directly, removes `delta_edge_id_map`
- `crates/sparrowdb/tests/spa_178_edge_properties.rs` — 4 new SPA-240 regression tests

## Test plan

- [x] `cargo check -p sparrowdb` — no errors
- [x] `cargo test --test spa_178_edge_properties` — 8/8 pass (4 existing + 4 new SPA-240 regression tests)
- [x] `cargo test -p sparrowdb` — all suites pass (pre-existing `spa_168_degree_cache_wiring` failures are unrelated and pre-date this branch)

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep edge properties readable after checkpointing**

### What Changed
- Edge property values now stay available after a checkpoint, instead of turning into null on later reads.
- Edge property filters also continue to work after checkpointing, including matches that use property values in the relationship pattern.
- Added coverage for integer, float, and string edge properties after checkpoint, plus a filter case that matches and misses as expected.

### Impact
`✅ Edge properties still show after checkpoint`
`✅ Fewer null edge values in graph reads`
`✅ Reliable edge property filters after checkpoint`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue where edge properties were lost after database checkpoint operations, ensuring data persistence and consistency.

* **Tests**
  * Added regression tests verifying that edge properties with various data types (integers, floats, strings) persist and remain queryable after checkpointing.
  * Added tests confirming inline edge property filtering queries continue to work correctly on checkpointed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->