### PR TITLE
Add specification documents for HTTP/SSE transport, bulk CSV loader, and query features

### DIFF
--- a/specs/289-multi-label-nodes.md
+++ b/specs/289-multi-label-nodes.md
@@ -1,0 +1,168 @@
+# Spec: Multi-Label Nodes `(n:A:B)` — SPA-200
+
+**Issue:** #289
+**Status:** Draft
+**Date:** 2026-03-27
+
+## Problem
+
+SparrowDB enforces a single label per node. Standard openCypher supports multi-label nodes: `CREATE (n:Person:Employee {name: "Alice"})` assigns both `:Person` and `:Employee` to the same node, and `MATCH (n:Person)` must return that node even though it also carries `:Employee`.
+
+The parser already accepts `(n:A:B)` and populates `NodePattern.labels: Vec<String>`, but the engine silently drops all labels after the first.
+
+Current single-label constraints:
+
+| Layer | Constraint |
+|---|---|
+| **NodeId encoding** | `(label_id: u32) << 32 \| slot: u32` — label embedded in ID |
+| **Storage** | Column files under `nodes/{label_id}/` — one dir per label |
+| **Catalog** | `LabelId = u16`, simple name-to-id map |
+| **Execution** | `node.labels.first()` everywhere |
+| **Property index** | Keyed by `(label_id, col_id)` — assumes one label |
+
+## Design: Primary Label + Secondary Label Set
+
+Every node retains exactly **one primary label** (determines NodeId encoding and `nodes/{label_id}/` storage directory). Additional labels are tracked in a **label-set side table** that maps `NodeId -> Set<LabelId>`.
+
+### Storage: Fixed-Width Bitset Column (Phase 1)
+
+New file per primary label directory:
+
+```
+nodes/{primary_label_id}/secondary_labels.bin
+```
+
+A single `u64` per slot where each bit maps to a secondary label. Supports up to 64 total labels. Simple, cache-friendly, O(1) lookup.
+
+Overflow (variable-length list of LabelIds) can be added in Phase 2 behind a feature flag if >64 labels are needed.
+
+### Parser Changes
+
+**None required.** The parser already handles `(n:A:B:C)` correctly:
+
+```rust
+// parser.rs:1451-1456
+let mut labels = Vec::new();
+while matches!(self.peek(), Token::Colon) {
+    self.advance();
+    let label = self.expect_label_or_type()?;
+    labels.push(label);
+}
+```
+
+### Catalog Changes
+
+1. **No change to `LabelEntry` or `LabelId`** — each label name still maps to a unique `LabelId`.
+
+2. **New TLV entry type: `NodeLabelSet`** — persists secondary label assignments:
+   ```
+   Tag: 0x03 (new)
+   Fields: primary_label_id: u16, slot: u32, secondary_label_ids: Vec<u16>
+   ```
+   Appended to `catalog.tlv` on multi-label node creation or `SET n:NewLabel`.
+
+3. **In-memory indexes** loaded on catalog open:
+   - Forward: `HashMap<NodeId, HashSet<LabelId>>` — "which labels does this node have?"
+   - Reverse: `HashMap<LabelId, HashSet<NodeId>>` — "which nodes have this label?" Used by MATCH to find nodes by secondary label without full scans.
+
+### MATCH Semantics
+
+`MATCH (n:A)` must return all nodes whose label set contains `:A`, regardless of primary vs secondary.
+
+**Single-label query `MATCH (n:A)`:**
+1. Primary-label scan (existing path, no change).
+2. Reverse index lookup `secondary_label_index[A]`.
+3. Union both sets, deduplicate by NodeId.
+
+**Multi-label query `MATCH (n:A:B)`:**
+1. For each label, collect the set of NodeIds that have that label.
+2. Intersect all sets.
+3. Return the intersection.
+
+**Implementation in `scan.rs`:** Every call site that currently does `let label = node.labels.first()` must be updated to resolve all labels in the pattern and use intersection semantics.
+
+The `__labels__` metadata injected for `labels(n)` must return the full label set, not just the primary label.
+
+### CREATE Semantics
+
+`CREATE (n:Person:Employee {name: "Alice"})`:
+
+1. First label (`:Person`) = primary label — determines NodeId and storage.
+2. Subsequent labels (`:Employee`) = secondary labels.
+3. After `create_node(label_id, props)`:
+   - Write `NodeLabelSet` TLV entry to catalog.
+   - Update in-memory forward and reverse indexes.
+4. `labels()` returns `["Person", "Employee"]`.
+
+**Primary label selection:** Positional (first in syntax), matching Neo4j behavior.
+
+### MERGE Semantics
+
+`MERGE (n:Person:Employee {name: "Alice"})`:
+
+1. `parse_merge` must accept multiple labels (currently errors after first).
+2. Match phase: look up nodes with **all** specified labels plus matching properties.
+3. Create phase: if no match, create with all labels (same as CREATE above).
+
+### Property Index Impact
+
+Property index is keyed by `(label_id, col_id)`. A node `(:Person:Employee {name: "Alice"})` stores columns under primary `label_id` (Person).
+
+**Phase 1 limitation:** `CREATE INDEX ON :Employee(name)` will NOT automatically index nodes whose primary label is `:Person` but have `:Employee` as secondary. Document this. Phase 2 adds cross-label index support by scanning the reverse index during index builds.
+
+### `labels()` Function
+
+After this change, `labels(n)` returns the full ordered set: `[primary_label, secondary_1, secondary_2, ...]`. Primary label is always first.
+
+### WAL Integration
+
+New WAL op code for label-set writes. The WAL codec must learn to replay `NodeLabelSet` entries.
+
+### Migration
+
+**Zero migration required.** The design is purely additive:
+- Nodes with no secondary labels have no entry in the side table.
+- Existing queries work identically.
+- `catalog.tlv` is append-only; new entry types are ignored by older readers.
+
+## Risks & Open Questions
+
+| # | Item | Decision |
+|---|---|---|
+| 1 | Primary label immutability | Accept: primary label baked into NodeId, changing it breaks edge references. |
+| 2 | Label count limit (64 via bitset) | Sufficient for Phase 1. Add overflow if needed. |
+| 3 | Secondary-label index gap | Document limitation. Phase 2 follow-up. |
+| 4 | Edge storage | NodeId encoding unchanged — no edge migration. |
+| 5 | WAL replay | Needs new WAL op code. |
+| 6 | `REMOVE n:PrimaryLabel` | Error in Phase 1. |
+| 7 | `labels()` ordering | Insertion order (primary first). |
+| 8 | `WHERE n:A` label predicates | Out of scope — separate ticket. |
+
+## Phasing
+
+| Phase | Work | Size |
+|---|---|---|
+| **1a** | Catalog side table + in-memory indexes + CREATE multi-label | M |
+| **1b** | MATCH resolution (primary + secondary scan, intersection) | M |
+| **1c** | `labels()` function update + `__labels__` metadata | S |
+| **1d** | MERGE multi-label support | S |
+| **2** | Cross-label property indexes | M |
+| **3** | SET/REMOVE label mutations | L |
+
+**Overall: L (Large)**
+
+Recommended: Phase 1a+1b+1c+1d as a single PR (end-to-end feature), Phase 2 and 3 as follow-ups.
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `crates/sparrowdb-catalog/src/catalog.rs` | Label-set side table, reverse index, new TLV entry |
+| `crates/sparrowdb-catalog/src/tlv.rs` | New `NodeLabelSet` TLV tag (0x03) |
+| `crates/sparrowdb-storage/src/wal/codec.rs` | New WAL op for label-set writes |
+| `crates/sparrowdb-storage/src/wal/replay.rs` | Replay handler for label-set ops |
+| `crates/sparrowdb-execution/src/engine/scan.rs` | Multi-label MATCH resolution (~15 call sites) |
+| `crates/sparrowdb-execution/src/engine/hop.rs` | Multi-label hop traversal |
+| `crates/sparrowdb-execution/src/engine/mutation.rs` | CREATE + MERGE multi-label support |
+| `crates/sparrowdb-execution/src/engine/expr.rs` | `labels()` function update |
+| `crates/sparrowdb-cypher/src/parser.rs` | MERGE multi-label parsing (minor) |

