### PR TITLE
perf(export): drop String from dedup key — O(1) per entry instead of O(len) alloc (closes #314)

### DIFF
--- a/crates/sparrowdb/src/export.rs
+++ b/crates/sparrowdb/src/export.rs
@@ -194,20 +194,22 @@ impl GraphDb {
         let path = &self.inner.path;
         let rel_tables = catalog.list_rel_tables_with_ids();
         let mut edges: Vec<EdgeDump> = Vec::new();
-        // Deduplicate: delta log edges may also appear in CSR after checkpoint.
-        let mut seen: std::collections::HashSet<(u64, u64, String)> =
-            std::collections::HashSet::new();
 
         for (catalog_id, src_label_id, dst_label_id, rel_type) in &rel_tables {
             let storage_rel_id = sparrowdb_storage::edge_store::RelTableId(*catalog_id as u32);
 
             if let Ok(store) = sparrowdb_storage::edge_store::EdgeStore::open(path, storage_rel_id)
             {
+                // Deduplicate within this rel_type: delta log edges may also
+                // appear in CSR after checkpoint.  Keying on (src, dst) is
+                // sufficient because rel_type is constant for this iteration.
+                let mut seen: std::collections::HashSet<(u64, u64)> =
+                    std::collections::HashSet::new();
+
                 // Delta log — stores full NodeId pairs (label_id << 32 | slot).
                 if let Ok(records) = store.read_delta() {
                     for rec in records {
-                        let key = (rec.src.0, rec.dst.0, rel_type.clone());
-                        if seen.insert(key) {
+                        if seen.insert((rec.src.0, rec.dst.0)) {
                             edges.push(EdgeDump {
                                 src_id: rec.src.0,
                                 dst_id: rec.dst.0,
@@ -225,8 +227,7 @@ impl GraphDb {
                         let src_id = (*src_label_id as u64) << 32 | src_slot;
                         for &dst_slot in csr.neighbors(src_slot) {
                             let dst_id = (*dst_label_id as u64) << 32 | dst_slot;
-                            let key = (src_id, dst_id, rel_type.clone());
-                            if seen.insert(key) {
+                            if seen.insert((src_id, dst_id)) {
                                 edges.push(EdgeDump {
                                     src_id,
                                     dst_id,

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -2530,10 +2530,20 @@ impl GraphDb {
 
             if let Ok(store) = sparrowdb_storage::edge_store::EdgeStore::open(path, storage_rel_id)
             {
+                // Deduplicate within this rel_type: delta log edges may also
+                // appear in CSR after checkpoint.  Keying on (src, dst) is
+                // sufficient because rel_type is constant for this iteration.
+                let mut seen: std::collections::HashSet<(i64, i64)> =
+                    std::collections::HashSet::new();
+
                 // Delta log: stores full NodeId pairs directly.
                 if let Ok(records) = store.read_delta() {
                     for rec in records {
-                        edge_triples.push((rec.src.0 as i64, rel_type.clone(), rec.dst.0 as i64));
+                        let src = rec.src.0 as i64;
+                        let dst = rec.dst.0 as i64;
+                        if seen.insert((src, dst)) {
+                            edge_triples.push((src, rel_type.clone(), dst));
+                        }
                     }
                 }
 
@@ -2544,7 +2554,9 @@ impl GraphDb {
                         let src_id = ((*src_label_id as u64) << 32 | src_slot) as i64;
                         for &dst_slot in csr.neighbors(src_slot) {
                             let dst_id = ((*dst_label_id as u64) << 32 | dst_slot) as i64;
-                            edge_triples.push((src_id, rel_type.clone(), dst_id));
+                            if seen.insert((src_id, dst_id)) {
+                                edge_triples.push((src_id, rel_type.clone(), dst_id));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## **User description**
## Summary

- In `export.rs` `GraphDb::export`: replaced the single `HashSet<(u64, u64, String)>` allocated before the loop with a `HashSet<(u64, u64)>` scoped *inside* each `rel_table` iteration. Since `rel_type` is constant within one iteration it was redundant in the key — removing it eliminates a heap-allocated `String` clone per dedup entry, cutting per-entry memory roughly in half and avoiding a String heap allocation on every `seen.insert()`.
- In `lib.rs` `GraphDb::export_dot`: added the same per-rel_table `HashSet<(i64, i64)>` dedup that was entirely missing — delta-log edges could appear twice after a checkpoint, producing duplicate DOT arrows.

## Memory impact

Before: one `HashSet<(u64, u64, String)>` across all rel-types — on a 500K-edge graph with a 10-char rel_type name this is ~500K × (16 + 24) = ~20 MB, allocated before the first byte is written.

After: one small `HashSet<(u64, u64)>` per rel-type, freed when the type's block exits. Peak footprint equals the edge count for the *largest single rel-type*, not the whole graph.

## Test plan

- [x] `cargo check -p sparrowdb` — clean
- [x] `cargo test -p sparrowdb` — all existing export/visualizer/import tests pass; 2 pre-existing failures in `spa_168_degree_cache_wiring` (tracked in #325) are unaffected by this change
- [x] `cargo fmt -p sparrowdb` — no formatting changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Avoid duplicate edges in exports and reduce export memory use**

### What Changed
- Exported graph edges are now deduplicated within each relationship type, so the same edge no longer appears twice when it exists in both the delta log and checkpointed data.
- Export now tracks fewer details while checking for duplicates, which lowers memory use during large exports.
- DOT graph output now also removes duplicate edges, preventing repeated arrows in visualizations.

### Impact
`✅ Fewer duplicate edges in exports`
`✅ Cleaner graph visualizations`
`✅ Lower memory during large exports`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
