### PR TITLE
fix(engine): two-hop intermediate node props use correct slot→index mapping — closes #241

### DIFF
--- a/crates/sparrowdb-execution/src/engine/hop.rs
+++ b/crates/sparrowdb-execution/src/engine/hop.rs
@@ -848,7 +848,7 @@ impl Engine {
 
         // Collect col_ids for src: columns referenced in RETURN (for projection)
         // plus columns referenced in WHERE for the src variable.
-        // SPA-252: projection columns must be included so that project_fof_row
+        // SPA-252: projection columns must be included so that project_three_var_row
         // can resolve src-variable columns (e.g. `RETURN a.name` when src_var = "a").
         let col_ids_src_where: Vec<u32> = {
             let mut ids = collect_col_ids_for_var(&src_node_pat.var, column_names, src_label_id);
@@ -884,7 +884,11 @@ impl Engine {
                 .map(|id| id as u32)
                 .unwrap_or(src_label_id)
         };
-        let col_ids_mid: Vec<u32> = if second_hop_incoming && !mid_node_pat.var.is_empty() {
+        // SPA-241: collect col_ids for the mid node for BOTH forward-forward
+        // and incoming patterns.  Previously this was only populated for the
+        // incoming case, leaving mid node properties unresolvable in the
+        // forward-forward path (a)-[:R]->(m)-[:R]->(b).
+        let col_ids_mid: Vec<u32> = if !mid_node_pat.var.is_empty() {
             let mut ids = collect_col_ids_for_var(&mid_node_pat.var, column_names, mid_label_id);
             for p in &mid_node_pat.props {
                 let col_id = prop_name_to_col_id(&p.key);
@@ -1178,139 +1182,194 @@ impl Engine {
             }
 
             // ── Forward-forward path (both hops Outgoing) ─────────────────────
-            let mut fof_slots: Vec<u64> = {
-                // Use ASP-Join.
-                join.two_hop(src_slot)?
+            // SPA-241: use factorized join to preserve mid_slot→fof_slots mapping.
+            // The previous flat two_hop() call discarded which mid node connected
+            // src to each fof, making it impossible to read or return mid properties.
+            let mut mid_fof_pairs: Vec<(u64, Vec<u64>)> = {
+                let chunk = join.two_hop_factorized(src_slot)?;
+                chunk.groups.into_iter().map(|g| (g.mid_slot, g.fof_slots)).collect()
             };
 
-            // SPA-163: extend with delta-log 2-hop paths (forward-forward only).
+            // SPA-163 + SPA-241: extend with delta-log 2-hop paths, preserving
+            // the mid→fof structure so we can read mid node properties.
             {
                 let first_hop_delta = delta_adj
                     .get(&src_slot)
                     .map(|v| v.as_slice())
                     .unwrap_or(&[]);
                 if !first_hop_delta.is_empty() {
-                    let mut delta_fof: HashSet<u64> = HashSet::new();
                     for &mid_slot in first_hop_delta {
-                        // CSR second hop from mid (use merged multi-type CSR):
+                        let mut fof_for_mid: HashSet<u64> = HashSet::new();
+                        // CSR second hop from mid:
                         for &fof in merged_csr.neighbors(mid_slot) {
-                            delta_fof.insert(fof);
+                            fof_for_mid.insert(fof);
                         }
                         // Delta second hop from mid:
                         if let Some(mid_neighbors) = delta_adj.get(&mid_slot) {
                             for &fof in mid_neighbors {
-                                delta_fof.insert(fof);
+                                fof_for_mid.insert(fof);
+                            }
+                        }
+                        if !fof_for_mid.is_empty() {
+                            // Merge into existing group for this mid_slot or add new.
+                            if let Some(existing) =
+                                mid_fof_pairs.iter_mut().find(|(ms, _)| *ms == mid_slot)
+                            {
+                                for fof in fof_for_mid {
+                                    if !existing.1.contains(&fof) {
+                                        existing.1.push(fof);
+                                    }
+                                }
+                            } else {
+                                let mut fof_vec: Vec<u64> = fof_for_mid.into_iter().collect();
+                                fof_vec.sort_unstable();
+                                mid_fof_pairs.push((mid_slot, fof_vec));
                             }
                         }
                     }
-                    fof_slots.extend(delta_fof);
-                    // Re-deduplicate the combined set.
-                    let unique: HashSet<u64> = fof_slots.into_iter().collect();
-                    fof_slots = unique.into_iter().collect();
-                    fof_slots.sort_unstable();
                 }
             }
 
-            // ── SPA-200: batch-read fof properties — O(cols) fs::read() calls
-            // instead of O(fof_slots × cols). ────────────────────────────────
-            // `col_ids_fof` is constant for this src_slot iteration (determined
-            // by the query structure, not by the specific fof node).
-            let fof_slots_u32: Vec<u32> = fof_slots.iter().map(|&s| s as u32).collect();
+            // Collect all unique fof slots for batch property reads (SPA-200).
+            let all_fof_slots: Vec<u32> = {
+                let mut seen: HashSet<u64> = HashSet::new();
+                let mut v: Vec<u32> = Vec::new();
+                for (_, fof_slots) in &mid_fof_pairs {
+                    for &fof in fof_slots {
+                        if seen.insert(fof) {
+                            v.push(fof as u32);
+                        }
+                    }
+                }
+                v.sort_unstable();
+                v
+            };
+
+            // Batch-read fof properties once per src_slot.
             let fof_batch: Vec<Vec<u64>> = if !col_ids_fof.is_empty() {
                 self.snapshot.store.batch_read_node_props(
                     fof_label_id,
-                    &fof_slots_u32,
+                    &all_fof_slots,
                     &col_ids_fof,
                 )?
             } else {
                 vec![]
             };
-            // Build slot → batch-row index map for O(1) lookup in the inner loop.
-            let fof_slot_to_idx: HashMap<u64, usize> = fof_slots
+            let fof_slot_to_idx: HashMap<u64, usize> = all_fof_slots
                 .iter()
                 .enumerate()
-                .map(|(i, &s)| (s, i))
+                .map(|(i, &s)| (s as u64, i))
                 .collect();
 
-            for fof_slot in fof_slots {
-                let fof_node = NodeId(((fof_label_id as u64) << 32) | fof_slot);
-                // Build fof_props in the same Vec<(col_id, u64)> format as
-                // read_node_props returns: filter out 0-sentinel (absent) values.
-                let fof_props: Vec<(u32, u64)> = if !col_ids_fof.is_empty() {
-                    if let Some(&idx) = fof_slot_to_idx.get(&fof_slot) {
-                        col_ids_fof
-                            .iter()
-                            .copied()
-                            .zip(fof_batch[idx].iter().copied())
-                            .filter(|&(_, v)| v != 0)
-                            .collect()
-                    } else {
-                        // Fallback: individual read (delta-only slot not in batch).
-                        read_node_props(&self.snapshot.store, fof_node, &col_ids_fof)?
-                    }
+            for (mid_slot, fof_slots) in mid_fof_pairs {
+                // SPA-241: read mid node properties for forward-forward path.
+                let mid_node = NodeId(((mid_label_id as u64) << 32) | mid_slot);
+                let mid_props: Vec<(u32, u64)> = if !col_ids_mid.is_empty() {
+                    read_node_props(&self.snapshot.store, mid_node, &col_ids_mid)?
                 } else {
                     vec![]
                 };
 
-                // Apply fof inline prop filter.
-                if !self.matches_prop_filter(&fof_props, &fof_node_pat.props) {
+                // Apply mid inline prop filter.
+                if !self.matches_prop_filter(&mid_props, &mid_node_pat.props) {
                     continue;
                 }
 
-                // Apply WHERE clause predicate.
-                if let Some(ref where_expr) = m.where_clause {
-                    let mut row_vals = build_row_vals(
-                        &src_props,
-                        &src_node_pat.var,
-                        &col_ids_src_where,
-                        &self.snapshot.store,
-                    );
-                    row_vals.extend(build_row_vals(
-                        &fof_props,
-                        &fof_node_pat.var,
-                        &col_ids_fof,
-                        &self.snapshot.store,
-                    ));
-                    // Inject label metadata so labels(n) works in WHERE.
-                    if !src_node_pat.var.is_empty() && !src_label.is_empty() {
-                        row_vals.insert(
-                            format!("{}.__labels__", src_node_pat.var),
-                            Value::List(vec![Value::String(src_label.clone())]),
-                        );
-                    }
-                    if !fof_node_pat.var.is_empty() && !fof_label.is_empty() {
-                        row_vals.insert(
-                            format!("{}.__labels__", fof_node_pat.var),
-                            Value::List(vec![Value::String(fof_label.clone())]),
-                        );
-                    }
-                    // Inject relationship type metadata so type(r) works in WHERE.
-                    if !pat.rels[0].var.is_empty() {
-                        row_vals.insert(
-                            format!("{}.__type__", pat.rels[0].var),
-                            Value::String(pat.rels[0].rel_type.clone()),
-                        );
-                    }
-                    if !pat.rels[1].var.is_empty() {
-                        row_vals.insert(
-                            format!("{}.__type__", pat.rels[1].var),
-                            Value::String(pat.rels[1].rel_type.clone()),
-                        );
-                    }
-                    row_vals.extend(self.dollar_params());
-                    if !self.eval_where_graph(where_expr, &row_vals) {
+                for fof_slot in fof_slots {
+                    let fof_node = NodeId(((fof_label_id as u64) << 32) | fof_slot);
+                    // Build fof_props from batch or fallback individual read.
+                    let fof_props: Vec<(u32, u64)> = if !col_ids_fof.is_empty() {
+                        if let Some(&idx) = fof_slot_to_idx.get(&fof_slot) {
+                            col_ids_fof
+                                .iter()
+                                .copied()
+                                .zip(fof_batch[idx].iter().copied())
+                                .filter(|&(_, v)| v != 0)
+                                .collect()
+                        } else {
+                            // Fallback: individual read (delta-only slot not in batch).
+                            read_node_props(&self.snapshot.store, fof_node, &col_ids_fof)?
+                        }
+                    } else {
+                        vec![]
+                    };
+
+                    // Apply fof inline prop filter.
+                    if !self.matches_prop_filter(&fof_props, &fof_node_pat.props) {
                         continue;
                     }
-                }
 
-                let row = project_fof_row(
-                    &src_props,
-                    &fof_props,
-                    column_names,
-                    &src_node_pat.var,
-                    &self.snapshot.store,
-                );
-                rows.push(row);
+                    // Apply WHERE clause predicate.
+                    if let Some(ref where_expr) = m.where_clause {
+                        let mut row_vals = build_row_vals(
+                            &src_props,
+                            &src_node_pat.var,
+                            &col_ids_src_where,
+                            &self.snapshot.store,
+                        );
+                        row_vals.extend(build_row_vals(
+                            &mid_props,
+                            &mid_node_pat.var,
+                            &col_ids_mid,
+                            &self.snapshot.store,
+                        ));
+                        row_vals.extend(build_row_vals(
+                            &fof_props,
+                            &fof_node_pat.var,
+                            &col_ids_fof,
+                            &self.snapshot.store,
+                        ));
+                        // Inject label metadata so labels(n) works in WHERE.
+                        if !src_node_pat.var.is_empty() && !src_label.is_empty() {
+                            row_vals.insert(
+                                format!("{}.__labels__", src_node_pat.var),
+                                Value::List(vec![Value::String(src_label.clone())]),
+                            );
+                        }
+                        if !mid_node_pat.var.is_empty() && !mid_label.is_empty() {
+                            row_vals.insert(
+                                format!("{}.__labels__", mid_node_pat.var),
+                                Value::List(vec![Value::String(mid_label.clone())]),
+                            );
+                        }
+                        if !fof_node_pat.var.is_empty() && !fof_label.is_empty() {
+                            row_vals.insert(
+                                format!("{}.__labels__", fof_node_pat.var),
+                                Value::List(vec![Value::String(fof_label.clone())]),
+                            );
+                        }
+                        // Inject relationship type metadata so type(r) works in WHERE.
+                        if !pat.rels[0].var.is_empty() {
+                            row_vals.insert(
+                                format!("{}.__type__", pat.rels[0].var),
+                                Value::String(pat.rels[0].rel_type.clone()),
+                            );
+                        }
+                        if !pat.rels[1].var.is_empty() {
+                            row_vals.insert(
+                                format!("{}.__type__", pat.rels[1].var),
+                                Value::String(pat.rels[1].rel_type.clone()),
+                            );
+                        }
+                        row_vals.extend(self.dollar_params());
+                        if !self.eval_where_graph(where_expr, &row_vals) {
+                            continue;
+                        }
+                    }
+
+                    // SPA-241: use three-var projection so mid variable columns
+                    // are resolved from mid_props rather than defaulting to fof_props.
+                    let row = project_three_var_row(
+                        &src_props,
+                        &mid_props,
+                        &fof_props,
+                        column_names,
+                        &src_node_pat.var,
+                        &mid_node_pat.var,
+                        &self.snapshot.store,
+                    );
+                    rows.push(row);
+                }
             }
         }
 

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -1991,12 +1991,17 @@ fn project_hop_row(
         .collect()
 }
 
-/// Project a single 2-hop result row.
+/// Project a single 2-hop result row (src + fof only, no mid).
 ///
 /// For each return column of the form `var.prop`, looks up the property value
 /// from `src_props` when `var == src_var`, and from `fof_props` otherwise.
 /// This ensures that `RETURN a.name, c.name` correctly reads the source and
 /// destination node properties independently (SPA-252).
+///
+/// NOTE: SPA-241 replaced calls to this function in the forward-forward two-hop
+/// path with `project_three_var_row`, which also handles the mid variable.
+/// Retained for potential future use in simplified single-level projections.
+#[allow(dead_code)]
 fn project_fof_row(
     src_props: &[(u32, u64)],
     fof_props: &[(u32, u64)],

--- a/crates/sparrowdb/tests/spa_241_multihop_props.rs
+++ b/crates/sparrowdb/tests/spa_241_multihop_props.rs
@@ -1,0 +1,258 @@
+//! Regression tests for SPA-241: intermediate node properties return wrong values
+//! in chained 2-hop MATCH patterns.
+//!
+//! Before the fix, a query like:
+//!   MATCH (a:Node)-[:E]->(m:Node)-[:E]->(b:Node) RETURN a.name, m.name, b.name
+//!
+//! returned m.name equal to a.name (or b.name) rather than the actual intermediate
+//! node's property value. This happened because:
+//!   1. col_ids_mid was only populated for the incoming hop case — forward-forward
+//!      two-hop queries never read mid node properties at all.
+//!   2. The flat two_hop() call discarded which mid node connected src to each fof,
+//!      making it impossible to track mid→fof structure needed for property reads.
+//!   3. project_fof_row() had no concept of the mid variable — any unrecognised var
+//!      fell through to fof_props, producing wrong values.
+//!
+//! The fix:
+//!   - Populates col_ids_mid for forward-forward patterns when mid_node_pat.var is set.
+//!   - Switches to two_hop_factorized() which preserves mid_slot→fof_slots grouping.
+//!   - Reads mid props per group and uses project_three_var_row() for projection.
+
+use sparrowdb::open;
+use sparrowdb_execution::types::Value;
+
+fn make_db() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+/// Build: (alice:Node {name:"alice",age:30}) -[:E]-> (mid:Node {name:"mid",age:25}) -[:E]-> (bob:Node {name:"bob",age:20})
+fn setup_simple_chain(db: &sparrowdb::GraphDb) {
+    db.execute("CREATE (:Node {name: 'alice', age: 30})").unwrap();
+    db.execute("CREATE (:Node {name: 'mid', age: 25})").unwrap();
+    db.execute("CREATE (:Node {name: 'bob', age: 20})").unwrap();
+
+    db.execute(
+        "MATCH (a:Node {name: 'alice'}), (m:Node {name: 'mid'}) CREATE (a)-[:E]->(m)",
+    )
+    .unwrap();
+    db.execute(
+        "MATCH (m:Node {name: 'mid'}), (b:Node {name: 'bob'}) CREATE (m)-[:E]->(b)",
+    )
+    .unwrap();
+}
+
+/// Core regression: m.name must be "mid", not "alice" or "bob".
+#[test]
+fn two_hop_intermediate_name_is_correct() {
+    let (_dir, db) = make_db();
+    setup_simple_chain(&db);
+
+    let result = db
+        .execute(
+            "MATCH (a:Node)-[:E]->(m:Node)-[:E]->(b:Node) RETURN a.name, m.name, b.name",
+        )
+        .expect("two-hop query");
+
+    assert_eq!(result.rows.len(), 1, "expected exactly 1 result row, got {:?}", result.rows);
+    let row = &result.rows[0];
+    assert_eq!(
+        row[0],
+        Value::String("alice".to_string()),
+        "a.name should be alice, got {:?}",
+        row[0]
+    );
+    assert_eq!(
+        row[1],
+        Value::String("mid".to_string()),
+        "m.name should be mid (not alice or bob), got {:?}",
+        row[1]
+    );
+    assert_eq!(
+        row[2],
+        Value::String("bob".to_string()),
+        "b.name should be bob, got {:?}",
+        row[2]
+    );
+}
+
+/// m.age must be 25, not 30 (alice's age) or 20 (bob's age).
+#[test]
+fn two_hop_intermediate_age_is_correct() {
+    let (_dir, db) = make_db();
+    setup_simple_chain(&db);
+
+    let result = db
+        .execute(
+            "MATCH (a:Node)-[:E]->(m:Node)-[:E]->(b:Node) RETURN m.age",
+        )
+        .expect("two-hop age query");
+
+    assert_eq!(result.rows.len(), 1, "expected exactly 1 row, got {:?}", result.rows);
+    // age is stored as integer — accept either Int or Float representation.
+    let age_val = &result.rows[0][0];
+    let age_num = match age_val {
+        Value::Int64(n) => *n as f64,
+        Value::Float64(f) => *f,
+        other => panic!("unexpected value type for m.age: {:?}", other),
+    };
+    assert!(
+        (age_num - 25.0).abs() < 0.01,
+        "m.age should be 25, got {}",
+        age_num
+    );
+}
+
+/// Three source nodes, each with 3 distinct intermediate nodes to a single terminal.
+/// This catches off-by-one errors in the slot→index mapping across multiple groups.
+#[test]
+fn two_hop_multi_intermediate_correct_bindings() {
+    let (_dir, db) = make_db();
+
+    // Create: src1, src2, src3 — each with 3 mid nodes — all pointing to dst.
+    for src_i in 1..=3usize {
+        db.execute(&format!(
+            "CREATE (:Hop {{name: 'src{}', kind: 'src'}})",
+            src_i
+        ))
+        .unwrap();
+    }
+    for mid_i in 1..=9usize {
+        db.execute(&format!(
+            "CREATE (:Hop {{name: 'mid{}', kind: 'mid', idx: {}}})",
+            mid_i, mid_i
+        ))
+        .unwrap();
+    }
+    db.execute("CREATE (:Hop {name: 'dst', kind: 'dst'})").unwrap();
+
+    // src1 -> mid1, mid2, mid3; src2 -> mid4, mid5, mid6; src3 -> mid7, mid8, mid9
+    for src_i in 1..=3usize {
+        for local_mid in 0..3usize {
+            let mid_num = (src_i - 1) * 3 + local_mid + 1;
+            db.execute(&format!(
+                "MATCH (s:Hop {{name: 'src{}'}}), (m:Hop {{name: 'mid{}'}}) CREATE (s)-[:L]->(m)",
+                src_i, mid_num
+            ))
+            .unwrap();
+        }
+    }
+    // All mids -> dst
+    for mid_i in 1..=9usize {
+        db.execute(&format!(
+            "MATCH (m:Hop {{name: 'mid{}'}}), (d:Hop {{name: 'dst'}}) CREATE (m)-[:L]->(d)",
+            mid_i
+        ))
+        .unwrap();
+    }
+
+    let result = db
+        .execute(
+            "MATCH (s:Hop)-[:L]->(m:Hop)-[:L]->(d:Hop) \
+             WHERE s.kind = 'src' AND m.kind = 'mid' AND d.kind = 'dst' \
+             RETURN s.name, m.name, d.name",
+        )
+        .expect("multi-intermediate two-hop");
+
+    // Should be 9 rows: 3 srcs × 3 mids each × 1 dst
+    assert_eq!(
+        result.rows.len(),
+        9,
+        "expected 9 rows (3 src × 3 mid), got {:?}",
+        result.rows
+    );
+
+    // Every row: m.name must start with "mid", NOT "src" or "dst".
+    for (i, row) in result.rows.iter().enumerate() {
+        let m_name = match &row[1] {
+            Value::String(s) => s.clone(),
+            other => panic!("row {}: m.name is not a string: {:?}", i, other),
+        };
+        assert!(
+            m_name.starts_with("mid"),
+            "row {}: m.name should start with 'mid' but got '{}' (full row: {:?})",
+            i, m_name, row
+        );
+
+        let s_name = match &row[0] {
+            Value::String(s) => s.clone(),
+            other => panic!("row {}: s.name is not a string: {:?}", i, other),
+        };
+        assert!(
+            s_name.starts_with("src"),
+            "row {}: s.name should start with 'src' but got '{}'",
+            i, s_name
+        );
+
+        let d_name = match &row[2] {
+            Value::String(s) => s.clone(),
+            other => panic!("row {}: d.name is not a string: {:?}", i, other),
+        };
+        assert_eq!(d_name, "dst", "row {}: d.name should be 'dst' but got '{}'", i, d_name);
+    }
+
+    // Verify each mid1..mid9 appears exactly once.
+    let mut mid_names: Vec<String> = result
+        .rows
+        .iter()
+        .map(|row| match &row[1] {
+            Value::String(s) => s.clone(),
+            other => panic!("m.name not a string: {:?}", other),
+        })
+        .collect();
+    mid_names.sort();
+    let expected: Vec<String> = (1..=9).map(|i| format!("mid{}", i)).collect();
+    assert_eq!(mid_names, expected, "each mid node should appear exactly once");
+}
+
+/// Verify b.uid != a.uid in the pattern from the issue report (Enron-style).
+/// Uses uid property to confirm no property aliasing between src and intermediate.
+#[test]
+fn two_hop_uid_no_aliasing() {
+    let (_dir, db) = make_db();
+
+    // Create 3 person nodes with distinct uid values.
+    db.execute("CREATE (:Person {uid: 1, name: 'A'})").unwrap();
+    db.execute("CREATE (:Person {uid: 2, name: 'B'})").unwrap();
+    db.execute("CREATE (:Person {uid: 3, name: 'C'})").unwrap();
+
+    // A -[EMAILED]-> B -[EMAILED]-> C
+    db.execute(
+        "MATCH (a:Person {uid: 1}), (b:Person {uid: 2}) CREATE (a)-[:EMAILED]->(b)",
+    )
+    .unwrap();
+    db.execute(
+        "MATCH (b:Person {uid: 2}), (c:Person {uid: 3}) CREATE (b)-[:EMAILED]->(c)",
+    )
+    .unwrap();
+
+    let result = db
+        .execute(
+            "MATCH (a:Person)-[:EMAILED]->(b:Person)-[:EMAILED]->(c:Person) \
+             RETURN a.uid, b.uid, c.uid",
+        )
+        .expect("uid two-hop");
+
+    assert_eq!(result.rows.len(), 1, "expected 1 row, got {:?}", result.rows);
+    let row = &result.rows[0];
+
+    // Extract uids as numbers.
+    let uid = |v: &Value| -> i64 {
+        match v {
+            Value::Int64(n) => *n,
+            Value::Float64(f) => *f as i64,
+            other => panic!("unexpected uid value: {:?}", other),
+        }
+    };
+
+    let a_uid = uid(&row[0]);
+    let b_uid = uid(&row[1]);
+    let c_uid = uid(&row[2]);
+
+    assert_eq!(a_uid, 1, "a.uid should be 1, got {}", a_uid);
+    assert_eq!(b_uid, 2, "b.uid should be 2, got {} (was it aliased to a.uid={}?)", b_uid, a_uid);
+    assert_eq!(c_uid, 3, "c.uid should be 3, got {}", c_uid);
+    assert_ne!(b_uid, a_uid, "b.uid must NOT equal a.uid (property aliasing bug)");
+    assert_ne!(b_uid, c_uid, "b.uid must NOT equal c.uid");
+}


### PR DESCRIPTION
## **User description**
## Summary

Fixes `(a)-[:R]->(m)-[:R]->(b)` forward-forward two-hop queries returning wrong property values for the intermediate node `m`.

**Root cause — three compounding bugs:**

1. `col_ids_mid` was guarded by `second_hop_incoming`, so it was always `vec![]` for forward-forward patterns. The intermediate node's properties were never read.
2. The flat `AspJoin::two_hop()` call discarded which mid node connected `src` to each `fof`, making the mid→fof structure unrecoverable.  
3. `project_fof_row()` had no concept of the mid variable — any column reference to `m.prop` fell through to `fof_props`, returning the terminal node's value instead.

**Fix:**

- `col_ids_mid` now collects columns whenever `mid_node_pat.var` is non-empty (both forward-forward and incoming patterns).
- Forward-forward path switches from `two_hop()` → `two_hop_factorized()`, which preserves `mid_slot → Vec<fof_slots>` grouping.
- Mid node properties are read once per mid group and passed to `project_three_var_row` (already existed for the incoming case).
- Delta-log extension preserves mid→fof structure rather than flattening to a set.
- WHERE clause evaluation now includes mid props/labels for forward-forward queries.

## Test plan

- [x] `two_hop_intermediate_name_is_correct` — single chain `alice→mid→bob`, verifies `m.name == "mid"`
- [x] `two_hop_intermediate_age_is_correct` — verifies `m.age == 25`, not src/dst age
- [x] `two_hop_uid_no_aliasing` — replicates Enron repro from issue: `b.uid` must not equal `a.uid`
- [x] `two_hop_multi_intermediate_correct_bindings` — 3 src × 3 mid each → 9 rows, all mid names correct, no slot aliasing
- [x] `cargo check -p sparrowdb` passes clean
- [x] Full `cargo test -p sparrowdb` passes (pre-existing `spa_168_degree_cache_wiring` failures also present on `main`)

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix wrong property values for the middle node in chained two-hop matches

### What Changed
- Queries like `MATCH (a)-[:R]->(m)-[:R]->(b)` now return the actual properties of `m` instead of values from the first or last node
- Middle-node properties and labels are now read and used in filtering and return values for forward-forward two-hop patterns
- Two-hop results keep the middle node grouped with its matching end nodes, which avoids mixing values across matches
- Added regression tests for the middle node’s name, age, uid separation, and multiple middle-node bindings

### Impact
`✅ Correct middle-node results in chained graph queries`
`✅ Fewer wrong property values in two-hop matches`
`✅ Safer filtering and returning of intermediate nodes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved property binding logic in multi-hop graph traversals, ensuring intermediate nodes' properties are correctly bound and projected in query results alongside source and destination properties.

* **Tests**
  * Added regression tests validating correct property resolution for multi-hop graph patterns, including complex scenarios with multiple sources and intermediate nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->