--- a/specs/290-call-subqueries.md
+++ b/specs/290-call-subqueries.md
@@ -1,0 +1,209 @@
+# Spec: General `CALL { }` Subquery Support
+
+**Issue:** #290
+**Status:** Draft
+**Date:** 2026-03-27
+
+## Problem
+
+SparrowDB supports `CALL procedure(args) YIELD col` for built-in procedures and `EXISTS { pattern }` for existence predicates, but not general `CALL { ... }` subquery blocks that allow embedding arbitrary Cypher queries as composable building blocks.
+
+Users cannot write:
+
+```cypher
+-- Uncorrelated subquery
+MATCH (p:Person)
+CALL { MATCH (c:City) RETURN count(c) AS cityCount }
+RETURN p.name, cityCount
+
+-- Correlated subquery
+MATCH (p:Person)
+CALL { WITH p MATCH (p)-[:LIVES_IN]->(c:City) RETURN c.name AS city }
+RETURN p.name, city
+```
+
+## Current State
+
+| Feature | Status |
+|---------|--------|
+| `CALL db.schema()` | Works — `parse_call()` parses dotted procedure name + `(args)` + `YIELD` |
+| `EXISTS { pattern }` | Works — `parse_atom()` consumes `EXISTS { path_pattern }` |
+| `CALL { MATCH ... RETURN ... }` | Broken — parser expects `CALL` followed by dotted name, not `{` |
+| `CALL { WITH x ... }` | Broken — no correlated-subquery execution path |
+| `CALL { }` as pipeline stage | Missing — `PipelineStage` has no `CallSubquery` variant |
+
+**Root cause:** In `parser.rs:2257`, `parse_call()` unconditionally expects `CALL <dotted_ident>( args )`. When it encounters `CALL {`, the `{` fails `advance_as_prop_name()`.
+
+## Design
+
+### AST Changes
+
+```rust
+/// A general CALL { ... } subquery block.
+pub struct CallSubquery {
+    /// The inner query body (MATCH...RETURN, UNION, etc.)
+    pub body: Box<Statement>,
+    /// Variables imported from outer scope (empty = uncorrelated)
+    pub imports: Vec<String>,
+}
+```
+
+Extend `Statement` and `PipelineStage`:
+
+```rust
+pub enum Statement {
+    // ... existing ...
+    CallSubquery(CallSubquery),
+}
+
+pub enum PipelineStage {
+    // ... existing ...
+    CallSubquery(CallSubquery),
+}
+```
+
+### Parser Changes
+
+Modify `parse_call()` to branch on `{` vs dotted-ident:
+
+```
+parse_call():
+    consume CALL
+    if peek == '{':
+        return parse_call_subquery()
+    else:
+        ... existing procedure-call logic ...
+
+parse_call_subquery():
+    consume '{'
+    if peek == WITH:
+        parse imports (WITH x, y, z — bare variable names only)
+    parse inner statement (reuse parse_statement())
+    consume '}'
+    return Statement::CallSubquery(...)
+```
+
+**Key constraint:** The `WITH` at the top of a correlated subquery is NOT a regular WITH clause (no expressions, no WHERE, no ORDER BY). It is a variable import list. The parser must distinguish this from a regular WITH by checking for bare identifiers followed by a statement keyword.
+
+### Scoping Rules (per openCypher spec)
+
+**Uncorrelated** (`CALL { MATCH ... RETURN ... }`):
+- Inner query has NO access to outer variables.
+- Inner RETURN columns cross-producted with outer rows.
+- If inner returns 0 rows, outer row is eliminated.
+
+**Correlated** (`CALL { WITH x MATCH (x)-[...]->(y) RETURN y }`):
+- Only variables in the leading `WITH` are visible inside.
+- Inner query executes once per outer row with imported variables bound.
+- Inner RETURN columns appended to outer row.
+- 0 inner rows -> outer row eliminated. N inner rows -> outer row duplicated N times.
+
+**Column naming:**
+- Inner RETURN columns must not collide with outer columns (error at bind time).
+- Aliases in inner RETURN become the added column names.
+
+### Execution Model
+
+**Uncorrelated:**
+1. Execute inner query independently -> `Vec<HashMap<String, Value>>`
+2. Cross-product: for each outer row x each inner row, merge column maps.
+3. Inner returns 0 rows -> entire cross-product empty.
+
+**Correlated:**
+```
+for each outer_row in outer_rows:
+    bind imported variables from outer_row
+    execute inner query with those bindings -> inner_rows
+    for each inner_row in inner_rows:
+        emit merge(outer_row, inner_row)
+```
+
+Nested-loop join. For N outer rows, inner query executes N times.
+
+### Pipeline Integration
+
+In `execute_pipeline()`, handle `PipelineStage::CallSubquery`:
+
+```rust
+PipelineStage::CallSubquery(sub) => {
+    let mut next_rows = Vec::new();
+    if sub.imports.is_empty() {
+        // Uncorrelated: execute once, cross-product
+        let inner_result = self.execute_statement(&sub.body)?;
+        let inner_maps = result_to_maps(&inner_result);
+        for outer in &current_rows {
+            for inner in &inner_maps {
+                let mut merged = outer.clone();
+                merged.extend(inner.clone());
+                next_rows.push(merged);
+            }
+        }
+    } else {
+        // Correlated: execute per outer row
+        for outer in &current_rows {
+            let bindings = extract_imports(outer, &sub.imports);
+            let inner_result = self.execute_with_bindings(&sub.body, &bindings)?;
+            let inner_maps = result_to_maps(&inner_result);
+            for inner in inner_maps {
+                let mut merged = outer.clone();
+                merged.extend(inner);
+                next_rows.push(merged);
+            }
+        }
+    }
+    current_rows = next_rows;
+}
+```
+
+Main new infrastructure: `execute_with_bindings()` — run an inner statement with pre-bound variables by injecting bindings as a synthetic leading row set.
+
+### UNION Inside CALL
+
+```cypher
+CALL {
+    MATCH (p:Person) RETURN p.name AS name
+    UNION
+    MATCH (c:Company) RETURN c.name AS name
+}
+RETURN name
+```
+
+Already works at the AST level — `Statement::Union` can be the body of `CallSubquery`. No special handling needed.
+
+### Binder Changes
+
+`binder.rs` currently skips `Statement::Call(_)`. New validation needed:
+- Column-collision check between inner RETURN and outer scope.
+- For correlated subqueries: validate imported variable names exist in outer scope.
+
+## Phasing
+
+| Phase | Scope | Size |
+|---|---|---|
+| **1** | Uncorrelated subqueries: AST, parser branch, cross-product execution, binder collision check | M |
+| **2** | Correlated subqueries: import-WITH parsing, per-row execution, `execute_with_bindings()` | L |
+| **3** | Pipeline integration: `PipelineStage::CallSubquery`, mid-pipeline CALL { } | M |
+| **4** | UNION inside CALL: parser + execution validation | S |
+
+## Risks & Open Questions
+
+| # | Risk | Mitigation |
+|---|---|---|
+| 1 | Variable injection depth — scan functions don't accept pre-bound vars | Modify `scan_label_nodes` and `execute_pipeline_match_stage` to accept bindings |
+| 2 | Nested subqueries `CALL { CALL { ... } }` — stack overflow risk | Add max-depth limit (e.g., 8) |
+| 3 | Write clauses inside CALL — no nested transaction support | Reject with error in Phase 1-4; add as future enhancement |
+| 4 | Parser ambiguity: `CALL { WITH x ...` (import) vs `CALL { WITH x AS y ...` (projection) | Import-WITH has no expressions or aliases — just bare names followed by MATCH/RETURN/UNWIND |
+| 5 | 0-row uncorrelated: eliminate outer row or produce NULLs? | Eliminate (matches Neo4j behavior) |
+| 6 | `CALL { RETURN 42 AS x }` with no MATCH | Should work for free via `parse_standalone_return()` |
+| 7 | Correlated performance on large outer sets | Log warning if outer row count exceeds configurable threshold |
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `crates/sparrowdb-cypher/src/ast.rs` | `CallSubquery` struct, `Statement::CallSubquery`, `PipelineStage::CallSubquery` |
+| `crates/sparrowdb-cypher/src/parser.rs` | Branch in `parse_call()` on `{` vs dotted-ident; `parse_call_subquery()` |
+| `crates/sparrowdb-cypher/src/binder.rs` | Column-collision check, import variable validation |
+| `crates/sparrowdb-execution/src/engine/mod.rs` | `execute()` dispatch for `Statement::CallSubquery` |
+| `crates/sparrowdb-execution/src/engine/scan.rs` | `execute_pipeline()` stage for `CallSubquery`; `execute_with_bindings()` |
+| `crates/sparrowdb-execution/src/engine/expr.rs` | May need binding-aware expression evaluation |

