### PR TITLE
perf(engine): HashSet intersection for mutual neighbor queries (closes #287)

### DIFF
--- a/crates/sparrowdb-execution/src/engine/hop.rs
+++ b/crates/sparrowdb-execution/src/engine/hop.rs
@@ -1,6 +1,10 @@
 //! Auto-generated submodule — see engine/mod.rs for context.
 use super::*;
 
+/// Precomputed neighbor entry for the `b`-slot in a mutual-friends (FoF)
+/// hash-set intersection: `(b_slot, forward_neighbor_set, b_property_values)`.
+type BNeighborEntry = (u64, HashSet<u64>, Vec<(u32, u64)>);
+
 impl Engine {
     // ── 1-hop traversal: (a)-[:R]->(f) ───────────────────────────────────────
 
@@ -1086,23 +1090,13 @@ impl Engine {
         //
         // Pre-compute: for each qualifying b-slot, its forward neighbor set via
         // hop2 (since b→m means m ∈ hop2_fwd_neighbors(b)).
-        let b_neighbor_sets: Option<Vec<(u64, HashSet<u64>, Vec<(u32, u64)>)>> =
+        let b_neighbor_sets: Option<Vec<BNeighborEntry>> =
             if second_hop_incoming && !fof_node_pat.props.is_empty() {
                 let hwm_fof = self.snapshot.store.hwm_for_label(fof_label_id)?;
-                let mut sets: Vec<(u64, HashSet<u64>, Vec<(u32, u64)>)> = Vec::new();
-                let fof_prop_col_ids: Vec<u32> = {
-                    let mut v = col_ids_fof.clone();
-                    for p in &fof_node_pat.props {
-                        let col_id = prop_name_to_col_id(&p.key);
-                        if !v.contains(&col_id) {
-                            v.push(col_id);
-                        }
-                    }
-                    v
-                };
+                let mut sets: Vec<BNeighborEntry> = Vec::new();
                 for b_slot in 0..hwm_fof {
                     let b_node = NodeId(((fof_label_id as u64) << 32) | b_slot);
-                    let b_props = read_node_props(&self.snapshot.store, b_node, &fof_prop_col_ids)?;
+                    let b_props = read_node_props(&self.snapshot.store, b_node, &col_ids_fof)?;
                     if !self.matches_prop_filter(&b_props, &fof_node_pat.props) {
                         continue;
                     }


### PR DESCRIPTION
## **User description**
## Summary

- Pre-identifies qualifying b-nodes when they have inline property filters, collects their forward neighbors into HashSets
- Replaces the O(|neighbors(a)| x avg_predecessor_degree) backward CSR scan with O(min(deg_a, deg_b)) set intersection for mutual neighbor queries
- Preserves the original predecessor-scan fallback path when b-side has no inline property filters

## Test plan

- [x] All 5 `spa_201_csr_backward` mutual friend tests pass (basic, no_common, multiple, directed_vs_undirected, empty_anchor)
- [x] All 13 LDBC IC3-IC14 tests pass (including ic8_replies)
- [x] `cargo check -p sparrowdb` clean
- [x] `cargo fmt` applied
- [ ] Benchmark Q8 mutual neighbors to confirm 2-3x improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Speed up mutual-friend queries by checking overlaps instead of scanning every predecessor**

### What Changed
- For the common two-hop pattern that finds shared neighbors, the query now compares the first-hop neighbors of both sides directly to find matches
- When the right-hand side has filters, it now preloads only the matching nodes before searching for shared neighbors
- If that fast path cannot be used, the previous search method still runs as a fallback

### Impact
`✅ Faster mutual-friend lookups`
`✅ Lower latency on filtered two-hop queries`
`✅ Fewer slow scans on large neighbor lists`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster execution for two-hop incoming relationship queries, especially when filtering on properties of the far-side node.
  * Reduced repeated work during traversal, improving response times for complex three-node patterns while preserving previous behavior when the new fast path doesn't apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->