### PR TITLE
feat(parser): backtick escaping for Cypher-reserved identifiers

### DIFF
--- a/crates/sparrowdb-cypher/src/lexer.rs
+++ b/crates/sparrowdb-cypher/src/lexer.rs
@@ -292,6 +292,28 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>> {
                     Token::Integer(v)
                 }
             }
+            '`' => {
+                // Backtick-escaped identifier: `ORDER`, `CONTAINS`, etc.
+                // Always produces Token::Ident, bypassing keyword matching.
+                i += 1; // consume opening backtick
+                let start = i;
+                while i < n && chars[i] != '`' {
+                    i += 1;
+                }
+                if i >= n {
+                    return Err(Error::InvalidArgument(
+                        "unterminated backtick-quoted identifier".into(),
+                    ));
+                }
+                let ident: String = chars[start..i].iter().collect();
+                i += 1; // consume closing backtick
+                if ident.is_empty() {
+                    return Err(Error::InvalidArgument(
+                        "empty backtick-quoted identifier".into(),
+                    ));
+                }
+                Token::Ident(ident)
+            }
             c if c.is_alphabetic() || c == '_' => {
                 let start = i;
                 while i < n && (chars[i].is_alphanumeric() || chars[i] == '_') {

--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -15,6 +15,65 @@ use crate::ast::{
 };
 use crate::lexer::{tokenize, Token};
 
+/// Map a keyword `Token` variant to its canonical string representation.
+///
+/// Returns `None` for non-keyword tokens (e.g. `Ident`, `Integer`, punctuation).
+fn token_keyword_name(tok: &Token) -> Option<&'static str> {
+    match tok {
+        Token::Match => Some("MATCH"),
+        Token::Create => Some("CREATE"),
+        Token::Return => Some("RETURN"),
+        Token::Where => Some("WHERE"),
+        Token::Not => Some("NOT"),
+        Token::And => Some("AND"),
+        Token::Or => Some("OR"),
+        Token::Order => Some("ORDER"),
+        Token::By => Some("BY"),
+        Token::Asc => Some("ASC"),
+        Token::Desc => Some("DESC"),
+        Token::Limit => Some("LIMIT"),
+        Token::Skip => Some("SKIP"),
+        Token::Distinct => Some("DISTINCT"),
+        Token::Optional => Some("OPTIONAL"),
+        Token::Union => Some("UNION"),
+        Token::Unwind => Some("UNWIND"),
+        Token::Delete => Some("DELETE"),
+        Token::Detach => Some("DETACH"),
+        Token::Set => Some("SET"),
+        Token::Merge => Some("MERGE"),
+        Token::Checkpoint => Some("CHECKPOINT"),
+        Token::Optimize => Some("OPTIMIZE"),
+        Token::Contains => Some("CONTAINS"),
+        Token::StartsWith => Some("STARTS"),
+        Token::EndsWith => Some("ENDS"),
+        Token::Count => Some("COUNT"),
+        Token::Null => Some("NULL"),
+        Token::True => Some("TRUE"),
+        Token::False => Some("FALSE"),
+        Token::As => Some("AS"),
+        Token::With => Some("WITH"),
+        Token::Exists => Some("EXISTS"),
+        Token::In => Some("IN"),
+        Token::Any => Some("ANY"),
+        Token::All => Some("ALL"),
+        Token::NoneKw => Some("NONE"),
+        Token::Single => Some("SINGLE"),
+        Token::Is => Some("IS"),
+        Token::Call => Some("CALL"),
+        Token::Yield => Some("YIELD"),
+        Token::Case => Some("CASE"),
+        Token::When => Some("WHEN"),
+        Token::Then => Some("THEN"),
+        Token::Else => Some("ELSE"),
+        Token::End => Some("END"),
+        Token::Index => Some("INDEX"),
+        Token::On => Some("ON"),
+        Token::Constraint => Some("CONSTRAINT"),
+        Token::Assert => Some("ASSERT"),
+        _ => None,
+    }
+}
+
 /// Parse a Cypher statement string.  Returns `Err` for any unsupported or
 /// malformed input; never panics.
 pub fn parse(input: &str) -> Result<Statement> {
@@ -99,6 +158,26 @@ impl Parser {
                 "expected identifier, got {:?}",
                 other
             ))),
