### PR TITLE
feat(engine): ASP-Join hash build spill to disk (SPA-101)

### DIFF
--- a/crates/sparrowdb/tests/spa_101_join_spill.rs
+++ b/crates/sparrowdb/tests/spa_101_join_spill.rs
@@ -1,0 +1,89 @@
+//! SPA-101 — ASP-Join hash build spill to disk.
+//!
+//! Tests that [`SpillingHashJoin`] produces the same results as the baseline
+//! in-memory [`AspJoin`] in both the in-memory fast path and the spill path.
+//!
+//! 1. Small graph that stays in memory — regression test.
+//! 2. Large ring graph that forces a spill — correctness test.
+
+use sparrowdb_execution::join::AspJoin;
+use sparrowdb_execution::join_spill::SpillingHashJoin;
+use sparrowdb_storage::csr::CsrForward;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn social_graph() -> CsrForward {
+    // Alice=0, Bob=1, Carol=2, Dave=3, Eve=4
+    // Alice->Bob, Alice->Carol, Bob->Dave, Carol->Dave, Carol->Eve
+    let edges = vec![(0u64, 1u64), (0, 2), (1, 3), (2, 3), (2, 4)];
+    CsrForward::build(5, &edges)
+}
+
+// ── Test 1: small join stays in memory (regression) ─────────────────────────
+
+#[test]
+fn spill_join_small_graph_matches_baseline() {
+    let csr = social_graph();
+    let baseline = AspJoin::new(&csr);
+    let spilling = SpillingHashJoin::new(&csr);
+
+    for src in 0u64..5 {
+        let expected = baseline.two_hop(src).unwrap();
+        let got = spilling.two_hop(src).unwrap();
+        assert_eq!(got, expected, "mismatch for src={src} (in-memory path)");
+    }
+}
+
+// ── Test 2: large join forces spill (correctness) ───────────────────────────
+
+#[test]
+fn spill_join_large_ring_forced_spill() {
+    // Build a ring: node i -> i+1 (mod N).
+    // Each node's 2-hop fof is [(i+2) % N].
+    const N: u64 = 5_000;
+
+    let edges: Vec<(u64, u64)> = (0..N).map(|i| (i, (i + 1) % N)).collect();
+    let csr = CsrForward::build(N, &edges);
+
+    let baseline = AspJoin::new(&csr);
+
+    // Threshold=1 forces every node into the spill path.
+    let spilling = SpillingHashJoin::with_thresholds(&csr, 1, 4);
+
+    for src in 0..N {
+        let expected = baseline.two_hop(src).unwrap();
+        let got = spilling.two_hop(src).unwrap();
+        assert_eq!(
+            got, expected,
+            "ring fof mismatch for src={src} (spill path)"
+        );
+    }
+}
+
+// ── Test 3: fan-out graph with overlapping fof ──────────────────────────────
+
+#[test]
+fn spill_join_fanout_graph_forced_spill() {
+    // Node 0 connects to nodes 1..=50.
+    // Each of those connects to nodes 100..=149.
+    // So node 0's fof = {100..=149}, reachable via every mid node.
+    // This creates a large build side (50 * 50 = 2500 entries).
+    let mut edges: Vec<(u64, u64)> = Vec::new();
+    for mid in 1u64..=50 {
+        edges.push((0, mid));
+        for fof in 100u64..=149 {
+            edges.push((mid, fof));
+        }
+    }
+    let csr = CsrForward::build(150, &edges);
+
+    let baseline = AspJoin::new(&csr);
+    let expected = baseline.two_hop(0).unwrap();
+
+    // Force spill with threshold lower than total entries (2500).
+    let spilling = SpillingHashJoin::with_thresholds(&csr, 100, 8);
+    let got = spilling.two_hop(0).unwrap();
+
+    assert_eq!(got, expected, "fan-out fof mismatch (spill path)");
+    assert_eq!(got.len(), 50, "should have exactly 50 fof nodes");
+}


### PR DESCRIPTION
## **User description**
## Summary
- Adds integration tests for `SpillingHashJoin` in `crates/sparrowdb/tests/spa_101_join_spill.rs`
- Tests cover: small graph in-memory path (regression), large ring graph with forced spill (correctness), and fan-out graph with overlapping fof and forced spill
- The spill-to-disk implementation itself was delivered in SPA-114 (commit 7d9b0fb); this PR adds the top-level integration test suite

## Test plan
- [x] `cargo test --test spa_101_join_spill` — all 3 tests pass
- [x] `cargo fmt --all` — clean
- [x] `cargo check -p sparrowdb` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add integration coverage for join results when the hash build stays in memory and when it spills to disk

### What Changed
- Added a regression test that checks a small graph returns the same two-hop results with the spilling join as with the existing in-memory join
- Added a forced-spill test on a large ring graph to verify spilled joins still match the baseline results
- Added a fan-out test with overlapping paths to confirm spill handling keeps the expected set of results

### Impact
`✅ Safer join spill releases`
`✅ Fewer spill-path regressions`
`✅ Higher confidence in large-graph join results`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