--- a/specs/291-http-sse-transport.md
+++ b/specs/291-http-sse-transport.md
@@ -1,0 +1,310 @@
+# Spec: HTTP/SSE Transport Layer — SPA-231
+
+**Issue:** #291
+**Status:** Draft
+**Date:** 2026-03-27
+
+## Problem
+
+SparrowDB is embedded-only. All access requires in-process embedding (Rust, Python, Node.js, Ruby) or stdio piping (CLI serve mode, MCP server). There is no network protocol for remote access.
+
+This blocks:
+- Multi-client access to a shared database
+- Web application backends querying SparrowDB
+- Language-agnostic clients (Go, Java, etc.) without native bindings
+- Cloud/remote deployment scenarios
+
+## Current Transport State
+
+| Transport | Protocol | Use Case |
+|-----------|----------|----------|
+| In-process | Direct Rust API (`GraphDb::execute()`) | Embedding in Rust apps |
+| CLI serve | NDJSON over stdio | Inter-process communication |
+| MCP server | JSON-RPC 2.0 over stdio | AI assistant integration |
+| Python/Node/Ruby | FFI over in-process | Language bindings |
+
+**No TCP/HTTP endpoint exists.**
+
+## Design Decision: HTTP + SSE
+
+After evaluating three options, HTTP + SSE is recommended for Phase 1:
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| **HTTP + SSE** | Simple, standard, works with any HTTP client, streaming for large results | No bidirectional streaming | **Recommended** |
+| Bolt protocol (Neo4j compat) | Driver reuse | Complex binary protocol, licensing concerns, overkill for v1 | Deferred |
+| WebSocket | Bidirectional, low overhead | More complex client code, connection management | Phase 2 option |
+
+### Why HTTP + SSE
+
+1. **Zero client-side dependencies** — `curl` can query the database.
+2. **SSE for streaming** — large result sets stream row-by-row without buffering entire response.
+3. **Stateless** — each request opens a fresh read/write transaction. No session management.
+4. **Compatible with MCP HTTP transport** — the MCP spec defines an HTTP+SSE transport; this aligns.
+
+## API Design
+
+### Endpoints
+
+```
+POST /cypher                     Execute a Cypher query (JSON request/response)
+POST /cypher/stream              Execute a Cypher query (SSE streaming response)
+POST /batch                      Execute multiple queries in a single transaction
+GET  /health                     Health check
+GET  /info                       Database metadata (counts, labels, rel types)
+POST /checkpoint                 Trigger WAL checkpoint
+POST /optimize                   Trigger CSR optimization
+```
+
+### Authentication
+
+Phase 1: **Bearer token** (static shared secret).
+
+```
+Authorization: Bearer <token>
+```
+
+- Token set via `--auth-token <token>` CLI flag or `SPARROWDB_AUTH_TOKEN` env var.
+- If no token configured, server is **localhost-only** (binds `127.0.0.1`).
+- If token configured, server may bind `0.0.0.0` (configurable via `--bind`).
+- mTLS and OIDC deferred to Phase 2.
+
+### Query Endpoint: `POST /cypher`
+
+**Request:**
+```json
+{
+  "query": "MATCH (n:Person) RETURN n.name, n.age",
+  "params": {"name": "Alice"},
+  "timeout_ms": 5000
+}
+```
+
+- `query` (required): Cypher string.
+- `params` (optional): Named parameters for parameterized queries (maps to `execute_with_params`).
+- `timeout_ms` (optional): Query timeout in milliseconds (default: 30000).
+
+**Response (success):**
+```json
+{
+  "columns": ["n.name", "n.age"],
+  "rows": [
+    {"n.name": "Alice", "n.age": 30},
+    {"n.name": "Bob", "n.age": 25}
+  ],
+  "stats": {
+    "rows_returned": 2,
+    "elapsed_ms": 12
+  }
+}
+```
+
+**Response (error):**
+```json
+{
+  "error": {
+    "code": "SYNTAX_ERROR",
+    "message": "Unexpected token at line 1, column 7"
+  }
+}
+```
+
+**Error codes:**
+- `SYNTAX_ERROR` — Cypher parse failure
+- `EXECUTION_ERROR` — Runtime error (missing label, constraint violation, etc.)
+- `TIMEOUT` — Query exceeded `timeout_ms`
+- `WRITE_CONFLICT` — Another writer is active (SWMR)
+- `AUTH_FAILED` — Invalid or missing token
+
+**HTTP status mapping:**
+- 200: Success
+- 400: Syntax error or invalid request
+- 401: Auth failed
+- 408: Timeout
+- 409: Write conflict
+- 500: Internal error
+
+### Streaming Endpoint: `POST /cypher/stream`
+
+Same request format as `/cypher`. Response is `text/event-stream` (SSE):
+
+```
+Content-Type: text/event-stream
+
+event: columns
+data: {"columns": ["n.name", "n.age"]}
+
+event: row
+data: {"n.name": "Alice", "n.age": 30}
+
+event: row
+data: {"n.name": "Bob", "n.age": 25}
+
+event: complete
+data: {"rows_returned": 2, "elapsed_ms": 12}
+
+```
+
+**Error during streaming:**
+```
+event: error
+data: {"code": "EXECUTION_ERROR", "message": "..."}
+
+```
+
+SSE allows clients to process rows as they arrive, reducing memory pressure for large result sets. The server iterates `QueryResult.rows` and sends each as an SSE event.
+
+### Batch Endpoint: `POST /batch`
+
+**Request:**
+```json
+{
+  "queries": [
+    "CREATE (a:Person {name: 'Alice'})",
+    "CREATE (b:Person {name: 'Bob'})",
+    "CREATE (a)-[:KNOWS]->(b)"
+  ],
+  "timeout_ms": 10000
+}
+```
+
+**Response:**
+```json
+{
+  "results": [
+    {"columns": [], "rows": [], "stats": {"rows_returned": 0}},
+    {"columns": [], "rows": [], "stats": {"rows_returned": 0}},
+    {"columns": [], "rows": [], "stats": {"rows_returned": 0}}
+  ],
+  "stats": {
+    "elapsed_ms": 45
+  }
+}
+```
+
+Maps to `GraphDb::execute_batch()`. All queries execute in a single transaction — if any fails, the entire batch is rolled back.
+
+### Health Endpoint: `GET /health`
+
+```json
+{"status": "ok", "version": "0.1.12"}
+```
+
+### Info Endpoint: `GET /info`
+
+```json
+{
+  "node_count": 1500,
+  "edge_count": 4200,
+  "labels": ["Person", "City", "Company"],
+  "relationship_types": ["KNOWS", "LIVES_IN", "WORKS_AT"]
+}
+```
+
+Maps to `GraphDb::db_counts()`, `GraphDb::labels()`, `GraphDb::relationship_types()`.
+
+## Architecture
+
+### New Crate: `sparrowdb-server`
+
+```
+crates/sparrowdb-server/
+  Cargo.toml
+  src/
+    main.rs          — CLI entry point, arg parsing
+    server.rs        — HTTP server loop
+    handlers.rs      — Route handlers
+    auth.rs          — Token validation middleware
+    sse.rs           — SSE response formatting
+```
+
+**Dependencies:**
+- `tiny_http` (already in workspace) — synchronous HTTP server
+- `sparrowdb` — database engine
+- `serde_json` — JSON serialization
+- `sparrowdb-execution` — `QueryResult`, `value_to_json`, `query_result_to_json`
+
+### Threading Model
+
+`tiny_http` spawns a thread pool for handling requests. `GraphDb` is `Send + Sync` (Arc-wrapped), safe to share across handler threads.
+
+```
+main thread:
+    GraphDb::open(path)
+    tiny_http::Server::http(bind_addr)
+    loop:
+        request = server.recv()
+        thread_pool.execute(|| handle_request(db.clone(), request))
+
+handle_request:
+    match route:
+        POST /cypher        -> handle_cypher(db, request)
+        POST /cypher/stream -> handle_cypher_stream(db, request)
+        POST /batch         -> handle_batch(db, request)
+        GET  /health        -> handle_health(request)
+        GET  /info          -> handle_info(db, request)
+        POST /checkpoint    -> handle_checkpoint(db, request)
+        _                   -> 404
+```
+
+### Concurrency Semantics
+
+SparrowDB uses SWMR (Single-Writer Multiple-Reader):
+- Multiple simultaneous read queries: OK (each gets snapshot isolation).
+- Only one write transaction at a time: second writer gets `WRITE_CONFLICT` (409).
+- The HTTP layer does NOT serialize writes — it forwards the SWMR error to the client.
+
+### CLI Interface
+
+```bash
+# Start server
+sparrowdb serve --http --db /path/to/db --bind 127.0.0.1:7480
+
+# With auth
+sparrowdb serve --http --db /path/to/db --bind 0.0.0.0:7480 --auth-token mytoken
+
+# Default port: 7480 (S=7, P=8, A=0 — "SPA" for SparrowDB API)
+```
+
+### Value Serialization
+
+Reuse the existing `query_result_to_json()` and `value_to_json()` from `sparrowdb-execution/src/json.rs`:
+- `Int64` -> JSON number (if within +-2^53) or string
+- `NodeRef`/`EdgeRef` -> `{"$type": "node"|"edge", "id": "u64_string"}`
+- `List` -> JSON array
+- `Map` -> JSON object
+
+## Phasing
+
+| Phase | Scope | Size |
+|---|---|---|
+| **1** | `sparrowdb-server` crate, `/cypher` + `/health` + `/info` endpoints, bearer token auth, `tiny_http` | M |
+| **2** | SSE streaming (`/cypher/stream`), `/batch` endpoint, `/checkpoint` + `/optimize` | M |
+| **3** | WebSocket transport (bidirectional), connection keep-alive | L |
+| **4** | mTLS, OIDC/JWT auth, rate limiting | M |
+
+## Risks & Open Questions
+
+| # | Item | Decision |
+|---|---|---|
+| 1 | Sync vs async HTTP | Phase 1 uses `tiny_http` (sync). If throughput demands it, migrate to `axum`/`tokio` in Phase 3. |
+| 2 | Large result sets without streaming | `/cypher` buffers entire result. Clients concerned about memory should use `/cypher/stream`. |
+| 3 | Transaction sessions | Phase 1 is stateless (one tx per request). Multi-statement sessions (BEGIN/COMMIT over HTTP) deferred. |
+| 4 | CORS | Phase 1 adds permissive CORS headers for browser clients. |
+| 5 | Request body size limit | Default 10 MB. Configurable via `--max-request-size`. |
+| 6 | Default port | 7480. Configurable via `--bind`. |
+| 7 | HTTPS/TLS termination | Phase 1: rely on reverse proxy (nginx, caddy). Phase 4: native TLS option. |
+| 8 | Query cancellation | SSE connection close triggers query timeout. Phase 1 relies on `execute_with_timeout`. |
+| 9 | Bolt protocol compatibility | Deferred. Significant complexity for limited v1 benefit. |
+
+## Files to Create/Modify
+
+| File | Change |
+|---|---|
+| `crates/sparrowdb-server/Cargo.toml` | New crate with `tiny_http`, `sparrowdb`, `serde_json` deps |
+| `crates/sparrowdb-server/src/main.rs` | CLI arg parsing, server startup |
+| `crates/sparrowdb-server/src/server.rs` | HTTP server loop, routing |
+| `crates/sparrowdb-server/src/handlers.rs` | Request handlers for each endpoint |
+| `crates/sparrowdb-server/src/auth.rs` | Bearer token validation |
+| `crates/sparrowdb-server/src/sse.rs` | SSE response formatting |
+| `Cargo.toml` | Add `sparrowdb-server` to workspace members |

