### PR TITLE
fix(cache): remove duplicate invalidate_prop_index calls (closes #312)

### DIFF
--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -494,17 +494,6 @@ impl GraphDb {
         })
     }
 
-    /// Invalidate the shared property-index cache (SPA-187).
-    ///
-    /// Called after every write-transaction commit so the next read query
-    /// re-populates from the updated column files on disk.
-    ///
-    /// SPA-286: also removes the persisted `prop_index.bin` file so that a
-    /// subsequent `open` does not load stale index data.
-    fn invalidate_prop_index(&self) {
-        self.inner.invalidate_prop_index();
-    }
-
     /// Persist the shared property-index cache to disk if new columns have
     /// been loaded since the last persist (SPA-286).
     ///
@@ -1141,7 +1130,6 @@ impl GraphDb {
         }
 
         tx.commit()?;
-        self.invalidate_prop_index();
         self.invalidate_catalog();
         Ok(QueryResult::empty(vec![]))
     }
@@ -1227,7 +1215,6 @@ impl GraphDb {
         let mut tx = self.begin_write()?;
         let node_id = tx.merge_node(&m.label, props.clone())?;
         tx.commit()?;
-        self.invalidate_prop_index();
         self.invalidate_catalog();
 
         // If the statement has a RETURN clause, project the merged node's properties.
@@ -1323,7 +1310,6 @@ impl GraphDb {
         let mut tx = self.begin_write()?;
         let node_id = tx.merge_node(&m.label, props.clone())?;
         tx.commit()?;
-        self.invalidate_prop_index();
         self.invalidate_catalog();
         if let Some(ref ret) = m.return_clause {
             use sparrowdb_cypher::ast::Expr;
@@ -1398,7 +1384,6 @@ impl GraphDb {
             }
             tx.commit()?;
             self.invalidate_csr_map();
-            self.invalidate_prop_index();
             self.invalidate_catalog();
             return Ok(QueryResult::empty(vec![]));
         }
@@ -1421,7 +1406,6 @@ impl GraphDb {
             }
         }
         tx.commit()?;
-        self.invalidate_prop_index();
         self.invalidate_catalog();
         Ok(QueryResult::empty(vec![]))
     }
@@ -1459,7 +1443,6 @@ impl GraphDb {
             }
             tx.commit()?;
             self.invalidate_csr_map();
-            self.invalidate_prop_index();
             self.invalidate_catalog();
             return Ok(QueryResult::empty(vec![]));
         }
@@ -1486,7 +1469,6 @@ impl GraphDb {
         }
 
         tx.commit()?;
-        self.invalidate_prop_index();
         self.invalidate_catalog();
         Ok(QueryResult::empty(vec![]))
     }
@@ -1740,7 +1722,6 @@ impl GraphDb {
         }
 
         tx.commit()?;
-        self.invalidate_prop_index();
         self.invalidate_catalog();
         Ok(QueryResult::empty(vec![]))
     }
@@ -1883,7 +1864,6 @@ impl GraphDb {
 
         // Single fsync commit — all mutations land in one WAL transaction.
         tx.commit()?;
-        self.invalidate_prop_index();
         self.invalidate_catalog();
 
         // Merge early (CHECKPOINT/OPTIMIZE) and mutation results in order.
@@ -2414,7 +2394,6 @@ impl GraphDb {
         let mut tx = self.begin_write()?;
         let result = tx.merge_node_by_property(label, match_key, match_value, properties)?;
         tx.commit()?;
-        self.invalidate_prop_index();
         self.invalidate_catalog();
         Ok(result)
     }
@@ -3477,11 +3456,9 @@ impl WriteTx {
 
         // Step 12: Invalidate the shared property-index cache (SPA-259).
         //
-        // GraphDb-level execute functions (execute_create_standalone, etc.)
-        // call invalidate_prop_index() again after this — the extra clear
-        // is harmless (just bumps the generation counter).  The critical
-        // case is when a caller uses WriteTx directly without going through
-        // a GraphDb::execute path, which previously left the cache stale.
+        // This is the single canonical invalidation point (#312).
+        // Callers using WriteTx directly (without GraphDb::execute) still
+        // get correct cache invalidation.
         self.inner.invalidate_prop_index();
 
         self.committed = true;


### PR DESCRIPTION
## **User description**
## Summary
- Removed 10 redundant `invalidate_prop_index()` calls from `execute_*` methods in `GraphDb`
- `WriteTx::commit()` already calls `invalidate_prop_index()` — it is the single canonical invalidation point
- Removed the now-dead `GraphDb::invalidate_prop_index()` wrapper method
- Updated the comment in `commit()` to reflect the consolidated ownership

## Context
Architecture audit §4.2.2 identified that `commit()` and each `execute_*` method both called `invalidate_prop_index`. The extra call was harmless (just bumps a generation counter) but meant cache invalidation was not owned in one place.

## Test plan
- [x] `cargo check -p sparrowdb` passes with zero warnings
- [x] `cargo fmt` applied
- [x] `cargo test -p sparrowdb` — all tests pass (one pre-existing flaky perf test fails on main too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep property-index refresh in one place after writes**

### What Changed
- Write operations now refresh the property index only once after commit
- Direct write-transaction callers still clear the cached property index, so later reads use current data
- Removed the extra post-commit refresh from graph write paths that already commit through the shared transaction flow

### Impact
`✅ Fewer stale property lookups after writes`
`✅ Consistent reads after direct transaction commits`
`✅ Less redundant cache refresh work during updates`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
