### PR TITLE
fix(engine): 2-hop aggregate queries return null instead of count (SPA-263)

### DIFF
--- a/crates/sparrowdb-execution/src/engine/hop.rs
+++ b/crates/sparrowdb-execution/src/engine/hop.rs
@@ -1068,6 +1068,11 @@ impl Engine {
         };
 
         let mut rows = Vec::new();
+        // SPA-263: detect aggregates early so we can build proper HashMap rows
+        // instead of projecting through project_three_var_row (which returns Null
+        // for aggregate columns like COUNT(*)).
+        let use_agg = has_aggregate_in_return(&m.return_clause.items);
+        let mut raw_rows: Vec<HashMap<String, Value>> = Vec::new();
 
         // Scan source nodes.
         for src_slot in 0..hwm_src {
@@ -1225,20 +1230,53 @@ impl Engine {
                             }
                         }
 
-                        // Project a row: src (a) + mid (m) + fof (b) columns.
-                        // We build the row using a 3-var aware helper here so that
-                        // `RETURN m.name`, `RETURN a.name`, and `RETURN b.name` all
-                        // resolve correctly.
-                        let row = project_three_var_row(
-                            &src_props,
-                            &mid_props,
-                            &b_props,
-                            column_names,
-                            &src_node_pat.var,
-                            &mid_node_pat.var,
-                            &self.snapshot.store,
-                        );
-                        rows.push(row);
+                        // SPA-263: when aggregates are present, build a HashMap
+                        // row with node refs (needed for COUNT(var), etc.) instead
+                        // of projecting through project_three_var_row which returns
+                        // Null for non-property columns.
+                        if use_agg {
+                            let mut row_vals = build_row_vals(
+                                &src_props,
+                                &src_node_pat.var,
+                                &col_ids_src_where,
+                                &self.snapshot.store,
+                            );
+                            row_vals.extend(build_row_vals(
+                                &mid_props,
+                                &mid_node_pat.var,
+                                &col_ids_mid,
+                                &self.snapshot.store,
+                            ));
+                            row_vals.extend(build_row_vals(
+                                &b_props,
+                                &fof_node_pat.var,
+                                &col_ids_fof,
+                                &self.snapshot.store,
+                            ));
+                            // Bind node refs so COUNT(var) resolves as non-null.
+                            if !src_node_pat.var.is_empty() {
+                                row_vals.insert(src_node_pat.var.clone(), Value::NodeRef(src_node));
+                            }
+                            if !mid_node_pat.var.is_empty() {
+                                row_vals.insert(mid_node_pat.var.clone(), Value::NodeRef(mid_node));
+                            }
+                            if !fof_node_pat.var.is_empty() {
+                                row_vals.insert(fof_node_pat.var.clone(), Value::NodeRef(b_node));
+                            }
+                            raw_rows.push(row_vals);
+                        } else {
+                            // Project a row: src (a) + mid (m) + fof (b) columns.
+                            let row = project_three_var_row(
+                                &src_props,
+                                &mid_props,
+                                &b_props,
+                                column_names,
+                                &src_node_pat.var,
+                                &mid_node_pat.var,
+                                &self.snapshot.store,
+                            );
+                            rows.push(row);
+                        }
                         found_valid_fof = true;
                         // Continue — multiple b nodes may match (emit one row per match).
                     }
@@ -1407,35 +1445,58 @@ impl Engine {
                         }
                     }
 