--- a/specs/292-publish-sparrowontology.md
+++ b/specs/292-publish-sparrowontology.md
@@ -1,0 +1,204 @@
+# Spec: Publish SparrowOntology to crates.io — SPA-226
+
+**Issue:** #292
+**Status:** Draft
+**Date:** 2026-03-27
+
+## Problem
+
+SparrowOntology is referenced throughout the codebase (MCP tools like `create_entity`, `add_property`; test fixtures using `OntologyClass` labels; `__SO_` reserved prefix) but does not yet exist as a standalone crate. It needs to be extracted, packaged, and published to crates.io so downstream users can depend on it independently.
+
+## Current State
+
+- **No `sparrowontology` crate exists** in the workspace. The 13 current workspace members do not include it.
+- The `__SO_` prefix is reserved in the codebase for ontology system objects (`__SO_Property`, `__SO_Class`).
+- MCP server tools (`create_entity`, `add_property`, `merge_node_by_property`) implement ontology-like operations inline.
+- The CI/CD release workflow (`.github/workflows/release.yml`) publishes npm bindings but has **no `cargo publish` step** for crates.io.
+- All crates use workspace-level version inheritance (`0.1.12`).
+
+## Scope
+
+This is primarily a packaging and CI task, not a feature implementation. The work is:
+
+1. **Extract** ontology logic into a new `sparrow-ontology` crate.
+2. **Verify** it compiles independently.
+3. **Add** `cargo publish` to the CI release workflow.
+4. **Publish** initial version.
+
+## Design
+
+### Crate Structure
+
+```
+crates/sparrow-ontology/
+  Cargo.toml
+  src/
+    lib.rs           — Public API: OntologyDb, init(), create_class(), etc.
+    schema.rs        — OntologyClass, OntologyProperty definitions
+    validation.rs    — Schema validation, constraint checking
+    error.rs         — OntologyError type
+```
+
+### Cargo.toml
+
+```toml
+[package]
+name = "sparrow-ontology"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Schema and ontology management layer for SparrowDB"
+categories = ["database", "data-structures"]
+keywords = ["graph-database", "ontology", "schema", "sparrowdb"]
+readme = "README.md"
+
+[dependencies]
+sparrowdb = { path = "../sparrowdb", version = "0.1.12" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+```
+
+**Key constraints for crates.io:**
+- `description` is required.
+- `license` or `license-file` is required (MIT — inherited from workspace).
+- All path dependencies must also be published, with matching version constraints.
+- `sparrowdb` itself must be published first (or simultaneously) since `sparrow-ontology` depends on it.
+
+### Public API Surface
+
+```rust
+pub struct OntologyDb {
+    db: GraphDb,
+}
+
+impl OntologyDb {
+    /// Wrap an existing GraphDb with ontology management.
+    pub fn new(db: GraphDb) -> Self;
+
+    /// Initialize ontology schema (creates __SO_ system nodes if missing).
+    pub fn init(&self) -> Result<()>;
+
+    /// Define a new ontology class (node label with schema).
+    pub fn create_class(&self, name: &str, properties: &[PropertyDef]) -> Result<()>;
+
+    /// Create an entity (node) validated against its class schema.
+    pub fn create_entity(&self, class: &str, props: HashMap<String, Value>) -> Result<NodeId>;
+
+    /// Add a property definition to an existing class.
+    pub fn add_property(&self, class: &str, prop: PropertyDef) -> Result<()>;
+
+    /// List all defined classes.
+    pub fn list_classes(&self) -> Result<Vec<String>>;
+
+    /// Get schema for a class.
+    pub fn get_class(&self, name: &str) -> Result<ClassSchema>;
+
+    /// Validate that all nodes of a class conform to its schema.
+    pub fn validate(&self, class: &str) -> Result<ValidationReport>;
+}
+
+pub struct PropertyDef {
+    pub name: String,
+    pub value_type: ValueType,    // String, Int64, Float64, Bool
+    pub required: bool,
+    pub unique: bool,
+}
+```
+
+### Independence Check
+
+The crate must compile with only its declared dependencies. Verify:
+
+```bash
+# From crates/sparrow-ontology/
+cargo check
+cargo test
+cargo package --allow-dirty  # Dry run — checks crates.io readiness
+```
+
+Ensure no workspace-only imports leak through (e.g., dev-dependencies on internal test utilities).
+
+### CI/CD: Add `cargo publish` to Release Workflow
+
+Modify `.github/workflows/release.yml` to add a crates.io publish job:
+
+```yaml
+  publish-crates:
+    runs-on: ubuntu-latest
+    needs: [create-release]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Publish sparrowdb-common
+        run: cargo publish -p sparrowdb-common --token ${{ secrets.CRATES_IO_TOKEN }}
+      - name: Publish sparrowdb-storage
+        run: cargo publish -p sparrowdb-storage --token ${{ secrets.CRATES_IO_TOKEN }}
+      - name: Publish sparrowdb-catalog
+        run: cargo publish -p sparrowdb-catalog --token ${{ secrets.CRATES_IO_TOKEN }}
+      - name: Publish sparrowdb-cypher
+        run: cargo publish -p sparrowdb-cypher --token ${{ secrets.CRATES_IO_TOKEN }}
+      - name: Publish sparrowdb-execution
+        run: cargo publish -p sparrowdb-execution --token ${{ secrets.CRATES_IO_TOKEN }}
+      - name: Publish sparrowdb
+        run: cargo publish -p sparrowdb --token ${{ secrets.CRATES_IO_TOKEN }}
+      - name: Publish sparrow-ontology
+        run: cargo publish -p sparrow-ontology --token ${{ secrets.CRATES_IO_TOKEN }}
+```
+
+**Publish order matters** — crates must be published in dependency order. Each `cargo publish` must wait for the previous crate to be indexed (~30s).
+
+**Prerequisite:** Add `CRATES_IO_TOKEN` secret to the GitHub repository settings.
+
+### Workspace Changes
+
+Add to root `Cargo.toml`:
+
+```toml
+[workspace]
+members = [
+    # ... existing 13 members ...
+    "crates/sparrow-ontology",
+]
+```
+
+## Blockers
+
+- **#289 (Multi-label nodes)** and **#290 (CALL subqueries)** should be stable first. The ontology layer may use multi-label semantics for class hierarchies. Rushing the publish before these stabilize risks breaking API changes.
+- **`sparrowdb` must be published to crates.io first** (or in the same release). Currently no `cargo publish` step exists for any crate.
+
+## Phasing
+
+| Phase | Scope | Size |
+|---|---|---|
+| **1** | Create crate skeleton, extract `__SO_` logic, basic `create_class`/`create_entity` API | M |
+| **2** | Schema validation, `PropertyDef` with type checking, `validate()` | S |
+| **3** | CI: add `cargo publish` for all workspace crates in dependency order | S |
+| **4** | Publish initial version (0.1.12 matching workspace) | S |
+
+**Overall: M (Medium)**
+
+## Risks & Open Questions
+
+| # | Item | Decision |
+|---|---|---|
+| 1 | Versioning: same as workspace or independent? | Same version (workspace inheritance) for v1. Independent versioning once API stabilizes. |
+| 2 | `sparrowdb` not yet on crates.io | Must publish `sparrowdb` (and its deps) first. This is the real blocker. |
+| 3 | API stability | Pre-1.0, so breaking changes are acceptable. Document with `#[doc(hidden)]` for unstable APIs. |
+| 4 | Crate name: `sparrow-ontology` vs `sparrowontology` | `sparrow-ontology` (hyphenated) is idiomatic Rust. |
+| 5 | Feature flags | Consider `default-features = false` for minimal builds; `full` feature for validation + schema introspection. |
+| 6 | `CRATES_IO_TOKEN` secret | Must be created by repo owner. |
+
+## Files to Create/Modify
+
+| File | Change |
+|---|---|
+| `crates/sparrow-ontology/Cargo.toml` | New crate |
+| `crates/sparrow-ontology/src/lib.rs` | Public API |
+| `crates/sparrow-ontology/src/schema.rs` | Class/property definitions |
+| `crates/sparrow-ontology/src/validation.rs` | Schema validation |
+| `crates/sparrow-ontology/src/error.rs` | Error types |
+| `crates/sparrow-ontology/README.md` | Crate documentation |
+| `Cargo.toml` | Add workspace member |
+| `.github/workflows/release.yml` | Add `cargo publish` jobs |

