### PR TITLE
fix(engine): id(n) in RETURN returns correct node ID (closes #372)

### DIFF
--- a/crates/sparrowdb-execution/src/engine/hop.rs
+++ b/crates/sparrowdb-execution/src/engine/hop.rs
@@ -77,10 +77,11 @@ impl Engine {
             .map(|(catalog_id, sid, did, rt)| (catalog_id, sid as u32, did as u32, rt))
             .collect();
 
-        // use_agg is true for aggregations OR for id(n)/NodeRef-dependent RETURN
-        // items (#372): the raw-rows + aggregate_rows_graph path correctly injects
-        // NodeRef into the row map, whereas project_hop_row does not handle id().
-        let use_agg = has_aggregate_in_return(&m.return_clause.items)
+        // use_raw_rows_path is true for aggregations OR for id(n)/NodeRef-dependent
+        // RETURN items (#372): the raw-rows + aggregate_rows_graph path correctly
+        // injects NodeRef into the row map, whereas project_hop_row does not handle
+        // id().
+        let use_raw_rows_path = has_aggregate_in_return(&m.return_clause.items)
             || needs_node_ref_in_return(&m.return_clause.items);
         let mut raw_rows: Vec<HashMap<String, Value>> = Vec::new();
         let mut rows: Vec<Vec<Value>> = Vec::new();
@@ -147,7 +148,7 @@ impl Engine {
                 &dst_node_pat.var,
                 &m.return_clause.items,
             );
-            if use_agg {
+            if use_raw_rows_path {
                 for item in &m.return_clause.items {
                     collect_col_ids_from_expr(&item.expr, &mut col_ids_src);
                     collect_col_ids_from_expr(&item.expr, &mut col_ids_dst);
@@ -409,7 +410,7 @@ impl Engine {
                         }
                     }
 
-                    if use_agg {
+                    if use_raw_rows_path {
                         let mut row_vals = build_row_vals(
                             &src_props,
                             &src_node_pat.var,
@@ -555,7 +556,7 @@ impl Engine {
                     &dst_node_pat.var,
                     &m.return_clause.items,
                 );
-                if use_agg {
+                if use_raw_rows_path {
                     for item in &m.return_clause.items {
                         collect_col_ids_from_expr(&item.expr, &mut col_ids_src);
                         collect_col_ids_from_expr(&item.expr, &mut col_ids_dst);
@@ -708,7 +709,7 @@ impl Engine {
                             }
                         }
 
-                        if use_agg {
+                        if use_raw_rows_path {
                             let mut row_vals = build_row_vals(
                                 &b_props,
                                 &src_node_pat.var,
@@ -794,7 +795,7 @@ impl Engine {
             }
         }
 
-        if use_agg {
+        if use_raw_rows_path {
             rows = self.aggregate_rows_graph(&raw_rows, &m.return_clause.items);
         } else {
             // DISTINCT

--- a/crates/sparrowdb-execution/src/engine/pipeline_exec.rs
+++ b/crates/sparrowdb-execution/src/engine/pipeline_exec.rs
@@ -112,12 +112,8 @@ impl Engine {
         {
             return false;
         }
-        // id(n) and other NodeRef-dependent functions require the row engine eval
-        // path (which injects Value::NodeRef into the row map).  The chunked path
-        // uses project_row which matches by column-name string; when an AS alias
-        // is present the column name is the alias (not "id(n)"), so project_row
-        // returns Null.  Fall back to the row engine for all such queries (#372).
-        if needs_node_ref_in_return(&m.return_clause.items) {
+        // id(n) and other NodeRef-dependent functions require the row engine (#372).
+        if return_requires_row_engine(&m.return_clause.items) {
             return false;
         }
         !m.pattern[0].nodes[0].labels.is_empty()
@@ -206,9 +202,8 @@ impl Engine {
         if pat.nodes.iter().any(|n| !n.props.is_empty()) {
             return false;
         }
-        // id(n) and other NodeRef-dependent functions are not supported by the
-        // chunked one-hop path (project_hop_row does not handle id() — #372).
-        if needs_node_ref_in_return(&m.return_clause.items) {
+        // id(n) and other NodeRef-dependent functions require the row engine (#372).
+        if return_requires_row_engine(&m.return_clause.items) {
             return false;
         }
         // Resolve to exactly one rel table.
@@ -775,7 +770,7 @@ impl Engine {
             }
         }
         // id(n) and other NodeRef-dependent functions require the row engine (#372).
-        if needs_node_ref_in_return(&m.return_clause.items) {
+        if return_requires_row_engine(&m.return_clause.items) {
             return false;
         }
         // Rel table must exist.
@@ -1125,7 +1120,7 @@ impl Engine {
             return false;
         }
         // id(n) and other NodeRef-dependent functions require the row engine (#372).
-        if needs_node_ref_in_return(&m.return_clause.items) {
+        if return_requires_row_engine(&m.return_clause.items) {
             return false;
         }
         // Both hops must resolve to the same relationship table.
@@ -2304,4 +2299,17 @@ fn find_slot_by_props(
         }
     }
     None
+}
+
+/// Returns `true` when the RETURN clause contains expressions that the chunked
+/// pipeline paths cannot handle and the query must fall back to the row engine.
+///
+/// Specifically, `id(n)` and other `NodeRef`-dependent functions require
+/// `Value::NodeRef` to be injected into the row map by the eval path.  The
+/// chunked `project_row` / `project_hop_row` paths match by column-name string;
+/// when an AS alias is present the column name is the alias rather than
+/// `"id(n)"`, so those paths return Null.  The row engine's eval path resolves
+/// `id(n)` correctly via `eval_expr` (#372).
+fn return_requires_row_engine(items: &[ReturnItem]) -> bool {
+    needs_node_ref_in_return(items)
 }

--- a/crates/sparrowdb/tests/regression_372.rs
+++ b/crates/sparrowdb/tests/regression_372.rs
@@ -98,11 +98,9 @@ fn id_function_unique_ids() {
         })
         .collect();
 
-    let mut sorted = ids.clone();
-    sorted.sort_unstable();
-    sorted.dedup();
+    let unique_ids: std::collections::HashSet<_> = ids.iter().collect();
     assert_eq!(
-        sorted.len(),
+        unique_ids.len(),
         3,
         "all node IDs must be distinct, got: {:?}",
         ids


### PR DESCRIPTION
## Summary

- `id(n)` in a RETURN clause (especially with an AS alias like `RETURN id(n) AS nid`) was returning Null instead of the node's internal integer ID
- Root cause: `build_read_engine` enables the chunked pipeline, but the four `can_use_*_chunked` eligibility guards did not exclude queries with `id()` in RETURN items. The chunked path uses `project_row` which matches column names by string pattern (`"id(n)"`), but when an alias is present the column name is the alias (`"nid"`), so the match fails and Null is returned.
- The same issue affected `execute_one_hop` where `project_hop_row` had no branch for `FnCall { name: "id" }`.

**Fix (two sites):**
1. Added `needs_node_ref_in_return` guard to all four `can_use_*_chunked` functions in `pipeline_exec.rs` — queries with `id()` in RETURN now fall back to the row engine which injects `Value::NodeRef` into the row map and resolves `id(n)` correctly via `eval_expr`.
2. Extended `use_agg` flag in `execute_one_hop` (`hop.rs`) to also be `true` when `needs_node_ref_in_return` returns true, routing hop queries with `id()` through the raw-rows + `aggregate_rows_graph` path instead of `project_hop_row`.

## Test plan

- [x] All 4 pre-existing `spa_196_id_function` tests pass (they were regressed by this bug)
- [x] 4 new regression tests in `regression_372.rs`:
  - `id_function_with_alias_returns_integer` — exact query from issue: `MATCH (n:Person {name: 'Alice'}) RETURN id(n), n.name`
  - `id_function_alias_returns_integer` — `RETURN id(n) AS nid` with alias
  - `id_function_unique_ids` — confirms returned IDs are distinct per-node
  - `id_function_where_filter_with_inline_prop` — `WHERE id(n) = alice_id` with inline prop filter
- [x] `cargo check -p sparrowdb` passes
- [x] Full test suite passes (3 pre-existing regression_355 failures are unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query evaluation to correctly handle `id(n)` and other node reference expressions in RETURN clauses, ensuring proper node identifier retrieval.

* **Tests**
  * Added comprehensive regression tests for `id(n)` functionality, covering node ID retrieval, column aliasing, filtering by node ID, and ID uniqueness validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->