### PR TITLE
perf(engine): flat bitvector visited-set + HashSet::with_capacity for SlotIntersect (closes #350)

### DIFF
--- a/crates/sparrowdb-execution/src/engine/pipeline_exec.rs
+++ b/crates/sparrowdb-execution/src/engine/pipeline_exec.rs
@@ -1187,6 +1187,7 @@ impl Engine {
             })?;
 
         let hwm_src = self.snapshot.store.hwm_for_label(src_label_id).unwrap_or(0);
+        let hwm_dst = self.snapshot.store.hwm_for_label(dst_label_id).unwrap_or(0);
         tracing::debug!(
             engine = "chunked",
             src_label = %src_label,
@@ -1194,6 +1195,7 @@ impl Engine {
             dst_label = %dst_label,
             rel_type = %rel_type,
             hwm_src,
+            hwm_dst,
             "executing via chunked pipeline (2-hop)"
         );
 
@@ -1297,7 +1299,7 @@ impl Engine {
         // O(1) visited-set membership testing — no per-chunk HashSet allocation.
         // arena.clear() only zeroes modified bitvector words (O(dirty)), not
         // the full pre-allocated bitvector.
-        let node_capacity = (hwm_src as usize).max(64);
+        let node_capacity = (hwm_src.max(hwm_dst) as usize).max(64);
         let mut frontier = BfsArena::new(
             avg_degree_hint * (crate::chunk::CHUNK_CAPACITY / 2),
             node_capacity,

--- a/crates/sparrowdb-execution/src/pipeline.rs
+++ b/crates/sparrowdb-execution/src/pipeline.rs
@@ -816,6 +816,8 @@ impl BfsArena {
         let bit = 1u64 << (slot % 64);
         if word_idx >= self.visited_bits.len() {
             // Slot out of pre-allocated range — grow to fit.
+            // resize fills with 0u64 — new words will be tracked by the
+            // `*word == 0` dirty-list guard below on their first bit-set.
             self.visited_bits.resize(word_idx + 1, 0);
         }
         let word = &mut self.visited_bits[word_idx];
@@ -838,13 +840,16 @@ impl BfsArena {
         self.visited_bits[word_idx] & (1u64 << (slot % 64)) != 0
     }
 
-    /// Byte footprint of live frontier entries.
+    /// Byte footprint of live frontier entries plus the visited bitvector.
     ///
-    /// Only counts entries in the live frontier vecs — pre-allocated capacity
-    /// and the visited bitvector are fixed overhead, not per-query allocation.
+    /// Counts both the live frontier vecs and the pre-allocated bitvector so
+    /// that QueryMemoryExceeded fires correctly on large graphs.
     /// This is O(1) with no container iteration.
     pub fn bytes_used(&self) -> usize {
-        (self.buf_a.len() + self.buf_b.len()) * std::mem::size_of::<u64>()
+        let frontier_bytes = (self.buf_a.len() + self.buf_b.len()) * std::mem::size_of::<u64>();
+        // Include pre-allocated bitvector so QueryMemoryExceeded fires on large graphs
+        let bitmap_bytes = self.visited_bits.len() * std::mem::size_of::<u64>();
+        frontier_bytes + bitmap_bytes
     }
 }
 


### PR DESCRIPTION
## Summary

- **BfsArena**: replaced `roaring::RoaringBitmap` with a flat `Vec<u64>` bitvector. For sparse graphs (e.g. Facebook 4,039 nodes), RoaringBitmap used array containers with O(log n) binary search per insert/contains — never reaching the bitset threshold. The new flat bitvector gives O(1) bit-test/set. `clear()` uses a `visited_dirty` word index list so only modified words are zeroed (O(dirty words), not O(node_capacity)).
- **SlotIntersect**: replaced `roaring::RoaringBitmap` build side with `HashSet::with_capacity()` seeded from `cardinality_hint()`. Removes the `u32` cast, eliminates `serialized_size()` from the hot-path memory check.
- **`BfsArena::new()`** gains a `node_capacity` parameter; call site in `pipeline_exec.rs` passes `hwm_src` as the bound.
- `roaring` dependency retained in `Cargo.toml` — still used by `join.rs`.

## Test plan

- [x] `cargo check -p sparrowdb-execution` — clean
- [x] `cargo test -p sparrowdb-execution` — 10/10 pass + 3 integration tests pass
- [x] `cargo fmt --all` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized BFS dedup arena initialization for better memory efficiency.
  * Enhanced visited-set tracking using a more efficient data structure to reduce memory overhead.
  * Improved query execution performance through refined intersection operation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->