### PR TITLE
feat(api): Cypher MATCH...DELETE r edge deletion (closes #219)

### DIFF
--- a/crates/sparrowdb-execution/src/engine/mutation.rs
+++ b/crates/sparrowdb-execution/src/engine/mutation.rs
@@ -78,6 +78,154 @@ impl Engine {
         &mm.mutation
     }
 
+    /// Scan edges matching a MATCH pattern with exactly one hop and return
+    /// `(src, dst, rel_type)` tuples for edge deletion.
+    ///
+    /// Supports `MATCH (a:Label)-[r:REL]->(b:Label) DELETE r` with optional
+    /// inline property filters on source and destination node patterns.
+    ///
+    /// Includes both checkpointed (CSR) and uncheckpointed (delta) edges.
+    pub fn scan_match_mutate_edges(
+        &self,
+        mm: &MatchMutateStatement,
+    ) -> Result<Vec<(NodeId, NodeId, String)>> {
+        if mm.match_patterns.len() != 1 {
+            return Err(sparrowdb_common::Error::InvalidArgument(
+                "MATCH...DELETE edge: only single-path patterns are supported".into(),
+            ));
+        }
+        let pat = &mm.match_patterns[0];
+        if pat.rels.len() != 1 || pat.nodes.len() != 2 {
+            return Err(sparrowdb_common::Error::InvalidArgument(
+                "MATCH...DELETE edge: pattern must have exactly one relationship hop".into(),
+            ));
+        }
+
+        let src_node_pat = &pat.nodes[0];
+        let dst_node_pat = &pat.nodes[1];
+        let rel_pat = &pat.rels[0];
+
+        let src_label = src_node_pat.labels.first().cloned().unwrap_or_default();
+        let dst_label = dst_node_pat.labels.first().cloned().unwrap_or_default();
+
+        // Resolve optional label-id constraints.
+        let src_label_id_opt: Option<u32> = if src_label.is_empty() {
+            None
+        } else {
+            match self.snapshot.catalog.get_label(&src_label)? {
+                Some(id) => Some(id as u32),
+                None => return Ok(vec![]), // unknown label → no matches
+            }
+        };
+        let dst_label_id_opt: Option<u32> = if dst_label.is_empty() {
+            None
+        } else {
+            match self.snapshot.catalog.get_label(&dst_label)? {
+                Some(id) => Some(id as u32),
+                None => return Ok(vec![]), // unknown label → no matches
+            }
+        };
+
+        // Filter registered rel tables by rel type and src/dst label.
+        let rel_tables: Vec<(u64, u32, u32, String)> = self
+            .snapshot
+            .catalog
+            .list_rel_tables_with_ids()
+            .into_iter()
+            .filter(|(_, sid, did, rt)| {
+                let type_ok = rel_pat.rel_type.is_empty() || rt == &rel_pat.rel_type;
+                let src_ok = src_label_id_opt.map(|id| id == *sid as u32).unwrap_or(true);
+                let dst_ok = dst_label_id_opt.map(|id| id == *did as u32).unwrap_or(true);
+                type_ok && src_ok && dst_ok
+            })
+            .map(|(cid, sid, did, rt)| (cid, sid as u32, did as u32, rt))
+            .collect();
+
+        // Pre-compute col_ids for inline prop filters (avoid re-computing per slot).
+        let src_filter_col_ids: Vec<u32> = src_node_pat
+            .props
+            .iter()
+            .map(|p| prop_name_to_col_id(&p.key))
+            .collect();
+        let dst_filter_col_ids: Vec<u32> = dst_node_pat
+            .props
+            .iter()
+            .map(|p| prop_name_to_col_id(&p.key))
+            .collect();
+
+        let mut result: Vec<(NodeId, NodeId, String)> = Vec::new();
+
+        for (catalog_rel_id, effective_src_lid, effective_dst_lid, rel_type) in &rel_tables {
+            let catalog_rel_id_u32 =
+                u32::try_from(*catalog_rel_id).expect("catalog_rel_id overflowed u32");
+
+            // ── Checkpointed edges (CSR) ──────────────────────────────────────
+            let hwm_src = match self.snapshot.store.hwm_for_label(*effective_src_lid) {
+                Ok(hwm) => hwm,
+                Err(_) => continue,
+            };
+            for src_slot in 0..hwm_src {
+                let src_node = NodeId(((*effective_src_lid as u64) << 32) | src_slot);
+                if self.is_node_tombstoned(src_node) {
+                    continue;
+                }
+                if !self.node_matches_prop_filter(
+                    src_node,
+                    &src_filter_col_ids,
+                    &src_node_pat.props,
+                ) {
+                    continue;
+                }
+                for dst_slot in self.csr_neighbors(catalog_rel_id_u32, src_slot) {
+                    let dst_node = NodeId(((*effective_dst_lid as u64) << 32) | dst_slot);
+                    if self.is_node_tombstoned(dst_node) {
+                        continue;
+                    }
+                    if !self.node_matches_prop_filter(
+                        dst_node,
+                        &dst_filter_col_ids,
+                        &dst_node_pat.props,
+                    ) {
+                        continue;
+                    }
+                    result.push((src_node, dst_node, rel_type.clone()));
+                }
+            }
+
+            // ── Uncheckpointed edges (delta log) ──────────────────────────────
+            for rec in self.read_delta_for(catalog_rel_id_u32) {
+                let r_src_label = (rec.src.0 >> 32) as u32;
+                let r_dst_label = (rec.dst.0 >> 32) as u32;
+                if src_label_id_opt
+                    .map(|id| id != r_src_label)
+                    .unwrap_or(false)
+                {
+                    continue;
+                }
+                if dst_label_id_opt
+                    .map(|id| id != r_dst_label)
+                    .unwrap_or(false)
+                {
+                    continue;
+                }
+                if self.is_node_tombstoned(rec.src) || self.is_node_tombstoned(rec.dst) {
+                    continue;
+                }
+                if !self.node_matches_prop_filter(rec.src, &src_filter_col_ids, &src_node_pat.props)
+                {
+                    continue;
+                }
+                if !self.node_matches_prop_filter(rec.dst, &dst_filter_col_ids, &dst_node_pat.props)
+                {
+                    continue;
+                }
+                result.push((rec.src, rec.dst, rel_type.clone()));
+            }
+        }
+
+        Ok(result)
+    }
+
     // ── Node-scan helpers (shared by scan_match_create and scan_match_create_rows) ──
 
     /// Returns `true` if the given node has been tombstoned (col 0 == u64::MAX).

--- a/crates/sparrowdb-storage/src/edge_store.rs
+++ b/crates/sparrowdb-storage/src/edge_store.rs
@@ -337,48 +337,74 @@ impl EdgeStore {
 
     /// Remove the first delta-log record matching `(src, dst)` from this store.
     ///
-    /// The delta log is rewritten in-place with the matching record excised.
-    /// Returns [`Error::InvalidArgument`] if no such record exists.
+    /// Remove the directed edge `src → dst` from this rel table.
     ///
-    /// This is an O(n) operation proportional to the current delta log size.
-    /// For bulk deletions, prefer a CHECKPOINT after all deletions are staged.
+    /// Searches the delta log first; if not found there, falls back to the
+    /// checkpointed CSR.  For delta edges the log is rewritten in-place with
+    /// the record excised.  For CSR edges the forward and backward CSR files
+    /// are atomically rewritten without the matching (src_slot, dst_slot) pair.
+    ///
+    /// Returns [`Error::InvalidArgument`] if the edge is found in neither.
     pub fn delete_edge(&mut self, src: NodeId, dst: NodeId) -> Result<()> {
+        let src_slot = src.0 & 0xFFFF_FFFF;
+        let dst_slot = dst.0 & 0xFFFF_FFFF;
+
         let mut records = self.read_delta()?;
 
-        // Find the first record that matches (src, dst); rel_id is implicit from
-        // the store's own rel_table_id.
-        let pos = records
-            .iter()
-            .position(|r| r.src == src && r.dst == dst)
-            .ok_or_else(|| {
-                Error::InvalidArgument(format!(
+        // ── Delta path ────────────────────────────────────────────────────────
+        if let Some(pos) = records.iter().position(|r| r.src == src && r.dst == dst) {
+            records.remove(pos);
+
+            // Rewrite the delta log without the removed record.
+            let tmp_path = self.rel_dir.join("delta.log.tmp");
+            {
+                use std::io::Write as IoWrite;
+                let mut f = fs::OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(true)
+                    .open(&tmp_path)
+                    .map_err(Error::Io)?;
+                for r in &records {
+                    f.write_all(&r.encode()).map_err(Error::Io)?;
+                }
+                f.flush().map_err(Error::Io)?;
+            }
+            fs::rename(&tmp_path, self.delta_path()).map_err(Error::Io)?;
+            self.next_edge_id = records.len() as u64;
+            return Ok(());
+        }
+
+        // ── CSR (checkpointed) path ───────────────────────────────────────────
+        let fwd = match CsrForward::open(&self.fwd_path()) {
+            Ok(f) => f,
+            Err(Error::Io(ref e)) if e.kind() == io::ErrorKind::NotFound => {
+                return Err(Error::InvalidArgument(format!(
                     "edge {src:?} → {dst:?} not found in rel_table {:?}",
                     self.rel_table_id
-                ))
-            })?;
-
-        records.remove(pos);
-
-        // Rewrite the entire delta log without the removed record.
-        // Write to a temp file then rename for crash-safety.
-        let tmp_path = self.rel_dir.join("delta.log.tmp");
-        {
-            use std::io::Write as IoWrite;
-            let mut f = fs::OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(true)
-                .open(&tmp_path)
-                .map_err(Error::Io)?;
-            for r in &records {
-                f.write_all(&r.encode()).map_err(Error::Io)?;
+                )));
             }
-            f.flush().map_err(Error::Io)?;
-        }
-        fs::rename(&tmp_path, self.delta_path()).map_err(Error::Io)?;
+            Err(e) => return Err(e),
+        };
 
-        // Update the in-memory counter to reflect the new record count.
-        self.next_edge_id = records.len() as u64;
+        if !fwd.neighbors(src_slot).contains(&dst_slot) {
+            return Err(Error::InvalidArgument(format!(
+                "edge {src:?} → {dst:?} not found in rel_table {:?}",
+                self.rel_table_id
+            )));
+        }
+
+        // Rebuild edge list without the target (src_slot, dst_slot).
+        let n_nodes = fwd.n_nodes();
+        let mut edges: Vec<(u64, u64)> = Vec::new();
+        for s in 0..n_nodes {
+            for &d in fwd.neighbors(s) {
+                if !(s == src_slot && d == dst_slot) {
+                    edges.push((s, d));
+                }
+            }
+        }
+        self.write_csr_atomic(&edges, n_nodes)?;
         Ok(())
     }
 

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -1273,6 +1273,20 @@ impl GraphDb {
             csrs,
             &self.inner.path,
         );
+
+        // SPA-219: `MATCH (a)-[r:REL]->(b) DELETE r` — edge delete path.
+        if is_edge_delete_mutation(mm) {
+            let edges = engine.scan_match_mutate_edges(mm)?;
+            for (src, dst, rel_type) in edges {
+                tx.delete_edge(src, dst, &rel_type)?;
+            }
+            tx.commit()?;
+            self.invalidate_csr_map();
+            self.invalidate_prop_index();
+            self.invalidate_catalog();
+            return Ok(QueryResult::empty(vec![]));
+        }
+
         let matching_ids = engine.scan_match_mutate(mm)?;
         if matching_ids.is_empty() {
             return Ok(QueryResult::empty(vec![]));
@@ -1320,6 +1334,19 @@ impl GraphDb {
             csrs,
             &self.inner.path,
         );
+
+        // SPA-219: `MATCH (a)-[r:REL]->(b) DELETE r` — edge delete path.
+        if is_edge_delete_mutation(mm) {
+            let edges = engine.scan_match_mutate_edges(mm)?;
+            for (src, dst, rel_type) in edges {
+                tx.delete_edge(src, dst, &rel_type)?;
+            }
+            tx.commit()?;
+            self.invalidate_csr_map();
+            self.invalidate_prop_index();
+            self.invalidate_catalog();
+            return Ok(QueryResult::empty(vec![]));
+        }
 
         // Collect matching node ids via the engine's scan (lock already held).
         let matching_ids = engine.scan_match_mutate(mm)?;
@@ -1878,15 +1905,23 @@ impl GraphDb {
                     csrs,
                     &self.inner.path,
                 );
-                let matching_ids = engine.scan_match_mutate(mm)?;
-                for node_id in matching_ids {
-                    match &mm.mutation {
-                        sparrowdb_cypher::ast::Mutation::Set { prop, value, .. } => {
-                            let sv = expr_to_value(value);
-                            tx.set_property(node_id, prop, sv)?;
-                        }
-                        sparrowdb_cypher::ast::Mutation::Delete { .. } => {
-                            tx.delete_node(node_id)?;
+                // SPA-219: edge delete path.
+                if is_edge_delete_mutation(mm) {
+                    let edges = engine.scan_match_mutate_edges(mm)?;
+                    for (src, dst, rel_type) in edges {
+                        tx.delete_edge(src, dst, &rel_type)?;
+                    }
+                } else {
+                    let matching_ids = engine.scan_match_mutate(mm)?;
+                    for node_id in matching_ids {
+                        match &mm.mutation {
+                            sparrowdb_cypher::ast::Mutation::Set { prop, value, .. } => {
+                                let sv = expr_to_value(value);
+                                tx.set_property(node_id, prop, sv)?;
+                            }
+                            sparrowdb_cypher::ast::Mutation::Delete { .. } => {
+                                tx.delete_node(node_id)?;
+                            }
                         }
                     }
                 }
@@ -2283,6 +2318,7 @@ impl GraphDb {
         let mut tx = self.begin_write()?;
         tx.delete_edge(src, dst, rel_type)?;
         tx.commit()?;
+        self.invalidate_csr_map();
         Ok(())
     }
 }
@@ -3472,6 +3508,20 @@ fn literal_to_value(lit: &sparrowdb_cypher::ast::Literal) -> Value {
 
 /// Convert a Cypher [`Expr`] to a storage [`Value`].
 ///
+/// Returns `true` when the `DELETE` clause variable in a `MatchMutateStatement`
+/// refers to a relationship pattern variable rather than a node variable.
+///
+/// Used to route `MATCH (a)-[r:REL]->(b) DELETE r` to the edge-delete path
+/// instead of the node-delete path.
+fn is_edge_delete_mutation(mm: &sparrowdb_cypher::ast::MatchMutateStatement) -> bool {
+    let sparrowdb_cypher::ast::Mutation::Delete { var } = &mm.mutation else {
+        return false;
+    };
+    mm.match_patterns
+        .iter()
+        .any(|p| p.rels.iter().any(|r| !r.var.is_empty() && &r.var == var))
+}
+
 /// Only literal expressions are supported for SET values at this stage.
 fn expr_to_value(expr: &sparrowdb_cypher::ast::Expr) -> Value {
     use sparrowdb_cypher::ast::Expr;

--- a/crates/sparrowdb/tests/delete_edge.rs
+++ b/crates/sparrowdb/tests/delete_edge.rs
@@ -179,3 +179,81 @@ fn delete_edge_unknown_rel_type_errors() {
 
     drop(dir);
 }
+
+// ── Cypher MATCH...DELETE r ───────────────────────────────────────────────────
+
+/// `MATCH (a:P)-[r:KNOWS]->(b:P) DELETE r` removes the edge.
+#[test]
+fn cypher_match_delete_rel_removes_edge() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (a:Person {name:\"Alice\"})-[:KNOWS]->(b:Person {name:\"Bob\"})")
+        .expect("create");
+
+    assert_eq!(
+        count_matches(&db, "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN a, b"),
+        1,
+        "edge should exist before Cypher DELETE"
+    );
+
+    db.execute("MATCH (a:Person)-[r:KNOWS]->(b:Person) DELETE r")
+        .expect("delete");
+
+    assert_eq!(
+        count_matches(&db, "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN a, b"),
+        0,
+        "edge must be gone after Cypher DELETE r"
+    );
+}
+
+/// `MATCH (a)-[r:REL]->(b) DELETE r` with inline prop filter on src node.
+#[test]
+fn cypher_match_delete_rel_with_src_prop_filter() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (a:Item {id:1})-[:LINKED]->(b:Item {id:2})")
+        .expect("create 1->2");
+    db.execute("CREATE (a:Item {id:3})-[:LINKED]->(b:Item {id:4})")
+        .expect("create 3->4");
+
+    assert_eq!(
+        count_matches(&db, "MATCH (:Item)-[:LINKED]->(:Item) RETURN 1"),
+        2,
+        "two edges before delete"
+    );
+
+    // Only delete the edge starting from Item {id:1}.
+    db.execute("MATCH (a:Item {id:1})-[r:LINKED]->(b:Item) DELETE r")
+        .expect("delete with src filter");
+
+    assert_eq!(
+        count_matches(&db, "MATCH (:Item)-[:LINKED]->(:Item) RETURN 1"),
+        1,
+        "only one edge should remain after targeted delete"
+    );
+}
+
+/// Cypher edge delete survives CHECKPOINT.
+#[test]
+fn cypher_match_delete_rel_after_checkpoint() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (a:N {x:1})-[:E]->(b:N {x:2})")
+        .expect("create");
+    db.checkpoint().expect("checkpoint");
+
+    assert_eq!(
+        count_matches(&db, "MATCH (:N)-[:E]->(:N) RETURN 1"),
+        1,
+        "edge visible after checkpoint"
+    );
+
+    db.execute("MATCH (a:N)-[r:E]->(b:N) DELETE r")
+        .expect("delete after checkpoint");
+
+    assert_eq!(
+        count_matches(&db, "MATCH (:N)-[:E]->(:N) RETURN 1"),
+        0,
+        "edge gone after Cypher DELETE r post-checkpoint"
+    );
+}


### PR DESCRIPTION
## **User description**
## Summary

- **`MATCH (a)-[r:REL]->(b) DELETE r`** now works in Cypher — relationships can be deleted by pattern, not just nodes
- **`EdgeStore::delete_edge`** extended to handle post-CHECKPOINT edges (previously only searched the delta log; now also rewrites the CSR when the edge was checkpointed)
- **CSR cache invalidated** after edge deletion so subsequent MATCH queries see the updated graph
- **3 new Cypher acceptance tests**: basic deletion, src prop filter, post-checkpoint deletion

## What changed

| File | Change |
|------|--------|
| `crates/sparrowdb-execution/src/engine/mutation.rs` | Add `scan_match_mutate_edges` — scans CSR + delta for matching edge tuples |
| `crates/sparrowdb/src/lib.rs` | Route DELETE-rel patterns to edge path; add `invalidate_csr_map` after delete; add `is_edge_delete_mutation` helper |
| `crates/sparrowdb-storage/src/edge_store.rs` | Fix `delete_edge` to handle checkpointed (CSR) edges by rewriting the CSR files |
| `crates/sparrowdb/tests/delete_edge.rs` | 3 new Cypher-level tests |

## Test plan

- [x] `cargo test -p sparrowdb --test delete_edge` — all 7 tests pass
- [x] Full `cargo test -p sparrowdb` — no regressions
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Allow Cypher relationship deletes to remove edges in both live and checkpointed data**

### What Changed
- `MATCH (a)-[r:REL]->(b) DELETE r` now removes the matched edge instead of failing or deleting the wrong item
- Deletes now work for edges stored before and after a checkpoint
- Matching can still use source or destination labels and inline property filters, and only the matching relationship is removed
- After an edge delete, later queries see the updated graph

### Impact
`✅ Cypher edge deletes work`
`✅ Fewer post-checkpoint delete failures`
`✅ Updated graph results after delete`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deleting relationships using `MATCH ... DELETE r` Cypher syntax.
  * Relationship deletions work with both recently created and checkpointed data.
  * Inline node property filters can scope which relationships are deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->