### PR TITLE
fix(test): update wal_node_update_round_trip for typed WAL encoding

### DIFF
--- a/crates/sparrowdb/tests/phase7_mutation.rs
+++ b/crates/sparrowdb/tests/phase7_mutation.rs
@@ -348,8 +348,8 @@ fn wal_node_update_round_trip() {
                     if rec.kind == WalRecordKind::NodeUpdate {
                         if let WalPayload::NodeUpdate { key, after, .. } = &rec.payload {
                             if key == "score" {
-                                let after_val =
-                                    i64::from_le_bytes(after.as_slice().try_into().unwrap());
+                                assert_eq!(after[0], 0x01, "expected WAL_TAG_INT64");
+                                let after_val = i64::from_le_bytes(after[1..9].try_into().unwrap());
                                 assert_eq!(after_val, 88i64);
                                 found = true;
                             }


### PR DESCRIPTION
## Summary

- The test was written before commit 87b6561 introduced a 1-byte type tag prefix in WAL value encoding
- `after[0]` is now the tag byte (`WAL_TAG_INT64 = 0x01`); the i64 payload is at `after[1..9]`
- Fixes the pre-existing `wal_node_update_round_trip` failure by slicing correctly and adding a tag assertion

## Test plan

- [ ] `cargo test -p sparrowdb --test phase7_mutation wal_node_update_round_trip` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved write-ahead log node update test validation to ensure proper payload structure interpretation and enhance storage reliability verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->