+        }
+    }
+
+    /// Accept the next token as an identifier for a label or relationship type.
+    ///
+    /// In standard Cypher, backtick-escaped identifiers allow reserved words to
+    /// be used as labels or relationship types.  After lexing, backtick-quoted
+    /// words are already `Token::Ident`, but *unquoted* reserved words (e.g.
+    /// `CONTAINS`, `ORDER`) are lexed as keyword tokens.  This helper accepts
+    /// both `Token::Ident` and any keyword token and returns the string form,
+    /// so that `:CONTAINS` and `` :`CONTAINS` `` both work.
+    fn expect_label_or_type(&mut self) -> Result<String> {
+        let tok = self.advance().clone();
+        match tok {
+            Token::Ident(s) => Ok(s),
+            ref kw => token_keyword_name(kw)
+                .map(|s| s.to_string())
+                .ok_or_else(|| {
+                    Error::InvalidArgument(format!("expected label/type name, got {:?}", tok))
+                }),
         }
     }
 
@@ -1052,15 +1131,7 @@ impl Parser {
             ));
         }
         self.advance(); // consume ':'
-        let label = match self.advance().clone() {
-            Token::Ident(s) => s,
-            other => {
-                return Err(Error::InvalidArgument(format!(
-                    "expected label name after ':', got {:?}",
-                    other
-                )))
-            }
-        };
+        let label = self.expect_label_or_type()?;
 
         // Property map (optional but typical for MERGE).
         let props = if matches!(self.peek(), Token::LBrace) {
@@ -1180,7 +1251,7 @@ impl Parser {
     fn parse_create_index(&mut self) -> Result<Statement> {
         self.expect_tok(&Token::On)?;
         self.expect_tok(&Token::Colon)?;
-        let label = self.expect_ident()?;
+        let label = self.expect_label_or_type()?;
         self.expect_tok(&Token::LParen)?;
         let property = self.expect_ident()?;
         self.expect_tok(&Token::RParen)?;
@@ -1191,7 +1262,7 @@ impl Parser {
         self.expect_tok(&Token::LParen)?;
         let _var = self.expect_ident()?;
         self.expect_tok(&Token::Colon)?;
-        let label = self.expect_ident()?;
+        let label = self.expect_label_or_type()?;
         self.expect_tok(&Token::RParen)?;
         match self.advance().clone() {
             Token::Assert => {}
@@ -1380,15 +1451,7 @@ impl Parser {
         let mut labels = Vec::new();
         while matches!(self.peek(), Token::Colon) {
             self.advance();
-            let label = match self.advance().clone() {
-                Token::Ident(s) => s,
-                other => {
-                    return Err(Error::InvalidArgument(format!(
-                        "expected label name, got {:?}",
-                        other
-                    )))
-                }
-            };
+            let label = self.expect_label_or_type()?;
             labels.push(label);
         }
 
@@ -1493,15 +1556,7 @@ impl Parser {
         // Parse optional colon + rel type, or detect illegal bare star.
         let rel_type = if matches!(self.peek(), Token::Colon) {
             self.advance(); // consume ':'
-            match self.advance().clone() {
-                Token::Ident(s) => s,
-                other => {
-                    return Err(Error::InvalidArgument(format!(
-                        "expected relationship type, got {:?}",
-                        other
-                    )))
-                }
-            }
+            self.expect_label_or_type()?
         } else if matches!(self.peek(), Token::Star) {
             return Err(Error::InvalidArgument(
                 "variable-length paths require a relationship type: use [:R*] not [*]".into(),

--- a/crates/sparrowdb/tests/spa_265_backtick_escaping.rs
+++ b/crates/sparrowdb/tests/spa_265_backtick_escaping.rs
@@ -1,0 +1,211 @@
+//! SPA-265: Backtick escaping for Cypher-reserved identifiers.
+//!
+//! Node labels and relationship types that collide with Cypher keywords
+//! (e.g. `Order`, `CONTAINS`) must be usable via backtick escaping
+//! (`` `Order` ``, `` `CONTAINS` ``).  Additionally, bare keyword names
+//! after `:` in label/rel-type position should be accepted without
+//! backticks so that `[:CONTAINS]` works the same as `` [:`CONTAINS`] ``.
+
+use sparrowdb::GraphDb;
+use tempfile::tempdir;
+
+// ── Backtick-escaped node labels ────────────────────────────────────────────
+
+/// CREATE and MATCH with backtick-escaped label `Order`.
+#[test]
+fn backtick_escaped_label_order() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+
+    db.execute("CREATE (n:`Order` {name: 'test-order'})")
+        .expect("CREATE with backtick-escaped Order label");
+
+    let r = db
+        .execute("MATCH (n:`Order`) RETURN n.name AS name")
+        .expect("MATCH with backtick-escaped Order label");
+    assert_eq!(r.rows.len(), 1);
+    assert_eq!(r.rows[0][0].to_string(), "test-order");
+}
+
+/// Bare keyword `Order` as a label (no backticks) should also work.
+#[test]
+fn bare_keyword_label_order() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+
+    db.execute("CREATE (n:Order {name: 'bare-order'})")
+        .expect("CREATE with bare Order label");
+
+    let r = db
+        .execute("MATCH (n:Order) RETURN n.name AS name")
+        .expect("MATCH with bare Order label");
+    assert_eq!(r.rows.len(), 1);
+    assert_eq!(r.rows[0][0].to_string(), "bare-order");
+}
+
+/// Backtick-escaped label `Set` — another common keyword collision.
+#[test]
+fn backtick_escaped_label_set() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+
+    db.execute("CREATE (n:`Set` {v: 42})")
+        .expect("CREATE with backtick-escaped Set label");
+
+    let r = db
+        .execute("MATCH (n:`Set`) RETURN n.v AS v")
+        .expect("MATCH with backtick-escaped Set label");
+    assert_eq!(r.rows.len(), 1);
+    assert_eq!(r.rows[0][0].to_string(), "42");
+}
+
+// ── Backtick-escaped relationship types ─────────────────────────────────────
+
+/// CREATE and MATCH with backtick-escaped rel type `CONTAINS`.
+#[test]
+fn backtick_escaped_rel_type_contains() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+
+    db.execute("CREATE (a:Basket {name: 'cart'})")
+        .expect("CREATE Basket");
+    db.execute("CREATE (b:Product {name: 'widget'})")
+        .expect("CREATE Product");
+    db.execute(
+        "MATCH (a:Basket {name: 'cart'}), (b:Product {name: 'widget'}) \
+         CREATE (a)-[:`CONTAINS`]->(b)",
+    )
+    .expect("CREATE with backtick-escaped CONTAINS rel type");
+
+    let r = db
+        .execute("MATCH ()-[r:`CONTAINS`]->() RETURN COUNT(r) AS n")
+        .expect("MATCH with backtick-escaped CONTAINS rel type");
+    assert_eq!(r.rows.len(), 1);
+    assert_eq!(r.rows[0][0].to_string(), "1");
+}
+
+/// Bare keyword `CONTAINS` as a rel type (no backticks) should also work.
+#[test]
+fn bare_keyword_rel_type_contains() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+
+    db.execute("CREATE (a:Folder {name: 'root'})")
+        .expect("CREATE Folder");
+    db.execute("CREATE (b:File {name: 'readme'})")
+        .expect("CREATE File");
+    db.execute(
+        "MATCH (a:Folder {name: 'root'}), (b:File {name: 'readme'}) \
+         CREATE (a)-[:CONTAINS]->(b)",
+    )
+    .expect("CREATE with bare CONTAINS rel type");
+
+    let r = db
+        .execute("MATCH ()-[r:CONTAINS]->() RETURN COUNT(r) AS n")
+        .expect("MATCH with bare CONTAINS rel type");
+    assert_eq!(r.rows.len(), 1);
+    assert_eq!(r.rows[0][0].to_string(), "1");
+}
+
+/// Backtick-escaped rel type `IN` — keyword that would otherwise conflict.
+#[test]
+fn backtick_escaped_rel_type_in() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+
+    db.execute("CREATE (a:Item {name: 'x'})").expect("CREATE a");
+    db.execute("CREATE (b:Category {name: 'y'})")
+        .expect("CREATE b");
+    db.execute(
+        "MATCH (a:Item {name: 'x'}), (b:Category {name: 'y'}) \
+         CREATE (a)-[:`IN`]->(b)",
+    )
+    .expect("CREATE with backtick-escaped IN rel type");
+
+    let r = db
+        .execute("MATCH ()-[r:`IN`]->() RETURN COUNT(r) AS n")
+        .expect("MATCH with backtick-escaped IN rel type");
+    assert_eq!(r.rows.len(), 1);
+    assert_eq!(r.rows[0][0].to_string(), "1");
+}
+
+// ── Standalone CREATE path with backtick-escaped identifiers ────────────────
+
+/// Standalone CREATE (a:`Label`)-[:`TYPE`]->(b:Normal) should parse and execute.
+#[test]
+fn standalone_create_with_backtick_identifiers() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+
+    db.execute("CREATE (a:`Delete` {v: 1})-[:`LIMIT`]->(b:Normal {v: 2})")
+        .expect("Standalone CREATE with backtick-escaped Delete and LIMIT");
+
+    let r = db
+        .execute("MATCH (a:`Delete`) RETURN COUNT(a) AS n")
+        .expect("COUNT nodes with backtick-escaped Delete label");
+    assert_eq!(r.rows.len(), 1);
+    assert_eq!(r.rows[0][0].to_string(), "1");
+
+    let r = db
+        .execute("MATCH ()-[r:`LIMIT`]->() RETURN COUNT(r) AS n")
+        .expect("COUNT edges with backtick-escaped LIMIT rel type");
+    assert_eq!(r.rows.len(), 1);
+    assert_eq!(r.rows[0][0].to_string(), "1");
+}
+
+// ── Lexer edge cases ────────────────────────────────────────────────────────
+
+/// Unterminated backtick should produce a parse error.
+#[test]
+fn unterminated_backtick_is_error() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+
+    let err = db
+        .execute("CREATE (n:`UnclosedLabel)")
+        .expect_err("unterminated backtick must fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unterminated"),
+        "error must mention 'unterminated'; got: {msg}"
+    );
+}
+
+/// Empty backtick identifier should produce a parse error.
+#[test]
+fn empty_backtick_is_error() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+
+    let err = db
+        .execute("CREATE (n:`` {v: 1})")
+        .expect_err("empty backtick identifier must fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("empty"),
+        "error must mention 'empty'; got: {msg}"
+    );
+}
+
+/// Backtick-escaped and bare keyword with matching case are interchangeable.
+#[test]
+fn backtick_and_bare_keyword_same_case_are_interchangeable() {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+
+    // Bare keyword ORDER creates label "ORDER"; backtick `ORDER` also creates "ORDER".
+    db.execute("CREATE (n:Order {name: 'a'})").unwrap();
+    db.execute("CREATE (n:`ORDER` {name: 'b'})").unwrap();
+
+    // Both should match when queried with backtick `ORDER`.
+    let r = db
+        .execute("MATCH (n:`ORDER`) RETURN COUNT(n) AS cnt")
+        .unwrap();
+    assert_eq!(r.rows[0][0].to_string(), "2");
+
+    // And both should match when queried with bare keyword Order.
+    let r = db
+        .execute("MATCH (n:Order) RETURN COUNT(n) AS cnt")
+        .unwrap();
+    assert_eq!(r.rows[0][0].to_string(), "2");
+}