--- a/specs/296-bulk-csv-loader.md
+++ b/specs/296-bulk-csv-loader.md
@@ -1,0 +1,246 @@
+# Spec: Bulk CSV/Edge-List Loader
+
+**Issue:** #296
+**Status:** Draft
+**Date:** 2026-03-27
+
+## Problem
+
+SparrowDB's only ingestion path is individual Cypher CREATE statements, which tops out at ~76-333 edges/sec. Importing real-world datasets is impractical:
+
+| Dataset | Edges | Estimated Time |
+|---------|-------|----------------|
+| Facebook | 88K | ~5 min |
+| Pokec | 30.6M | **~5 days** |
+| LiveJournal | 69M | **~9 days** |
+| LDBC SF1 | 17M | **~3 days** |
+
+Neo4j's `neo4j-admin import` does Pokec in **30 seconds** (1M+ edges/sec). Target: 100K-1M+ edges/sec.
+
+## Current Import Path
+
+The CLI has a Neo4j APOC CSV importer (`sparrowdb import --neo4j-csv`):
+
+```
+crates/sparrowdb-cli/src/main.rs (lines 200-405)
+```
+
+**Why it's slow:**
+1. Each node/edge committed in a **separate transaction** (individual fsync).
+2. Properties parsed through the `WriteTx` API one-at-a-time.
+3. No batching of column writes or CSR construction.
+4. Edge delta log appended per-edge, then checkpointed separately.
+
+## Design: Direct Storage-Layer Bulk Loader
+
+Bypass `WriteTx` and Cypher entirely. Write directly to the storage layer files in a single pass.
+
+### API
+
+**Rust:**
+```rust
+use sparrowdb::bulk::{BulkLoader, BulkOptions, Format};
+
+let options = BulkOptions {
+    format: Format::Csv { delimiter: ',', has_header: true },
+    batch_size: 100_000,
+    skip_wal: true,          // No WAL for bulk load (db must be offline)
+    parallel_sort: true,     // Use Rayon for edge sorting
+};
+
+let loader = BulkLoader::new("/path/to/db", options)?;
+loader.load_nodes("nodes.csv")?;
+loader.load_edges("edges.csv")?;
+loader.finalize()?;           // Build CSR, write checkpoint, fsync
+```
+
+**CLI:**
+```bash
+# Generic CSV
+sparrowdb bulk-import --nodes nodes.csv --edges edges.csv --db /path/to/db
+
+# SNAP edge list (tab-separated src\tdst, no header)
+sparrowdb bulk-import --edges soc-pokec.txt --format snap --db /path/to/db
+
+# LDBC pipe-delimited
+sparrowdb bulk-import --nodes person.csv --edges knows.csv --format ldbc --db /path/to/db
+```
+
+**Node.js binding:**
+```javascript
+db.bulkImport({ nodes: "nodes.csv", edges: "edges.csv" });
+```
+
+### Input Formats
+
+**Generic CSV (default):**
+```
+_id,_label,name,age
+1,Person,Alice,30
+2,Person,Bob,25
+3,City,Seattle,
+```
+
+Nodes require `_id` (external ID) and `_label` columns. All other columns become properties.
+
+**Edge CSV:**
+```
+_start,_end,_type,weight
+1,2,KNOWS,0.9
+1,3,LIVES_IN,
+```
+
+Edges require `_start`, `_end` (referencing node `_id` values), and `_type` columns.
+
+**SNAP edge list:**
+```
+# Comment lines start with #
+0	1
+0	2
+1	3
+```
+
+Tab-separated `src_id\tdst_id`. No header. Nodes auto-created with a default label (configurable). No properties.
+
+**LDBC pipe-delimited:**
+```
+id|firstName|lastName|creationDate
+933|Mahinda|Perera|2010-02-14
+```
+
+Pipe `|` delimiter with header row. LDBC-specific column mappings.
+
+### Algorithm
+
+**Phase 1: Node ingestion**
+
+```
+1. Open CSV reader (streaming, not fully in memory)
+2. For each row:
+   a. Resolve label -> label_id (create in catalog if new)
+   b. Allocate slot = next HWM for that label
+   c. Compute NodeId = (label_id << 32) | slot
+   d. Map external _id -> NodeId in hash map
+   e. Buffer property values per (label_id, col_id)
+3. For each (label_id, col_id) buffer:
+   a. Write entire column file in one sequential write
+   b. Write null bitmap
+4. Update HWM files
+5. Flush catalog
+```
+
+**Key optimization:** Collect all property values for a column before writing. This turns N random writes into 1 sequential write per column file.
+
+**Phase 2: Edge ingestion**
+
+```
+1. Open edge CSV reader (streaming)
+2. For each row:
+   a. Resolve _start and _end via id_map -> (src_NodeId, dst_NodeId)
+   b. Resolve _type -> rel_table_id (create in catalog if new)
+   c. Append (src_slot, dst_slot) to per-rel-type edge buffer
+3. For each rel_table:
+   a. Sort edges by (src_slot, dst_slot) — parallel sort via Rayon
+   b. Deduplicate
+   c. Build CsrForward directly from sorted edges
+   d. Build CsrBackward (sort by dst, build offsets)
+   e. Write base.fwd.csr and base.bwd.csr atomically
+   f. Write empty delta.log (no delta needed — CSR is complete)
+4. Handle edge properties if present (write to edge_props.bin)
+```
+
+**Key optimization:** Skip the delta log entirely. Build the sorted CSR in memory from the complete edge set and write it once. This avoids the append-per-edge + checkpoint overhead.
+
+**Phase 3: Finalize**
+
+```
+1. Fsync all written files
+2. Write catalog.tlv with all new labels and rel types
+3. Write WAL checkpoint marker (so recovery knows the bulk load is committed)
+4. Fsync WAL
+```
+
+### Memory Management
+
+For large datasets that exceed available RAM:
+
+**Node properties:** Stream rows and write columns incrementally. Keep only the current batch in memory. Each batch writes its portion of the column file at the correct offset.
+
+**Edge sorting:** If edge count exceeds a threshold (e.g., 50M), use external sort:
+1. Read edges into chunks of `batch_size`.
+2. Sort each chunk in memory.
+3. Write sorted chunks to temp files.
+4. Merge-sort temp files into final CSR.
+
+**Id map:** The `HashMap<String, NodeId>` must fit in memory. For 100M nodes with 8-byte average ID strings, this is ~2.4 GB. Acceptable for datasets up to ~500M nodes on a 16 GB machine.
+
+### WAL Handling
+
+**Option A (recommended): Skip WAL for offline bulk load.**
+The database must be closed (no concurrent readers/writers). The bulk loader writes directly to storage files. On completion, it writes a single WAL checkpoint record as a commit marker.
+
+**Option B: WAL-backed bulk load.**
+Emit batched WAL records (e.g., 10K nodes per record). Slower but allows online loading with crash recovery. Deferred to Phase 2.
+
+### Error Handling
+
+- **Missing `_id` or `_label` column:** Fatal error before any writes.
+- **Duplicate `_id` values:** Last-write-wins (within same label) or error (configurable).
+- **Missing edge endpoints:** Skip edge with warning, or error (configurable).
+- **Malformed CSV row:** Skip with warning, or error (configurable via `--strict`).
+- **Crash during bulk load:** Database is in inconsistent state. Recovery: delete `nodes/` and `edges/` directories and re-run. WAL checkpoint marker is only written on success.
+
+### Progress Reporting
+
+```
+Loading nodes...  [████████████░░░░] 75%  750,000 / 1,000,000  (125K nodes/sec)
+Loading edges...  [██████░░░░░░░░░░] 37%  11.3M / 30.6M  (890K edges/sec)
+Building CSR...   [████████████████] 100% Forward + Backward
+Finalizing...     Done. 1,000,000 nodes, 30,600,000 edges in 42.3s
+```
+
+### Performance Targets
+
+| Operation | Target | Bottleneck |
+|-----------|--------|------------|
+| Node ingestion | 500K+ nodes/sec | Sequential column writes + CSV parsing |
+| Edge ingestion | 1M+ edges/sec | In-memory sort + sequential CSR write |
+| CSR build | O(E log E) | Parallel sort (Rayon) |
+| Total (Pokec 30.6M) | < 60 seconds | Edge sort dominates |
+
+## Phasing
+
+| Phase | Scope | Size |
+|---|---|---|
+| **1** | Core `BulkLoader` struct, generic CSV format, offline node + edge loading, direct CSR build | L |
+| **2** | SNAP and LDBC format support, edge properties, external sort for very large datasets | M |
+| **3** | CLI `bulk-import` command, progress reporting, Node.js/Python bindings | M |
+| **4** | Online bulk load (WAL-backed), concurrent reader support during import | L |
+
+**Overall: L (Large)**
+
+## Risks & Open Questions
+
+| # | Item | Decision |
+|---|---|---|
+| 1 | Offline-only requirement for Phase 1 | Accept. Document that db must be closed. Online loading in Phase 4. |
+| 2 | Memory for id_map on very large datasets | Accept up to ~500M nodes. Add disk-backed id map if needed. |
+| 3 | External sort complexity | Defer to Phase 2. Phase 1 assumes edges fit in memory. |
+| 4 | Multi-label nodes during bulk load | Defer until #289 is implemented. Phase 1 supports single-label only. |
+| 5 | Reuse existing `csv` crate (in workspace deps) vs hand-rolled parser | Use `csv` crate for robustness. Hand-rolled parser in current CLI has edge cases. |
+| 6 | Edge property storage format | Reuse existing `edge_props.bin` append format from `edge_store.rs`. |
+| 7 | Should `BulkLoader` be in `sparrowdb` or a new crate? | Put in `sparrowdb` crate (`src/bulk.rs`) — it needs direct access to `NodeStore`, `EdgeStore`, `Catalog`. |
+| 8 | Interaction with encryption | If db uses encryption, bulk loader must encrypt column/CSR files. Use same `XChaCha20-Poly1305` path. |
+
+## Files to Create/Modify
+
+| File | Change |
+|---|---|
+| `crates/sparrowdb/src/bulk.rs` | New: `BulkLoader`, `BulkOptions`, `Format`, core loading logic |
+| `crates/sparrowdb/src/lib.rs` | Export `bulk` module |
+| `crates/sparrowdb-cli/src/main.rs` | New `bulk-import` subcommand |
+| `crates/sparrowdb-storage/src/node_store.rs` | Add `write_column_batch()` for bulk column writes |
+| `crates/sparrowdb-storage/src/csr.rs` | Add `build_and_write()` that builds + writes CSR in one step |
+| `crates/sparrowdb-storage/src/edge_store.rs` | Add `write_csr_from_sorted()` for direct CSR creation |
+| `crates/sparrowdb-node/src/lib.rs` | Expose `bulkImport()` binding |
+| `crates/sparrowdb-python/src/lib.rs` | Expose `bulk_import()` binding |


