### PR TITLE
fix(storage): PropertyIndex skips Int64(0) due to missing null-bitmap wiring (closes #325)

### DIFF
--- a/crates/sparrowdb-storage/src/node_store.rs
+++ b/crates/sparrowdb-storage/src/node_store.rs
@@ -1339,6 +1339,33 @@ impl NodeStore {
         Ok(out)
     }
 
+    /// Read the null-bitmap for `(label_id, col_id)` and return a `Vec<bool>`
+    /// where index `i` is `true` iff slot `i` has a real value (was explicitly
+    /// written, as opposed to zero-padded for alignment or never written).
+    ///
+    /// If no bitmap file exists (old data written before SPA-207), returns
+    /// `None` to signal backward-compat mode — callers should fall back to the
+    /// `raw != 0` sentinel in that case.
+    ///
+    /// Used by [`PropertyIndex::build_for`] and [`PropertyIndex::build`] to
+    /// correctly index slots whose value is `Int64(0)` (raw = 0), which is
+    /// otherwise indistinguishable from the absent sentinel without the bitmap.
+    pub fn read_null_bitmap_all(&self, label_id: u32, col_id: u32) -> Result<Option<Vec<bool>>> {
+        let path = self.null_bitmap_path(label_id, col_id);
+        if !path.exists() {
+            return Ok(None); // backward compat: no bitmap file
+        }
+        let bits = fs::read(&path).map_err(Error::Io)?;
+        // Each byte encodes 8 slots: bit i of byte j → slot (j*8 + i).
+        let mut out = Vec::with_capacity(bits.len() * 8);
+        for &byte in &bits {
+            for bit_idx in 0..8u32 {
+                out.push((byte >> bit_idx) & 1 == 1);
+            }
+        }
+        Ok(Some(out))
+    }
+
     /// Selective sorted-slot read — O(K) seeks instead of O(N) reads.
     ///
     /// For each column, opens the file once and reads only the `slots` needed,

--- a/crates/sparrowdb-storage/src/property_index.rs
+++ b/crates/sparrowdb-storage/src/property_index.rs
@@ -268,6 +268,12 @@ impl PropertyIndex {
             }
         };
 
+        // Read the null-bitmap sidecar (SPA-207) so that legitimately-stored
+        // Int64(0) values (raw == 0) are not mistaken for absent/zero-padded
+        // slots.  When no bitmap file exists (old data), fall back to the raw
+        // == 0 sentinel for backward compatibility.
+        let null_bitmap = store.read_null_bitmap_all(label_id, col_id).unwrap_or(None);
+
         // Build a fresh BTreeMap for this column (always a new key at this
         // point since we checked `self.loaded` above and returned early on
         // cache hit).  Insert as `Arc::new` so later clones of this
@@ -275,7 +281,14 @@ impl PropertyIndex {
         let mut btree: BTreeMap<u64, Vec<u32>> = BTreeMap::new();
         for (slot, raw) in raw_vals.into_iter().enumerate() {
             let slot = slot as u32;
-            if raw == ABSENT || tombstone_slots.contains(&slot) {
+            // Determine if this slot has a real value.  With a null bitmap,
+            // only slots marked present (bit set) are indexed.  Without one
+            // (backward compat), treat raw == 0 as absent.
+            let is_present = match &null_bitmap {
+                Some(bits) => bits.get(slot as usize).copied().unwrap_or(false),
+                None => raw != ABSENT,
+            };
+            if !is_present || tombstone_slots.contains(&slot) {
                 continue;
             }
             // Apply the same sort_key transform used by `build` and `lookup`
@@ -341,11 +354,22 @@ impl PropertyIndex {
                     }
                 };
 
+                // Read the null-bitmap sidecar (SPA-207) so that
+                // legitimately-stored Int64(0) values (raw == 0) are not
+                // mistaken for absent/zero-padded slots.  Fall back to raw ==
+                // 0 sentinel when no bitmap exists (backward compat).
+                let null_bitmap = store.read_null_bitmap_all(label_id, col_id).unwrap_or(None);
+
                 let mut btree: BTreeMap<u64, Vec<u32>> = BTreeMap::new();
                 for (slot, raw) in raw_vals.into_iter().enumerate() {
                     let slot = slot as u32;
+                    // Determine if this slot has a real value.
+                    let is_present = match &null_bitmap {
+                        Some(bits) => bits.get(slot as usize).copied().unwrap_or(false),
+                        None => raw != ABSENT,
+                    };
                     // Skip absent and tombstoned slots.
-                    if raw == ABSENT || tombstone_slots.contains(&slot) {
+                    if !is_present || tombstone_slots.contains(&slot) {
                         continue;
                     }
                     btree.entry(sort_key(raw)).or_default().push(slot);

--- a/crates/sparrowdb/tests/match_property_index.rs
+++ b/crates/sparrowdb/tests/match_property_index.rs
@@ -110,8 +110,8 @@ fn match_create_edge_oi_performance() {
     const N_NODES: i64 = 10_000;
     const N_EDGES: usize = 1_000;
 
-    // Insert N_NODES User nodes each with a unique uid (1-based to avoid the
-    // Int64(0) == ABSENT encoding sentinel that prevents uid=0 from being indexed).
+    // Insert N_NODES User nodes each with a unique uid (1-based; uid=0 is
+    // now also correctly indexed since SPA-325 fixed the null-bitmap wiring).
     for uid in 1..=N_NODES {
         db.execute(&format!("CREATE (:User {{uid: {uid}}})",))
             .unwrap();


### PR DESCRIPTION
## **User description**
## Summary

- `PropertyIndex::build_for` and `build` used `raw == 0` (the `ABSENT` sentinel) to skip unset column slots, but `Int64(0)` also encodes to raw value `0` — causing nodes with integer-zero properties to be silently excluded from all MATCH scans
- Added `NodeStore::read_null_bitmap_all` to read the full SPA-207 null-bitmap sidecar in one call, and wired it into both property index build paths
- Falls back to the old `raw != 0` sentinel when no bitmap file exists (backward compat with pre-SPA-207 data)

## Root cause trace

```
MATCH (a:Tiny {id:0}), (b:Tiny {id:1}) CREATE (a)-[:E]->(b)
  → PropertyIndex lookup for id=0 → raw=0 → treated as ABSENT → no match rows
  → execute_match_create: matched_rows.is_empty() → early return, no edge written
  → delta log empty → DegreeCache: no delta records for slot 0
  → top_degree_nodes("Tiny", 100)[0].1 == 0, expected 1
```

## Test plan

- [ ] `cargo test -p sparrowdb --test spa_168_degree_cache_wiring` — all 5 tests pass (previously 2 failed)
- [ ] `cargo check -p sparrowdb` — clean
- [ ] `cargo fmt -- --check` — clean
- [ ] `cargo test -p sparrowdb --test spa_272_degree_cache --test spa_272_q7_cypher_wiring` — all pass
- [ ] `cargo test -p sparrowdb --test match_property_index` — correctness tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Index property values of `0` correctly**

### What Changed
- Nodes with `0` values are now included in property lookup and `MATCH` scans, instead of being skipped as if the field were unset
- Existing data without the newer bitmap files still uses the old fallback behavior, so older stores keep working
- Tests and comments were updated to reflect that `uid: 0` is now indexed correctly

### Impact
`✅ MATCH finds nodes with id 0`
`✅ Fewer missing edges during create-through-match flows`
`✅ Correct degree counts for nodes with zero-valued properties`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed indexing of zero values in properties. Previously, properties containing the value zero were incorrectly treated as absent, preventing them from being indexed and found in searches. They are now correctly indexed while maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->