### PR TITLE
fix(storage): delete_node checks CSR edges after checkpoint (closes #304)

### DIFF
--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -3032,7 +3032,8 @@ impl WriteTx {
     /// SPA-125: Delete a node, with edge-attachment check.
     ///
     /// Returns [`Error::NodeHasEdges`] if the node is referenced by any edge
-    /// in the delta log.  On success, queues a `NodeDelete` WAL record and
+    /// in the delta log or checkpointed CSR files (SPA-304).  On success,
+    /// queues a `NodeDelete` WAL record and
     /// buffers the tombstone write; the on-disk tombstone is only applied when
     /// [`commit`] is called.
     ///
@@ -3050,11 +3051,34 @@ impl WriteTx {
             rel_ids_to_check.push(0u32);
         }
         for rel_id in rel_ids_to_check {
-            let delta = EdgeStore::open(&self.inner.path, RelTableId(rel_id))
-                .and_then(|s| s.read_delta())
-                .unwrap_or_default();
-            if delta.iter().any(|r| r.src == node_id || r.dst == node_id) {
-                return Err(Error::NodeHasEdges { node_id: node_id.0 });
+            let store = EdgeStore::open(&self.inner.path, RelTableId(rel_id));
+
+            // Check delta log (un-checkpointed edges).
+            if let Ok(ref s) = store {
+                let delta = s.read_delta().unwrap_or_default();
+                if delta.iter().any(|r| r.src == node_id || r.dst == node_id) {
+                    return Err(Error::NodeHasEdges { node_id: node_id.0 });
+                }
+            }
+
+            // SPA-304: Check CSR forward file — the node may be a *source* of
+            // checkpointed edges that are no longer in the delta log.
+            if let Ok(ref s) = store {
+                if let Ok(csr) = s.open_fwd() {
+                    if !csr.neighbors(node_id.0).is_empty() {
+                        return Err(Error::NodeHasEdges { node_id: node_id.0 });
+                    }
+                }
+            }
+
+            // SPA-304: Check CSR backward file — the node may be a *destination*
+            // of checkpointed edges.
+            if let Ok(ref s) = store {
+                if let Ok(csr) = s.open_bwd() {
+                    if !csr.predecessors(node_id.0).is_empty() {
+                        return Err(Error::NodeHasEdges { node_id: node_id.0 });
+                    }
+                }
             }
         }
 

--- a/crates/sparrowdb/tests/phase7_mutation.rs
+++ b/crates/sparrowdb/tests/phase7_mutation.rs
@@ -648,3 +648,64 @@ fn merge_node_idempotent_within_single_tx() {
 
     drop(dir);
 }
+
+// ── SPA-304: DELETE node after checkpoint must still detect CSR edges ─────────
+
+#[test]
+fn delete_node_blocked_by_csr_edges_after_checkpoint() {
+    let (dir, db) = make_db();
+
+    // Create two nodes with label_id=0 so packed IDs equal slot numbers.
+    let (src, dst);
+    {
+        let mut tx = db.begin_write().unwrap();
+        src = tx.create_node(0, &[(0u32, Value::Int64(1))]).unwrap();
+        dst = tx.create_node(0, &[(0u32, Value::Int64(2))]).unwrap();
+        tx.commit().unwrap();
+    }
+
+    // Create an edge src → dst and commit.
+    {
+        let mut tx = db.begin_write().unwrap();
+        tx.create_edge(src, dst, "KNOWS", HashMap::new())
+            .expect("create_edge");
+        tx.commit().unwrap();
+    }
+
+    // Checkpoint: folds the delta log into CSR base files and clears the delta.
+    db.checkpoint().expect("checkpoint");
+
+    // Verify delta log is now empty (the bug: only delta was checked before).
+    {
+        use sparrowdb_storage::edge_store::{EdgeStore, RelTableId};
+        let store = EdgeStore::open(dir.path(), RelTableId(0)).unwrap();
+        let records = store.read_delta().unwrap();
+        assert!(
+            records.is_empty(),
+            "delta log must be empty after checkpoint, got {} records",
+            records.len()
+        );
+    }
+
+    // Try to delete src — must STILL fail because CSR has the edge.
+    {
+        let mut tx = db.begin_write().unwrap();
+        let result = tx.delete_node(src);
+        assert!(
+            matches!(result, Err(Error::NodeHasEdges { .. })),
+            "expected NodeHasEdges for src (outgoing CSR edge), got {result:?}"
+        );
+    }
+
+    // Try to delete dst — must STILL fail because CSR backward has the edge.
+    {
+        let mut tx = db.begin_write().unwrap();
+        let result = tx.delete_node(dst);
+        assert!(
+            matches!(result, Err(Error::NodeHasEdges { .. })),
+            "expected NodeHasEdges for dst (incoming CSR edge), got {result:?}"
+        );
+    }
+
+    drop(dir);
+}


### PR DESCRIPTION
## **User description**
## Summary
- **Bug**: `delete_node` only checked delta logs for attached edges, missing edges checkpointed into CSR base files. After a checkpoint, nodes with flushed edges could be deleted, creating dangling references.
- **Fix**: Added CSR forward (`open_fwd`) and backward (`open_bwd`) neighbor scans for each rel_table in the `delete_node` guard.
- **Test**: New `delete_node_blocked_by_csr_edges_after_checkpoint` test creates nodes+edges, checkpoints (clearing delta), then verifies both src and dst deletion is blocked.

## Test plan
- [x] `cargo check -p sparrowdb` passes
- [x] New test fails without fix (confirmed `Ok(())` returned for src delete)
- [x] New test passes with fix
- [x] All existing `delete_node` tests pass (no regressions)
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Prevent deleting nodes that still have checkpointed edges**

### What Changed
- Deleting a node now also checks edges that were already checkpointed, not just edges still in the temporary log.
- This blocks deletion when the node is still linked as either the source or destination of an existing edge.
- Added a test that confirms deletion stays blocked after a checkpoint clears the temporary edge log.

### Impact
`✅ Fewer accidental node deletions`
`✅ Safer deletes after checkpointing`
`✅ Fewer broken edge references`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
