### PR TITLE
perf: persist property indexes to disk (closes #286)

### DIFF
--- a/crates/sparrowdb-storage/src/property_index.rs
+++ b/crates/sparrowdb-storage/src/property_index.rs
@@ -185,6 +185,11 @@ impl PropertyIndex {
         self.index.clear();
         self.loaded.clear();
         self.generation = self.generation.wrapping_add(1);
+        // Reset the persistence watermark so that persist_if_grew will write
+        // again after the index is repopulated (the on-disk file is removed
+        // separately via remove_persisted, but the count must be zeroed here
+        // so the threshold comparison starts from scratch).
+        self.persisted_key_count = 0;
     }
 
     /// Merge column data from `other` into `self` using union semantics.

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -376,6 +376,32 @@ pub struct GraphDb {
     inner: Arc<DbInner>,
 }
 
+impl DbInner {
+    /// Invalidate the shared property-index cache.
+    ///
+    /// Clears the in-memory index (bumping its generation so stale Engine
+    /// clones are detectable) and removes the persisted `prop_index.bin` file
+    /// so a subsequent `open` does not load stale index data (SPA-286).
+    fn invalidate_prop_index(&self) {
+        self.prop_index
+            .write()
+            .expect("prop_index RwLock poisoned")
+            .clear();
+        sparrowdb_storage::property_index::PropertyIndex::remove_persisted(&self.path);
+    }
+
+    /// Persist the shared property-index cache to disk if new columns have
+    /// been loaded since the last persist (SPA-286).
+    ///
+    /// Only writes when the index has grown, avoiding redundant I/O on queries
+    /// that hit only already-persisted columns.
+    fn persist_prop_index(&self) {
+        if let Ok(mut guard) = self.prop_index.write() {
+            guard.persist_if_grew(&self.path);
+        }
+    }
+}
+
 impl GraphDb {
     /// Return the filesystem path of this database.
     pub fn path(&self) -> &Path {
@@ -391,6 +417,15 @@ impl GraphDb {
         let label_row_counts = RwLock::new(build_label_row_counts_from_disk(&catalog, path));
         // SPA-286: load persisted property index from disk if available,
         // otherwise start with an empty index (lazy rebuild from column files).
+        //
+        // Crash-safety: if the WAL has any prior activity (last_lsn > 0), a
+        // previous session may have written to column files after persisting the
+        // index — or may have crashed before removing the stale index file.
+        // Remove the on-disk snapshot and start with an empty index so we never
+        // serve stale data after a crash.
+        if wal_writer.last_lsn().0 > 0 {
+            sparrowdb_storage::property_index::PropertyIndex::remove_persisted(path);
+        }
         let prop_index = sparrowdb_storage::property_index::PropertyIndex::load_from_dir(path)
             .unwrap_or_default();
         Ok(GraphDb {
@@ -429,6 +464,15 @@ impl GraphDb {
         let label_row_counts = RwLock::new(build_label_row_counts_from_disk(&catalog, path));
         // SPA-286: load persisted property index (not encrypted; index data is
         // derived from column files which are also unencrypted on disk).
+        //
+        // Crash-safety: if the WAL has any prior activity (last_lsn > 0), a
+        // previous session may have written to column files after persisting the
+        // index — or may have crashed before removing the stale index file.
+        // Remove the on-disk snapshot and start with an empty index so we never
+        // serve stale data after a crash.
+        if wal_writer.last_lsn().0 > 0 {
+            sparrowdb_storage::property_index::PropertyIndex::remove_persisted(path);
+        }
         let prop_index = sparrowdb_storage::property_index::PropertyIndex::load_from_dir(path)
             .unwrap_or_default();
         Ok(GraphDb {
@@ -458,13 +502,7 @@ impl GraphDb {
     /// SPA-286: also removes the persisted `prop_index.bin` file so that a
     /// subsequent `open` does not load stale index data.
     fn invalidate_prop_index(&self) {
-        self.inner
-            .prop_index
-            .write()
-            .expect("prop_index RwLock poisoned")
-            .clear();
-        // SPA-286: remove stale persisted index.
-        sparrowdb_storage::property_index::PropertyIndex::remove_persisted(&self.inner.path);
+        self.inner.invalidate_prop_index();
     }
 
     /// Persist the shared property-index cache to disk if new columns have
@@ -476,9 +514,7 @@ impl GraphDb {
     /// were loaded), avoiding redundant I/O on repeated queries that hit the
     /// same already-persisted columns.
     fn persist_prop_index(&self) {
-        if let Ok(mut guard) = self.inner.prop_index.write() {
-            guard.persist_if_grew(&self.inner.path);
-        }
+        self.inner.persist_prop_index();
     }
 
     /// Refresh the shared catalog cache from disk (SPA-188) and simultaneously
@@ -2576,9 +2612,7 @@ impl ReadTx {
         // so subsequent queries benefit from warm column data.
         engine.write_back_prop_index(&self.inner.prop_index);
         // SPA-286: persist updated index to disk if new columns were loaded.
-        if let Ok(mut guard) = self.inner.prop_index.write() {
-            guard.persist_if_grew(&self.inner.path);
-        }
+        self.inner.persist_prop_index();
 
         tracing::debug!(
             rows = result.rows.len(),
@@ -3448,13 +3482,7 @@ impl WriteTx {
         // is harmless (just bumps the generation counter).  The critical
         // case is when a caller uses WriteTx directly without going through
         // a GraphDb::execute path, which previously left the cache stale.
-        self.inner
-            .prop_index
-            .write()
-            .expect("prop_index RwLock poisoned")
-            .clear();
-        // SPA-286: remove stale persisted index after write commit.
-        sparrowdb_storage::property_index::PropertyIndex::remove_persisted(&self.inner.path);
+        self.inner.invalidate_prop_index();
 
         self.committed = true;
         Ok(TxnId(new_id))


### PR DESCRIPTION
## **User description**
## Summary

- Property indexes (`PropertyIndex`) are now persisted to `prop_index.bin` and loaded on `GraphDb::open`, eliminating the O(n) column-file scan on every new Engine instance
- Write-transaction commits delete the persisted file to prevent stale data; `persist_if_grew` only writes when new `(label_id, col_id)` pairs are loaded, avoiding redundant I/O on repeated queries
- Binary format uses magic + version header for forward compatibility; corrupt/missing files fall back gracefully to lazy rebuild

## Test plan

- [x] `cargo check -p sparrowdb` passes with zero warnings
- [x] 6 new unit tests: save/load roundtrip, corrupt file handling, empty index cleanup, range lookup persistence, file removal
- [x] All existing sparrowdb tests pass (2 pre-existing degree-cache failures unrelated to this change)
- [x] `match_create_edge_oi_performance` test passes (previously failed at 45s due to per-query persist overhead; `persist_if_grew` eliminated the redundant writes)
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Load and reuse the property index from disk between database opens**

### What Changed
- The database now loads a saved property index when it starts, so queries can skip rebuilding it from column files.
- When queries discover new indexed columns, the updated index is saved for the next open; repeated queries that do not add new columns avoid extra disk writes.
- After writes, the saved index file is removed so reopened databases do not use stale index data.

### Impact
`✅ Faster database startup`
`✅ Faster first property-filter queries after reopen`
`✅ Fewer repeated disk writes during read-heavy workloads`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
