### PR TITLE
fix(engine): 2-hop reverse arrow cross-label pattern returns 0 rows (closes #294)

### DIFF
--- a/crates/sparrowdb-execution/src/engine/hop.rs
+++ b/crates/sparrowdb-execution/src/engine/hop.rs
@@ -941,13 +941,23 @@ impl Engine {
             })
             .map(|(id, _, _, _)| *id)
             .collect();
+        // #294: when the second hop is Incoming, the pattern is
+        // (mid)<-[:R]-(fof), meaning edges are stored as (fof)-[:R]->(mid)
+        // in the catalog (src=fof_label, dst=mid_label).  We must swap the
+        // label filter so we actually find matching rel tables.
         let hop2_rel_ids: Vec<u64> = all_rel_tables_2hop
             .iter()
             .filter(|(_, sid, did, rt)| {
                 let type_ok = rel2.rel_type.is_empty() || rt == &rel2.rel_type;
-                let src_ok = *sid as u32 == mid_label_id;
-                let dst_ok = *did as u32 == fof_label_id;
-                type_ok && src_ok && dst_ok
+                if second_hop_incoming {
+                    let src_ok = *sid as u32 == fof_label_id;
+                    let dst_ok = *did as u32 == mid_label_id;
+                    type_ok && src_ok && dst_ok
+                } else {
+                    let src_ok = *sid as u32 == mid_label_id;
+                    let dst_ok = *did as u32 == fof_label_id;
+                    type_ok && src_ok && dst_ok
+                }
             })
             .map(|(id, _, _, _)| *id)
             .collect();