### PR DESCRIPTION
## **User description**
## Summary

- Lexer now handles backtick-quoted identifiers (`` `Order` ``, `` `CONTAINS` ``), producing `Token::Ident` and bypassing keyword matching
- Parser accepts keyword tokens in label/rel-type positions via `expect_label_or_type()`, so both `[:CONTAINS]` and `` [:`CONTAINS`] `` work
- Adds `token_keyword_name()` helper that maps all keyword token variants to their canonical string form

Closes #265

## Test plan

- [x] 10 e2e tests in `spa_265_backtick_escaping.rs` covering:
  - Backtick-escaped node labels (`Order`, `Set`, `Delete`)
  - Backtick-escaped rel types (`CONTAINS`, `IN`, `LIMIT`)
  - Bare keyword labels and rel types (no backticks)
  - Standalone CREATE paths with backtick identifiers
  - Interchangeability of backtick and bare keyword (same case)
  - Error cases: unterminated backtick, empty backtick
- [x] `cargo fmt --all` clean
- [x] `cargo check -p sparrowdb` passes
- [x] `cargo clippy -p sparrowdb-cypher` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Allow reserved words to be used as labels and relationship types**

### What Changed
- Users can now write labels and relationship types with backticks, such as `` `Order` `` and `` `CONTAINS` ``, and have them accepted in CREATE, MATCH, MERGE, index, and constraint statements
- Bare keyword names in label or relationship type positions, such as `:Order` and `:CONTAINS`, are also accepted
- Invalid backtick usage now returns clear errors for unterminated or empty backtick-quoted names

### Impact
`✅ Fewer query errors with reserved names`
`✅ Easier schema setup with keyword-like labels`
`✅ Clearer feedback for malformed identifiers`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added support for backtick-quoted identifiers in Cypher queries, enabling reserved keywords to be used as node labels and relationship types (e.g., `Order`, `CONTAINS`, `LIMIT`)

## Bug Fixes
- Improved error handling for malformed backtick identifiers with clear messages for unterminated or empty identifiers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->