-                    // SPA-241: use three-var projection so mid variable columns
-                    // are resolved from mid_props rather than defaulting to fof_props.
-                    let row = project_three_var_row(
-                        &src_props,
-                        &mid_props,
-                        &fof_props,
-                        column_names,
-                        &src_node_pat.var,
-                        &mid_node_pat.var,
-                        &self.snapshot.store,
-                    );
-                    rows.push(row);
+                    // SPA-263: when aggregates are present, build a HashMap
+                    // row with node refs instead of projecting.
+                    if use_agg {
+                        let mut row_vals = build_row_vals(
+                            &src_props,
+                            &src_node_pat.var,
+                            &col_ids_src_where,
+                            &self.snapshot.store,
+                        );
+                        row_vals.extend(build_row_vals(
+                            &mid_props,
+                            &mid_node_pat.var,
+                            &col_ids_mid,
+                            &self.snapshot.store,
+                        ));
+                        row_vals.extend(build_row_vals(
+                            &fof_props,
+                            &fof_node_pat.var,
+                            &col_ids_fof,
+                            &self.snapshot.store,
+                        ));
+                        // Bind node refs so COUNT(var) resolves as non-null.
+                        if !src_node_pat.var.is_empty() {
+                            row_vals.insert(src_node_pat.var.clone(), Value::NodeRef(src_node));
+                        }
+                        if !mid_node_pat.var.is_empty() {
+                            row_vals.insert(mid_node_pat.var.clone(), Value::NodeRef(mid_node));
+                        }
+                        if !fof_node_pat.var.is_empty() {
+                            row_vals.insert(fof_node_pat.var.clone(), Value::NodeRef(fof_node));
+                        }
+                        raw_rows.push(row_vals);
+                    } else {
+                        // SPA-241: use three-var projection so mid variable columns
+                        // are resolved from mid_props rather than defaulting to fof_props.
+                        let row = project_three_var_row(
+                            &src_props,
+                            &mid_props,
+                            &fof_props,
+                            column_names,
+                            &src_node_pat.var,
+                            &mid_node_pat.var,
+                            &self.snapshot.store,
+                        );
+                        rows.push(row);
+                    }
                 }
             }
         }
 
-        // SPA-263: apply aggregation (COUNT, SUM, etc.) if RETURN has aggregates.
-        let use_agg = has_aggregate_in_return(&m.return_clause.items);
+        // SPA-263: apply aggregation using pre-built raw_rows (with node refs).
         if use_agg {
-            let raw_rows: Vec<HashMap<String, Value>> = rows
-                .iter()
-                .map(|row| {
-                    column_names
-                        .iter()
-                        .zip(row.iter())
-                        .map(|(col, val)| (col.clone(), val.clone()))
-                        .collect()
-                })
-                .collect();
             rows = self.aggregate_rows_graph(&raw_rows, &m.return_clause.items);
         } else {
             // DISTINCT

--- a/crates/sparrowdb/tests/spa_263_two_hop_agg.rs
+++ b/crates/sparrowdb/tests/spa_263_two_hop_agg.rs
@@ -1,0 +1,153 @@
+//! Regression tests for SPA-263: 2-hop MATCH with aggregates (COUNT, etc.)
+//! returns null instead of proper aggregate values.
+//!
+//! The root cause: `project_three_var_row` returns `Value::Null` for aggregate
+//! columns like `COUNT(*) AS n` because they don't match any `var.prop` pattern.
+//! The fix makes the 2-hop path use `build_row_vals` + `aggregate_rows_graph`
+//! when aggregates are present (same approach as the 1-hop path).
+
+use sparrowdb::open;
+use sparrowdb_execution::types::Value;
+
+fn make_db() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+/// Same-label 2-hop COUNT(*) must return a single integer row, not null rows.
+///
+/// Graph:
+///   Alice -[:KNOWS]-> Bob -[:WORKS_AT]-> Acme
+///   Carol -[:KNOWS]-> Dave -[:WORKS_AT]-> BigCo
+#[test]
+fn two_hop_same_rel_count_star() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (:Person {name: 'Alice'})").unwrap();
+    db.execute("CREATE (:Person {name: 'Bob'})").unwrap();
+    db.execute("CREATE (:Person {name: 'Carol'})").unwrap();
+    db.execute("CREATE (:Person {name: 'Dave'})").unwrap();
+    db.execute("CREATE (:Company {name: 'Acme'})").unwrap();
+    db.execute("CREATE (:Company {name: 'BigCo'})").unwrap();
+
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) \
+         CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+    db.execute(
+        "MATCH (b:Person {name: 'Bob'}), (c:Company {name: 'Acme'}) \
+         CREATE (b)-[:WORKS_AT]->(c)",
+    )
+    .unwrap();
+    db.execute(
+        "MATCH (a:Person {name: 'Carol'}), (b:Person {name: 'Dave'}) \
+         CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+    db.execute(
+        "MATCH (b:Person {name: 'Dave'}), (c:Company {name: 'BigCo'}) \
+         CREATE (b)-[:WORKS_AT]->(c)",
+    )
+    .unwrap();
+
+    // This should return [[Int64(2)]], NOT [[Null], [Null]]
+    let result = db
+        .execute(
+            "MATCH (a:Person)-[:KNOWS]->(b:Person)-[:WORKS_AT]->(c:Company) \
+             RETURN COUNT(*) AS n",
+        )
+        .expect("2-hop COUNT(*)");
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "SPA-263: COUNT(*) must return exactly 1 row, got {}: {:?}",
+        result.rows.len(),
+        result.rows
+    );
+
+    assert_eq!(
+        result.rows[0][0],
+        Value::Int64(2),
+        "SPA-263: COUNT(*) should be 2, got {:?}",
+        result.rows[0][0]
+    );
+}
+
+/// Same-label 2-hop with COUNT(var) on a specific variable.
+#[test]
+fn two_hop_count_variable() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (:Person {name: 'Alice'})").unwrap();
+    db.execute("CREATE (:Person {name: 'Bob'})").unwrap();
+    db.execute("CREATE (:Company {name: 'Acme'})").unwrap();
+
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) \
+         CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+    db.execute(
+        "MATCH (b:Person {name: 'Bob'}), (c:Company {name: 'Acme'}) \
+         CREATE (b)-[:WORKS_AT]->(c)",
+    )
+    .unwrap();
+
+    let result = db
+        .execute(
+            "MATCH (a:Person)-[:KNOWS]->(b:Person)-[:WORKS_AT]->(c:Company) \
+             RETURN COUNT(c) AS company_count",
+        )
+        .expect("2-hop COUNT(c)");
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "SPA-263: COUNT(c) must return exactly 1 row, got {}: {:?}",
+        result.rows.len(),
+        result.rows
+    );
+
+    assert_eq!(
+        result.rows[0][0],
+        Value::Int64(1),
+        "SPA-263: COUNT(c) should be 1, got {:?}",
+        result.rows[0][0]
+    );
+}
+
+/// Non-aggregate 2-hop queries must still work correctly after the fix.
+#[test]
+fn two_hop_non_aggregate_still_works() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (:Person {name: 'Alice'})").unwrap();
+    db.execute("CREATE (:Person {name: 'Bob'})").unwrap();
+    db.execute("CREATE (:Company {name: 'Acme'})").unwrap();
+
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) \
+         CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+    db.execute(
+        "MATCH (b:Person {name: 'Bob'}), (c:Company {name: 'Acme'}) \
+         CREATE (b)-[:WORKS_AT]->(c)",
+    )
+    .unwrap();
+
+    let result = db
+        .execute(
+            "MATCH (a:Person)-[:KNOWS]->(b:Person)-[:WORKS_AT]->(c:Company) \
+             RETURN a.name, b.name, c.name",
+        )
+        .expect("2-hop non-aggregate");
+
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(result.rows[0][0], Value::String("Alice".to_string()));
+    assert_eq!(result.rows[0][1], Value::String("Bob".to_string()));
+    assert_eq!(result.rows[0][2], Value::String("Acme".to_string()));
+}