### PR DESCRIPTION
## **User description**
## Summary

This PR adds four comprehensive specification documents that outline planned features and architectural decisions for SparrowDB:

1. **HTTP/SSE Transport Layer** (SPA-291) — Network protocol for remote database access
2. **Bulk CSV/Edge-List Loader** (SPA-296) — High-performance data ingestion
3. **General CALL Subquery Support** (SPA-290) — Composable query blocks
4. **Multi-Label Nodes** (SPA-289) — Support for nodes with multiple labels
5. **SparrowOntology Publication** (SPA-292) — Packaging and publishing the ontology layer

## Key Specifications

### HTTP/SSE Transport (specs/291-http-sse-transport.md)
- Introduces a new `sparrowdb-server` crate providing HTTP endpoints for remote database access
- Defines REST API with endpoints: `POST /cypher`, `POST /cypher/stream` (SSE), `POST /batch`, `GET /health`, `GET /info`
- Bearer token authentication for Phase 1, with localhost-only binding when unauthenticated
- Streaming response support via Server-Sent Events for large result sets
- Phased approach: core endpoints in Phase 1, batch operations and maintenance endpoints in Phase 2

### Bulk CSV Loader (specs/296-bulk-csv-loader.md)
- Direct storage-layer bulk loading to achieve 100K-1M+ edges/sec (vs. current ~76-333 edges/sec)
- Supports multiple input formats: generic CSV, SNAP edge lists, LDBC pipe-delimited
- Offline-only in Phase 1 (database must be closed); online loading deferred to Phase 4
- Optimizations: batched column writes, parallel edge sorting via Rayon, direct CSR construction
- New `BulkLoader` API in `sparrowdb` crate with CLI command `sparrowdb bulk-import`

