### PR TITLE
perf: cache label_row_counts — eliminate per-label HWM disk reads (closes #186 #190)

### DIFF
--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -287,12 +287,29 @@ impl Engine {
     /// cache.  When `cached_index` is `Some`, the index is cloned out of the
     /// `RwLock` at construction time so the engine can use `RefCell` internally
     /// without holding the lock.
+    ///
+    /// When `cached_row_counts` is `Some`, the pre-built label row-count map is
+    /// used directly instead of re-reading each label's HWM from disk.  This
+    /// eliminates O(n_labels) syscalls on every read query (SPA-190).
     pub fn new_with_cached_index(
         store: NodeStore,
         catalog: Catalog,
         csrs: HashMap<u32, CsrForward>,
         db_root: &Path,
         cached_index: Option<&std::sync::RwLock<PropertyIndex>>,
+    ) -> Self {
+        Self::new_with_all_caches(store, catalog, csrs, db_root, cached_index, None)
+    }
+
+    /// Like [`Engine::new_with_cached_index`] but also accepts a pre-built
+    /// `label_row_counts` map to avoid the per-query HWM disk reads (SPA-190).
+    pub fn new_with_all_caches(
+        store: NodeStore,
+        catalog: Catalog,
+        csrs: HashMap<u32, CsrForward>,
+        db_root: &Path,
+        cached_index: Option<&std::sync::RwLock<PropertyIndex>>,
+        cached_row_counts: Option<HashMap<LabelId, usize>>,
     ) -> Self {
         // SPA-249 (lazy fix): property index is built on demand per
         // (label_id, col_id) pair via PropertyIndex::build_for, called from
@@ -311,26 +328,25 @@ impl Engine {
         // degree information (point lookups, full scans, hop traversals) pay
         // zero cost at engine-open time: no CSR iteration, no delta-log I/O.
         //
-        // SPA-Q1-perf: build label_row_counts ONCE at Engine::new() by reading
-        // each label's high-water-mark from the NodeStore HWM file (an O(1)
-        // in-memory map lookup after the first call per label).  Previously this
-        // map was left empty and only populated via the write path, so every
-        // read query started with an empty map, forcing the planner to fall back
-        // to per-scan HWM reads on every execution.  Now the snapshot carries a
-        // pre-populated map; the write path continues to increment it on creation.
-        let label_row_counts: HashMap<LabelId, usize> = catalog
-            .list_labels()
-            .unwrap_or_default()
-            .into_iter()
-            .filter_map(|(lid, _name)| {
-                let hwm = store.hwm_for_label(lid as u32).unwrap_or(0);
-                if hwm > 0 {
-                    Some((lid, hwm as usize))
-                } else {
-                    None
-                }
-            })
-            .collect();
+        // SPA-Q1-perf / SPA-190: use pre-built row counts when provided by the
+        // caller (GraphDb passes cached values to skip per-label HWM disk reads).
+        // Fall back to building from disk when no cache is available (Engine::new
+        // or first call after a write invalidation).
+        let label_row_counts: HashMap<LabelId, usize> = cached_row_counts.unwrap_or_else(|| {
+            catalog
+                .list_labels()
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|(lid, _name)| {
+                    let hwm = store.hwm_for_label(lid as u32).unwrap_or(0);
+                    if hwm > 0 {
+                        Some((lid, hwm as usize))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        });
 
         // SPA-273 (lazy): rel_degree_stats is now computed on first access via
         // ReadSnapshot::rel_degree_stats().  Simple traversal queries (Q3/Q4)

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -31,7 +31,7 @@
 //! db.optimize().unwrap();
 //! ```
 
-use sparrowdb_catalog::catalog::Catalog;
+use sparrowdb_catalog::catalog::{Catalog, LabelId};
 use sparrowdb_common::{col_id_of, TxnId};
 use sparrowdb_execution::Engine;
 
@@ -311,6 +311,13 @@ struct DbInner {
     /// instance.  Invalidated after CHECKPOINT / OPTIMIZE since those compact
     /// the delta log into new CSR base files.
     csr_map: RwLock<HashMap<u32, CsrForward>>,
+    /// Cached label row counts (SPA-190).
+    ///
+    /// Maps `LabelId → node count` (high-water mark).  Built once at open
+    /// time and refreshed after any write that creates or deletes nodes.
+    /// Passed to `Engine::new_with_all_caches` to avoid per-label HWM disk
+    /// reads on every read query.
+    label_row_counts: RwLock<HashMap<LabelId, usize>>,
     /// Persistent WAL writer (SPA-210).
     ///
     /// Reused across transaction commits to avoid paying segment-scan and
@@ -376,6 +383,7 @@ impl GraphDb {
         let catalog = Catalog::open(path)?;
         let wal_dir = path.join("wal");
         let wal_writer = WalWriter::open(&wal_dir)?;
+        let label_row_counts = RwLock::new(build_label_row_counts_from_disk(&catalog, path));
         Ok(GraphDb {
             inner: Arc::new(DbInner {
                 path: path.to_path_buf(),
@@ -388,6 +396,7 @@ impl GraphDb {
                 prop_index: RwLock::new(sparrowdb_storage::property_index::PropertyIndex::new()),
                 catalog: RwLock::new(catalog),
                 csr_map: RwLock::new(open_csr_map(path)),
+                label_row_counts,
                 wal_writer: Mutex::new(wal_writer),
             }),
         })
@@ -407,6 +416,7 @@ impl GraphDb {
         let catalog = Catalog::open(path)?;
         let wal_dir = path.join("wal");
         let wal_writer = WalWriter::open_encrypted(&wal_dir, key)?;
+        let label_row_counts = RwLock::new(build_label_row_counts_from_disk(&catalog, path));
         Ok(GraphDb {
             inner: Arc::new(DbInner {
                 path: path.to_path_buf(),
@@ -419,6 +429,7 @@ impl GraphDb {
                 prop_index: RwLock::new(sparrowdb_storage::property_index::PropertyIndex::new()),
                 catalog: RwLock::new(catalog),
                 csr_map: RwLock::new(open_csr_map(path)),
+                label_row_counts,
                 wal_writer: Mutex::new(wal_writer),
             }),
         })
@@ -436,15 +447,53 @@ impl GraphDb {
             .clear();
     }
 
-    /// Refresh the shared catalog cache from disk (SPA-188).
+    /// Refresh the shared catalog cache from disk (SPA-188) and simultaneously
+    /// rebuild the cached label row counts (SPA-190).
     ///
-    /// Called after DDL operations (label/rel-type creation, constraints) so
-    /// the next read query sees the updated schema without re-parsing the TLV
-    /// file itself.
+    /// Called after DDL operations and any write commit so the next read query
+    /// sees the updated schema and fresh node counts without extra disk reads.
     fn invalidate_catalog(&self) {
         if let Ok(fresh) = Catalog::open(&self.inner.path) {
+            // Rebuild row counts while we have the fresh catalog in hand —
+            // no extra I/O to open it again.
+            let new_counts = build_label_row_counts_from_disk(&fresh, &self.inner.path);
             *self.inner.catalog.write().expect("catalog RwLock poisoned") = fresh;
+            *self
+                .inner
+                .label_row_counts
+                .write()
+                .expect("label_row_counts RwLock poisoned") = new_counts;
         }
+    }
+
+    /// Build a read-optimised `Engine` using all available shared caches
+    /// (PropertyIndex, CSR map, label row counts) — SPA-190.
+    ///
+    /// All read query paths should use this instead of calling
+    /// `Engine::new_with_cached_index` directly.
+    fn build_read_engine(
+        &self,
+        store: NodeStore,
+        catalog: Catalog,
+        csrs: HashMap<u32, CsrForward>,
+    ) -> Engine {
+        Engine::new_with_all_caches(
+            store,
+            catalog,
+            csrs,
+            &self.inner.path,
+            Some(&self.inner.prop_index),
+            Some(self.cached_label_row_counts()),
+        )
+    }
+
+    /// Return a clone of the cached label row counts (SPA-190).
+    fn cached_label_row_counts(&self) -> HashMap<LabelId, usize> {
+        self.inner
+            .label_row_counts
+            .read()
+            .expect("label_row_counts RwLock poisoned")
+            .clone()
     }
 
     /// Clone the cached catalog for use in a single query (SPA-188).
@@ -684,13 +733,7 @@ impl GraphDb {
             let mut engine = {
                 let _open_span = info_span!("sparrowdb.open_engine").entered();
                 let csrs = self.cached_csr_map();
-                Engine::new_with_cached_index(
-                    NodeStore::open(&self.inner.path)?,
-                    catalog_snap,
-                    csrs,
-                    &self.inner.path,
-                    Some(&self.inner.prop_index),
-                )
+                self.build_read_engine(NodeStore::open(&self.inner.path)?, catalog_snap, csrs)
             };
 
             let result = {
@@ -781,14 +824,8 @@ impl GraphDb {
         let mut engine = {
             let _open_span = info_span!("sparrowdb.open_engine").entered();
             let csrs = self.cached_csr_map();
-            Engine::new_with_cached_index(
-                NodeStore::open(&self.inner.path)?,
-                catalog_snap,
-                csrs,
-                &self.inner.path,
-                Some(&self.inner.prop_index),
-            )
-            .with_deadline(deadline)
+            self.build_read_engine(NodeStore::open(&self.inner.path)?, catalog_snap, csrs)
+                .with_deadline(deadline)
         };
 
         let result = {
@@ -1080,14 +1117,8 @@ impl GraphDb {
         let mut engine = {
             let _open_span = info_span!("sparrowdb.open_engine").entered();
             let csrs = self.cached_csr_map();
-            Engine::new_with_cached_index(
-                NodeStore::open(&self.inner.path)?,
-                catalog_snap,
-                csrs,
-                &self.inner.path,
-                Some(&self.inner.prop_index),
-            )
-            .with_params(params)
+            self.build_read_engine(NodeStore::open(&self.inner.path)?, catalog_snap, csrs)
+                .with_params(params)
         };
 
         let result = {
@@ -1370,18 +1401,15 @@ impl GraphDb {
 
         // Build an Engine for the read-scan phase.
         //
-        // Use `new_with_cached_index` so that the lazy property index built
-        // during this engine's scan is seeded from (and written back to) the
-        // shared per-GraphDb cache.  MATCH…CREATE only creates edges — it never
-        // changes node property columns — so the cached column data remains
-        // valid across calls and does not need to be invalidated.
+        // Use build_read_engine so that the lazy property index and cached
+        // label row counts are reused.  MATCH…CREATE only creates edges — it
+        // never changes node property columns — so the cached data remains
+        // valid across calls.
         let csrs = self.cached_csr_map();
-        let engine = Engine::new_with_cached_index(
+        let engine = self.build_read_engine(
             NodeStore::open(&self.inner.path)?,
             self.catalog_snapshot(),
             csrs,
-            &self.inner.path,
-            Some(&self.inner.prop_index),
         );
 
         // SPA-208: reject reserved __SO_ rel-type prefix on edges in the CREATE clause.
@@ -2408,12 +2436,19 @@ impl ReadTx {
 
         let mut engine = {
             let _open_span = info_span!("sparrowdb.readtx.open_engine").entered();
-            Engine::new_with_cached_index(
+            let row_counts = self
+                .inner
+                .label_row_counts
+                .read()
+                .expect("label_row_counts RwLock poisoned")
+                .clone();
+            Engine::new_with_all_caches(
                 NodeStore::open(&self.inner.path)?,
                 catalog_snap,
                 csrs,
                 &self.inner.path,
                 Some(&self.inner.prop_index),
+                Some(row_counts),
             )
         };
 
@@ -3649,6 +3684,28 @@ fn collect_maintenance_params(
 ///
 /// SPA-185: replaces the old `open_csr_forward` that only opened `RelTableId(0)`.
 /// The catalog is used to discover all registered rel types.
+/// Build a `LabelId → node count` map by reading each label's HWM from disk
+/// (SPA-190).  Called at `GraphDb::open()` and after node-mutating writes.
+fn build_label_row_counts_from_disk(catalog: &Catalog, db_root: &Path) -> HashMap<LabelId, usize> {
+    let store = match NodeStore::open(db_root) {
+        Ok(s) => s,
+        Err(_) => return HashMap::new(),
+    };
+    catalog
+        .list_labels()
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|(lid, _name)| {
+            let hwm = store.hwm_for_label(lid as u32).unwrap_or(0);
+            if hwm > 0 {
+                Some((lid, hwm as usize))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 fn open_csr_map(path: &Path) -> HashMap<u32, CsrForward> {
     let catalog = match Catalog::open(path) {
         Ok(c) => c,


### PR DESCRIPTION
## **User description**
## Summary

- **Eliminates O(n_labels) disk reads** on every read query — previously `Engine::new()` called `hwm_for_label()` for each label to build `label_row_counts`, causing N syscalls even for simple point lookups
- **`label_row_counts` cached in `GraphDb::Inner`**, built once at open time and refreshed atomically inside `invalidate_catalog()` (which is already called after every write)
- **`Engine::new_with_all_caches()`** — new constructor that accepts all three caches (PropertyIndex, CSR map, label row counts); existing `Engine::new()` / `Engine::new_with_cached_index()` delegate to it with `None`
- **`GraphDb::build_read_engine()`** — helper that wires all caches for read paths
- All 5 read-query engine-construction paths updated; `ReadTx::execute` also benefits

## What changed

| File | Change |
|------|--------|
| `crates/sparrowdb-execution/src/engine/mod.rs` | Add `new_with_all_caches`, `new_with_cached_index` delegates to it |
| `crates/sparrowdb/src/lib.rs` | Add `label_row_counts` field, `build_read_engine`, `build_label_row_counts_from_disk`, update read paths |

## Test plan

- [x] `cargo test -p sparrowdb --test spa_178_edge_properties` — pass
- [x] `cargo test -p sparrowdb --test gap_10_parameterized_queries` — pass  
- [x] `cargo test -p sparrowdb --test spa_216_delete_node` — pass
- [x] `cargo check --workspace` — clean (no warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Use cached node counts on read queries**

### What Changed
- Read queries now reuse stored label counts instead of re-reading node totals for each label on every request
- The cached counts are loaded when the database opens and refreshed after writes that add or remove nodes
- Query paths that build a read engine now use the cached counts, including normal reads, timed reads, parameterized reads, and MATCH…CREATE scans
- The same cached counts are also used by read transactions

### Impact
`✅ Faster point lookups on databases with many labels`
`✅ Fewer disk reads during read queries`
`✅ Lower read latency after node-heavy writes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized label row count caching for improved query performance.
  * Enhanced engine initialization to more efficiently share and manage internal cache structures across read operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->