### PR DESCRIPTION
## **User description**
## Summary
- The 2-hop code path in `hop.rs` used `project_three_var_row` for all result rows, which returns `Value::Null` for aggregate columns (`COUNT(*)`, `COUNT(var)`) since they don't match any `var.prop` pattern
- When `has_aggregate_in_return` is true, both the incoming and forward-forward 2-hop paths now build `HashMap<String, Value>` rows via `build_row_vals` with node refs bound (matching the 1-hop aggregate approach)
- Non-aggregate 2-hop queries still use the existing `project_three_var_row` path unchanged

## Test plan
- [x] New test `spa_263_two_hop_agg.rs` with 3 cases: `COUNT(*)`, `COUNT(var)`, and non-aggregate 2-hop
- [x] Existing `spa_263_two_hop_null` tests still pass (cross-label null rows, count star, same-label)
- [x] `cargo check -p sparrowdb` passes
- [x] `cargo fmt --all` clean

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix 2-hop queries so aggregates return real counts instead of null rows

### What Changed
- 2-hop queries with aggregates now return the expected count values for `COUNT(*)` and `COUNT(var)`
- Non-aggregate 2-hop queries keep returning the same row data as before
- Added regression tests covering aggregate and non-aggregate 2-hop cases

### Impact
`✅ Correct counts in 2-hop graph queries`
`✅ Fewer null results in aggregate queries`
`✅ Safer 2-hop query behavior after upgrades`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed 2-hop path queries with aggregate functions (e.g., `COUNT`) to return correct results instead of null values.
* Improved multi-hop graph traversal handling with aggregation operations to correctly process variable bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->