### CALL Subquery Support (specs/290-call-subqueries.md)
- Enables general `CALL { ... }` subquery blocks for composable queries
- Supports both uncorrelated (`CALL { MATCH ... RETURN ... }`) and correlated (`CALL { WITH x MATCH ... }`) subqueries
- Cross-product semantics for uncorrelated; nested-loop join for correlated
- Parser changes to distinguish `CALL { }` from procedure calls; new `CallSubquery` AST node
- Phased: uncorrelated in Phase 1, correlated in Phase 2, pipeline integration in Phase 3

### Multi-Label Nodes (specs/289-multi-label-nodes.md)
- Extends single-label constraint to support `(n:Person:Employee)` syntax
- Primary label (first) determines NodeId encoding; secondary labels stored in side table
- Phase 1a-1d: catalog side table, MATCH resolution, `labels()` function, MERGE support
- Phase 2-3: cross-label indexes and label mutations
- Zero migration required; purely additive design

### SparrowOntology Publication (specs/292-publish-sparrowontology.md)
- Extracts ontology logic into standalone `sparrow-ontology` crate
- Adds `cargo publish` to CI/CD release workflow for crates.io publication
- Phased: crate extraction (Phase 1), schema validation (Phase 2), CI integration (Phase 3), initial publish (Phase 4)
- Depends on stabilization of #289 and #290 before publication