--- a/crates/sparrowdb/tests/reverse_arrow_294.rs
+++ b/crates/sparrowdb/tests/reverse_arrow_294.rs
@@ -1,0 +1,129 @@
+//! Regression test for GitHub issue #294:
+//! 2-hop reverse arrow pattern (a)-[:REL]->(b)<-[:REL]-(c) returns 0 rows
+//! when the src/mid/fof labels differ (e.g. Person → Movie ← Person).
+//!
+//! The bug: `hop2_rel_ids` filters rel tables as (src=mid, dst=fof), but for
+//! an incoming second hop the catalog stores edges as (src=fof, dst=mid).
+//! When mid and fof have the same label the filter accidentally works; with
+//! different labels it yields an empty set → zero results.
+
+use sparrowdb::open;
+use sparrowdb_execution::types::Value;
+
+fn make_db() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+fn collect_strings(rows: &[Vec<Value>]) -> Vec<String> {
+    rows.iter()
+        .filter_map(|row| match row.first() {
+            Some(Value::String(s)) => Some(s.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+// ── Test: co-actor pattern with heterogeneous labels ─────────────────────────
+//
+// Graph:  (Tom:Person)-[:ACTED_IN]->(m:Movie)<-[:ACTED_IN]-(coactor:Person)
+//
+//   Tom --ACTED_IN--> Matrix <--ACTED_IN-- Keanu
+//   Tom --ACTED_IN--> Matrix <--ACTED_IN-- Carrie
+//
+// Expected: coactor names include "Keanu" and "Carrie"
+
+#[test]
+fn reverse_arrow_cross_label_coactor() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (:Person {name: 'Tom'})").expect("Tom");
+    db.execute("CREATE (:Person {name: 'Keanu'})")
+        .expect("Keanu");
+    db.execute("CREATE (:Person {name: 'Carrie'})")
+        .expect("Carrie");
+    db.execute("CREATE (:Movie {title: 'Matrix'})")
+        .expect("Matrix");
+
+    db.execute(
+        "MATCH (p:Person {name:'Tom'}), (m:Movie {title:'Matrix'}) CREATE (p)-[:ACTED_IN]->(m)",
+    )
+    .expect("Tom->Matrix");
+    db.execute(
+        "MATCH (p:Person {name:'Keanu'}), (m:Movie {title:'Matrix'}) CREATE (p)-[:ACTED_IN]->(m)",
+    )
+    .expect("Keanu->Matrix");
+    db.execute(
+        "MATCH (p:Person {name:'Carrie'}), (m:Movie {title:'Matrix'}) CREATE (p)-[:ACTED_IN]->(m)",
+    )
+    .expect("Carrie->Matrix");
+
+    let result = db
+        .execute(
+            "MATCH (tom:Person {name:'Tom'})-[:ACTED_IN]->(m:Movie)<-[:ACTED_IN]-(coactor:Person) \
+             RETURN coactor.name",
+        )
+        .expect("co-actor query");
+
+    let mut names = collect_strings(&result.rows);
+    names.sort();
+
+    assert!(
+        !names.is_empty(),
+        "#294: reverse arrow cross-label pattern returned 0 rows"
+    );
+    // Tom should NOT appear as his own co-actor (self-loop), but Keanu and Carrie should.
+    // NOTE: if the engine doesn't filter self-loops, Tom may appear — that's a separate issue.
+    assert!(
+        names.contains(&"Keanu".to_string()),
+        "#294: expected Keanu in co-actors, got {:?}",
+        names
+    );
+    assert!(
+        names.contains(&"Carrie".to_string()),
+        "#294: expected Carrie in co-actors, got {:?}",
+        names
+    );
+}
+
+// ── Test: single co-actor, minimal graph ─────────────────────────────────────
+//
+// Graph:  Alice --WORKS_AT--> Acme <--WORKS_AT-- Bob
+//
+// Expected: MATCH (a:Employee {name:'Alice'})-[:WORKS_AT]->(c:Company)<-[:WORKS_AT]-(b:Employee)
+//           RETURN b.name  →  ["Bob"]
+
+#[test]
+fn reverse_arrow_cross_label_minimal() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (:Employee {name: 'Alice'})")
+        .expect("Alice");
+    db.execute("CREATE (:Employee {name: 'Bob'})").expect("Bob");
+    db.execute("CREATE (:Company {name: 'Acme'})")
+        .expect("Acme");
+
+    db.execute(
+        "MATCH (e:Employee {name:'Alice'}), (c:Company {name:'Acme'}) CREATE (e)-[:WORKS_AT]->(c)",
+    )
+    .expect("Alice->Acme");
+    db.execute(
+        "MATCH (e:Employee {name:'Bob'}), (c:Company {name:'Acme'}) CREATE (e)-[:WORKS_AT]->(c)",
+    )
+    .expect("Bob->Acme");
+
+    let result = db
+        .execute(
+            "MATCH (a:Employee {name:'Alice'})-[:WORKS_AT]->(c:Company)<-[:WORKS_AT]-(b:Employee) \
+             RETURN b.name",
+        )
+        .expect("colleague query");
+
+    let names = collect_strings(&result.rows);
+    assert!(
+        names.contains(&"Bob".to_string()),
+        "#294: expected Bob in colleagues, got {:?}",
+        names
+    );
+}


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause**: `hop2_rel_ids` in `execute_two_hop` filtered rel tables with `src=mid_label, dst=fof_label`, but when the second hop is Incoming (`<-`), edges are stored as `(fof)-[:R]->(mid)` in the catalog — i.e., `src=fof_label, dst=mid_label`. The filter was backwards, yielding an empty rel-table set and zero query results.
- **Fix**: Swap the label filter when `second_hop_incoming` is true so `hop2_rel_ids` correctly matches `src=fof_label, dst=mid_label`.
- **Why existing tests passed**: The SPA-201 tests used the same label (`User`) for all three nodes, so `mid_label_id == fof_label_id` and swapping had no effect.

## Test plan

- [x] New regression test `reverse_arrow_294.rs` with two cross-label scenarios (Person→Movie←Person, Employee→Company←Employee) — both failed before fix, pass after
- [x] Existing `spa_201_csr_backward` tests (same-label patterns) still pass (5/5)
- [x] `cargo check -p sparrowdb` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix 2-hop reverse-arrow queries when the two labels are different

### What Changed
- Queries like `(a)-[:R]->(b)<-[:R]-(c)` now return matching rows when `b` and `c` have different labels
- Reverse-arrow patterns now use the correct label direction for the second hop instead of filtering out all matches
- Added regression tests for two cross-label cases: people and movies, and employees and companies

### Impact
`✅ Fewer empty results in reverse-arrow searches`
`✅ Correct matches for cross-label 2-hop queries`
`✅ Reduced risk of this query pattern breaking again`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query results for 2-hop traversal patterns with reverse arrows connecting nodes of different labels.
  * Improved handling of incoming relationship directions in multi-hop graph queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->