### PR TITLE
refactor(mcp): inline Cypher strings, remove builder fns (closes #311)

### DIFF
--- a/crates/sparrowdb-mcp/src/main.rs
+++ b/crates/sparrowdb-mcp/src/main.rs
@@ -257,8 +257,31 @@ fn handle_tool_call_inner(params: Option<Value>) -> Result<Value, String> {
             let set_prop = args["set_prop"].as_str().ok_or("Missing set_prop")?;
             let set_val = &args["set_val"];
 
-            let set_query =
-                build_add_property_query(label, match_prop, match_val, set_prop, set_val)?;
+            validate_cypher_identifier(label, "add_property: label")?;
+            validate_cypher_identifier(match_prop, "add_property: match_prop")?;
+            validate_cypher_identifier(set_prop, "add_property: set_prop")?;
+            let cypher_set_val = json_scalar_to_cypher(set_val).ok_or_else(|| match set_val {
+                Value::Null => {
+                    "add_property: set_val is null; use a concrete scalar value".to_string()
+                }
+                Value::Array(_) => {
+                    "add_property: set_val is an array; only scalar values are supported"
+                        .to_string()
+                }
+                Value::Object(_) => {
+                    "add_property: set_val is a nested object; only scalar values are supported"
+                        .to_string()
+                }
+                _ => "add_property: unsupported set_val type".to_string(),
+            })?;
+            let set_query = format!(
+                "MATCH (n:{label} {{{match_prop}: '{match_val_escaped}'}}) SET n.{set_prop} = {cypher_set_val}",
+                label = label,
+                match_prop = match_prop,
+                match_val_escaped = escape_cypher_string(match_val),
+                set_prop = set_prop,
+                cypher_set_val = cypher_set_val,
+            );
 
             let db = sparrowdb::GraphDb::open(std::path::Path::new(db_path)).map_err(|e| {
                 format!(
@@ -267,7 +290,12 @@ fn handle_tool_call_inner(params: Option<Value>) -> Result<Value, String> {
                 )
             })?;
 
-            let count_query = build_count_query(label, match_prop, match_val);
+            let count_query = format!(
+                "MATCH (n:{label} {{{match_prop}: '{match_val_escaped}'}}) RETURN count(n) AS cnt",
+                label = label,
+                match_prop = match_prop,
+                match_val_escaped = escape_cypher_string(match_val),
+            );
             let count_result = db.execute(&count_query).map_err(|e| {
                 format!(
                     "add_property: count query failed for label '{}': {}",
@@ -324,7 +352,26 @@ fn handle_tool_call_inner(params: Option<Value>) -> Result<Value, String> {
             let class_name = args["class_name"].as_str().ok_or("Missing class_name")?;
             let props = &args["properties"];
 
-            let query = build_create_query(class_name, props)?;
+            validate_cypher_identifier(class_name, "create_entity: class_name")?;
+            let mut prop_parts: Vec<String> = Vec::new();
+            if let Some(obj) = props.as_object() {
+                for (key, val) in obj {
+                    validate_cypher_identifier(key, "create_entity: property key")?;
+                    let cypher_val = json_scalar_to_cypher(val).ok_or_else(|| match val {
+                        Value::Null => format!("create_entity: property '{}' is null; use a concrete value", key),
+                        Value::Array(_) => format!("create_entity: property '{}' is an array; only scalar values are supported", key),
+                        Value::Object(_) => format!("create_entity: property '{}' is a nested object; only scalar values are supported", key),
+                        _ => format!("create_entity: unsupported value for property '{}'", key),
+                    })?;
+                    prop_parts.push(format!("{}: {}", key, cypher_val));
+                }
+            }
+            let props_clause = if prop_parts.is_empty() {
+                String::new()
+            } else {
+                format!(" {{{}}}", prop_parts.join(", "))
+            };
+            let query = format!("CREATE (n:{}{})", class_name, props_clause);
 
             let db = sparrowdb::GraphDb::open(std::path::Path::new(db_path)).map_err(|e| {
                 format!(
@@ -499,78 +546,6 @@ fn json_scalar_to_cypher(v: &Value) -> Option<String> {
     }
 }
 
-/// Build a Cypher CREATE query from a class name and a JSON properties object.
-fn build_create_query(class_name: &str, props: &Value) -> Result<String, String> {
-    validate_cypher_identifier(class_name, "create_entity: class_name")?;
-
-    let mut prop_parts: Vec<String> = Vec::new();
-
-    if let Some(obj) = props.as_object() {
-        for (key, val) in obj {
-            validate_cypher_identifier(key, "create_entity: property key")?;
-            let cypher_val = json_scalar_to_cypher(val).ok_or_else(|| match val {
-                Value::Null => format!("create_entity: property '{}' is null; use a concrete value", key),
-                Value::Array(_) => format!("create_entity: property '{}' is an array; only scalar values are supported", key),
-                Value::Object(_) => format!("create_entity: property '{}' is a nested object; only scalar values are supported", key),
-                _ => format!("create_entity: unsupported value for property '{}'", key),
-            })?;
-            prop_parts.push(format!("{}: {}", key, cypher_val));
-        }
-    }
-
-    let props_clause = if prop_parts.is_empty() {
-        String::new()
-    } else {
-        format!(" {{{}}}", prop_parts.join(", "))
-    };
-
-    Ok(format!("CREATE (n:{}{})", class_name, props_clause))
-}
-
-/// Build a Cypher MATCH … SET query for the add_property tool.
-fn build_add_property_query(
-    label: &str,
-    match_prop: &str,
-    match_val: &str,
-    set_prop: &str,
-    set_val: &Value,
-) -> Result<String, String> {
-    validate_cypher_identifier(label, "add_property: label")?;
-    validate_cypher_identifier(match_prop, "add_property: match_prop")?;
-    validate_cypher_identifier(set_prop, "add_property: set_prop")?;
-
-    let cypher_set_val = json_scalar_to_cypher(set_val).ok_or_else(|| match set_val {
-        Value::Null => "add_property: set_val is null; use a concrete scalar value".to_string(),
-        Value::Array(_) => {
-            "add_property: set_val is an array; only scalar values are supported".to_string()
-        }
-        Value::Object(_) => {
-            "add_property: set_val is a nested object; only scalar values are supported".to_string()
-        }
-        _ => "add_property: unsupported set_val type".to_string(),
-    })?;
-
-    Ok(format!(
-        "MATCH (n:{label} {{{match_prop}: '{match_val_escaped}'}}) SET n.{set_prop} = {cypher_set_val}",
-        label = label,
-        match_prop = match_prop,
-        match_val_escaped = escape_cypher_string(match_val),
-        set_prop = set_prop,
-        cypher_set_val = cypher_set_val,
-    ))
-}
-
-/// Build a Cypher MATCH count query to check how many nodes match.
-/// Callers must have already validated `label` and `match_prop` as safe identifiers.
-fn build_count_query(label: &str, match_prop: &str, match_val: &str) -> String {
-    format!(
-        "MATCH (n:{label} {{{match_prop}: '{match_val_escaped}'}}) RETURN count(n) AS cnt",
-        label = label,
-        match_prop = match_prop,
-        match_val_escaped = escape_cypher_string(match_val),
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -602,15 +577,6 @@ mod tests {
         let result = handle_tool_call(None);
         assert!(result["isError"].as_bool().unwrap_or(false));
         assert!(result["content"].is_array());
-    }
-
-    #[test]
-    fn test_build_create_query_basic() {
-        let props = serde_json::json!({"name": "Alice", "age": 30});
-        let q = build_create_query("Person", &props).unwrap();
-        assert!(q.starts_with("CREATE (n:Person {"));
-        assert!(q.contains("name: 'Alice'"));
-        assert!(q.contains("age: 30"));
     }
 
     #[test]


### PR DESCRIPTION
## **User description**
## Summary

- Deleted `build_create_query`, `build_add_property_query`, and `build_count_query` — three private helpers that produced raw Cypher strings outside the parser/AST path (the divergence risk flagged in issue #311 / architecture audit §4.2.1)
- Inlined the same Cypher string construction directly in the `create_entity` and `add_property` match arms inside `handle_tool_call_inner`
- All security-critical sanitization (`validate_cypher_identifier`, `escape_cypher_string`, `json_scalar_to_cypher`) is retained and called at the now-single call sites
- Removed the unit test that targeted the deleted `build_create_query` function; `test_json_scalar_to_cypher` and other tests are unaffected

## Test plan

- [ ] `cargo check -p sparrowdb-mcp` passes (verified locally)
- [ ] `cargo fmt -p sparrowdb-mcp` produces no changes (verified locally)
- [ ] Confirm `create_entity` and `add_property` MCP tool paths compile and produce identical Cypher strings to the previous builder output
- [ ] Run existing MCP integration tests if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep Cypher query building in the main tool path**

### What Changed
- Create-entity and add-property actions now build their queries directly where they run, instead of relying on removed helper paths.
- Property names and labels are still checked before use, and only simple values can be written into the graph.
- Add-property still checks how many nodes match before updating them, using the same escaped match value.

### Impact
`✅ Fewer query path mismatches`
`✅ Safer graph updates from invalid input`
`✅ Clearer failures for unsupported property values`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for invalid property values when creating or modifying database entities, providing clearer feedback for unsupported data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->