### PR TITLE
fix(mcp): replace RETURN n with RETURN count(n) in merge_node_by_property

### DIFF
--- a/crates/sparrowdb-mcp/src/main.rs
+++ b/crates/sparrowdb-mcp/src/main.rs
@@ -492,7 +492,8 @@ fn handle_tool_call_inner(params: Option<Value>) -> Result<Value, String> {
                         set_clause_inner = set_parts.join(", "),
                     )
                 };
-                let _ = db.execute(&query)
+                let _ = db
+                    .execute(&query)
                     .map_err(|e| format!("merge_node_by_property: MATCH failed: {}", e))?;
             } else {
                 // Node does not exist — create it with all properties.
@@ -500,7 +501,8 @@ fn handle_tool_call_inner(params: Option<Value>) -> Result<Value, String> {
                 all_props.extend(prop_parts);
                 let props_str = all_props.join(", ");
                 let query = format!("CREATE (n:{label} {{{props_str}}})",);
-                let _ = db.execute(&query)
+                let _ = db
+                    .execute(&query)
                     .map_err(|e| format!("merge_node_by_property: CREATE failed: {}", e))?;
             }
 


### PR DESCRIPTION
## Summary
- `RETURN n` (bare node variable) is not supported by the Cypher engine
- The UPDATE and CREATE paths in `merge_node_by_property` both used `RETURN n`
- Fix: use `RETURN count(n)` which is supported

Fixes the merge UPDATE path returning an error after v0.1.19.

## Test plan
- [ ] merge_node_by_property UPDATE path (node exists, extra props)
- [ ] merge_node_by_property CREATE path (node does not exist)
- [ ] merge_node_by_property UPDATE path (node exists, no extra props)

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected node-merge responses: always report a single row in response metadata and removed the "(N row(s) returned)" text while preserving "created" vs "found (existing)" messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->