## Implementation Notes

- All specifications follow a consistent structure: problem statement, design rationale, API design, phasing, and risk assessment
- Specifications are marked as "Draft" status and reference GitHub issue numbers
- Each includes detailed file modification lists and phasing breakdowns for incremental implementation
- Architectural decisions are justified with trade-off analysis (e.g., HTTP+SSE vs. WebSocket vs. Bolt protocol)
- Backward compatibility and migration paths are considered throughout

## Next Steps

These specifications serve as design documents for implementation. Each feature will be implemented in phases as outlined, with corresponding PRs for code changes.

https://claude.ai/code/session_01QTpWC7ckfhxzBmLKo631r2


___

## **CodeAnt-AI Description**
**Add specification documents for multi-label nodes, subqueries, HTTP transport, bulk loading, and ontology publishing**

### What Changed
- Added detailed specs for multi-label nodes, including how queries, creation, and label lookup should work
- Added a spec for general `CALL { }` subqueries, covering both standalone and correlated use
- Added a spec for an HTTP/SSE server with query, health, info, batch, and streaming endpoints
- Added a spec for bulk CSV and edge-list import that loads data directly into storage for faster large dataset ingestion
- Added a spec for extracting SparrowOntology into a publishable crate and adding crates.io release steps

### Impact
`✅ Clearer feature scope for upcoming database releases`
`✅ Faster implementation planning for graph query and import features`
`✅ Lower risk of missed requirements during development`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
