### PR TITLE
feat(transport): add Bolt protocol server for gdotv compatibility (closes #388)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/sparrowdb-metrics",
     "crates/sparrowdb-bench",
     "crates/sparrowdb-ruby",
+    "crates/sparrowdb-bolt",
 ]
 
 [workspace.package]

--- a/crates/sparrowdb-bolt/Cargo.toml
+++ b/crates/sparrowdb-bolt/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "sparrowdb-bolt"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Bolt protocol TCP server for SparrowDB"
+publish = false
+
+[lib]
+name = "sparrowdb_bolt"
+path = "src/lib.rs"
+
+[[bin]]
+name = "sparrowdb-bolt"
+path = "src/main.rs"
+
+[dependencies]
+sparrowdb = { workspace = true }
+sparrowdb-execution = { workspace = true }
+tokio = { version = "1", features = ["full"] }
+bytes = "1"
+clap = { version = "4", features = ["derive", "env"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/sparrowdb-bolt/src/handler.rs
+++ b/crates/sparrowdb-bolt/src/handler.rs
@@ -309,10 +309,7 @@ async fn read_chunked_message(
             break;
         }
         if result.len() + chunk_len > MAX_MESSAGE_SIZE {
-            return Err(format!(
-                "message too large: would exceed {MAX_MESSAGE_SIZE} bytes"
-            )
-            .into());
+            return Err(format!("message too large: would exceed {MAX_MESSAGE_SIZE} bytes").into());
         }
         let mut chunk = vec![0u8; chunk_len];
         stream.read_exact(&mut chunk).await?;

--- a/crates/sparrowdb-bolt/src/handler.rs
+++ b/crates/sparrowdb-bolt/src/handler.rs
@@ -9,6 +9,16 @@ use sparrowdb_execution::{QueryResult, Value};
 use std::collections::HashMap;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
+use tokio::time::Duration;
+
+/// Maximum total size of a single chunked message (4 MiB).
+const MAX_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
+
+/// Maximum size of a single outgoing chunk (Bolt protocol limit).
+const MAX_CHUNK_SIZE: usize = 65_535;
+
+/// Timeout for the initial Bolt handshake.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Bolt magic preamble (4 bytes).
 const BOLT_MAGIC: [u8; 4] = [0x60, 0x60, 0xB0, 0x17];
@@ -40,7 +50,9 @@ async fn handle_inner(
     // ── 1. Handshake ────────────────────────────────────────────────
 
     let mut preamble = [0u8; 20];
-    stream.read_exact(&mut preamble).await?;
+    tokio::time::timeout(HANDSHAKE_TIMEOUT, stream.read_exact(&mut preamble))
+        .await
+        .map_err(|_| "handshake timeout")??;
 
     if preamble[..4] != BOLT_MAGIC {
         return Err("invalid bolt magic".into());
@@ -68,12 +80,7 @@ async fn handle_inner(
             selected = Some([0, 0, 4, 0]);
             break;
         }
-        // Check if any version in range matches major 4
-        if major >= 1 && major <= 4 {
-            selected = Some([0, 0, 4, 0]);
-            break;
-        }
-        let _ = range; // suppress unused warning
+        let _ = range; // version range field — reserved for future use
     }
 
     let version_bytes = match selected {
@@ -147,7 +154,12 @@ async fn handle_inner(
 
                 tracing::info!("RUN: {query}");
 
-                match db.execute(&query) {
+                let db2 = db.clone();
+                let exec_result = tokio::task::spawn_blocking(move || db2.execute(&query))
+                    .await
+                    .map_err(|e| format!("task join error: {e}"))?;
+
+                match exec_result {
                     Ok(result) => {
                         let mut meta = HashMap::new();
                         let field_names: Vec<BoltValue> = result
@@ -173,19 +185,59 @@ async fn handle_inner(
                     continue;
                 }
 
+                // Extract `n` (batch size) from PULL metadata map, default -1 = all.
+                let n_requested: i64 = fields
+                    .first()
+                    .and_then(|v| {
+                        if let BoltValue::Map(m) = v {
+                            m.get("n").and_then(|n| {
+                                if let BoltValue::Integer(i) = n {
+                                    Some(*i)
+                                } else {
+                                    None
+                                }
+                            })
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or(-1);
+
                 match &state {
                     State::Streaming { result, cursor } => {
                         let cursor = *cursor;
-                        // Send all remaining records.
-                        for row in &result.rows[cursor..] {
+                        let total = result.rows.len();
+                        let limit = if n_requested < 0 {
+                            total - cursor
+                        } else {
+                            (n_requested as usize).min(total - cursor)
+                        };
+
+                        // Buffer all records into a single write before flushing.
+                        let end = cursor + limit;
+                        let mut combined = BytesMut::new();
+                        for row in &result.rows[cursor..end] {
                             let bolt_row: Vec<BoltValue> =
                                 row.iter().map(sparrow_to_bolt).collect();
-                            send_record(stream, bolt_row).await?;
+                            append_record(&mut combined, bolt_row);
                         }
+
+                        // SUCCESS metadata
+                        let has_more = end < total;
                         let mut meta = HashMap::new();
-                        meta.insert("has_more".into(), BoltValue::Boolean(false));
-                        send_success(stream, meta).await?;
-                        state = State::Ready;
+                        meta.insert("has_more".into(), BoltValue::Boolean(has_more));
+                        append_success(&mut combined, meta);
+
+                        write_chunked_batch(stream, &combined).await?;
+
+                        if has_more {
+                            state = State::Streaming {
+                                result: result.clone(),
+                                cursor: end,
+                            };
+                        } else {
+                            state = State::Ready;
+                        }
                     }
                     _ => {
                         send_success(stream, HashMap::new()).await?;
@@ -200,17 +252,34 @@ async fn handle_inner(
                 send_success(stream, meta).await?;
             }
             packstream::SIG_BEGIN => {
-                // Auto-commit only — accept BEGIN but no real tx management.
-                send_success(stream, HashMap::new()).await?;
-                state = State::Ready;
+                // SparrowDB does not support multi-statement transactions.
+                // Returning SUCCESS here would give clients a false atomicity
+                // guarantee, so we reject BEGIN explicitly.
+                send_failure(
+                    stream,
+                    "SparrowDB.Unsupported",
+                    "explicit transactions are not supported; use auto-commit mode",
+                )
+                .await?;
+                state = State::Failed;
             }
             packstream::SIG_COMMIT => {
-                send_success(stream, HashMap::new()).await?;
-                state = State::Ready;
+                send_failure(
+                    stream,
+                    "SparrowDB.Unsupported",
+                    "explicit transactions are not supported; use auto-commit mode",
+                )
+                .await?;
+                state = State::Failed;
             }
             packstream::SIG_ROLLBACK => {
-                send_success(stream, HashMap::new()).await?;
-                state = State::Ready;
+                send_failure(
+                    stream,
+                    "SparrowDB.Unsupported",
+                    "explicit transactions are not supported; use auto-commit mode",
+                )
+                .await?;
+                state = State::Failed;
             }
             other => {
                 tracing::warn!("unknown message signature: 0x{other:02X}");
@@ -227,6 +296,7 @@ async fn handle_inner(
 ///
 /// Bolt chunking: `[u16 len][data]...  [0x0000]`
 /// Chunks are concatenated until a zero-length chunk is seen.
+/// Returns an error if the accumulated size exceeds `MAX_MESSAGE_SIZE`.
 async fn read_chunked_message(
     stream: &mut TcpStream,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
@@ -238,6 +308,12 @@ async fn read_chunked_message(
         if chunk_len == 0 {
             break;
         }
+        if result.len() + chunk_len > MAX_MESSAGE_SIZE {
+            return Err(format!(
+                "message too large: would exceed {MAX_MESSAGE_SIZE} bytes"
+            )
+            .into());
+        }
         let mut chunk = vec![0u8; chunk_len];
         stream.read_exact(&mut chunk).await?;
         result.extend_from_slice(&chunk);
@@ -245,18 +321,33 @@ async fn read_chunked_message(
     Ok(result)
 }
 
-/// Write a message using chunked transport.
+/// Write a message using chunked transport, splitting into ≤65535-byte chunks.
+///
+/// Per the Bolt spec, each chunk is prefixed by its u16 length, and the
+/// message is terminated by a zero-length chunk (`0x00 0x00`).
 async fn write_chunked_message(
     stream: &mut TcpStream,
     data: &[u8],
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Send as a single chunk (messages are typically small).
-    let len = data.len() as u16;
-    let mut out = BytesMut::with_capacity(2 + data.len() + 2);
-    out.put_u16(len);
-    out.extend_from_slice(data);
-    out.put_u16(0); // end marker
-    stream.write_all(&out).await?;
+    for chunk in data.chunks(MAX_CHUNK_SIZE) {
+        let len = chunk.len() as u16;
+        stream.write_all(&len.to_be_bytes()).await?;
+        stream.write_all(chunk).await?;
+    }
+    stream.write_all(&[0, 0]).await?; // end marker
+    stream.flush().await?;
+    Ok(())
+}
+
+/// Write a pre-built buffer of concatenated chunked messages in a single flush.
+///
+/// Used by PULL to batch-write all records before the final SUCCESS, avoiding
+/// a per-record `flush()` call.
+async fn write_chunked_batch(
+    stream: &mut TcpStream,
+    data: &[u8],
+) -> Result<(), Box<dyn std::error::Error>> {
+    stream.write_all(data).await?;
     stream.flush().await?;
     Ok(())
 }
@@ -289,14 +380,29 @@ async fn send_failure(
     write_chunked_message(stream, &buf).await
 }
 
-async fn send_record(
-    stream: &mut TcpStream,
-    fields: Vec<BoltValue>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let mut buf = BytesMut::new();
-    packstream::encode_struct_header(&mut buf, 1, packstream::SIG_RECORD);
-    packstream::encode_value(&mut buf, &BoltValue::List(fields));
-    write_chunked_message(stream, &buf).await
+/// Append a serialized RECORD message (with chunked framing) to `out`, without flushing.
+fn append_record(out: &mut BytesMut, fields: Vec<BoltValue>) {
+    let mut msg = BytesMut::new();
+    packstream::encode_struct_header(&mut msg, 1, packstream::SIG_RECORD);
+    packstream::encode_value(&mut msg, &BoltValue::List(fields));
+    append_chunked(out, &msg);
+}
+
+/// Append a serialized SUCCESS message (with chunked framing) to `out`, without flushing.
+fn append_success(out: &mut BytesMut, metadata: HashMap<String, BoltValue>) {
+    let mut msg = BytesMut::new();
+    packstream::encode_struct_header(&mut msg, 1, packstream::SIG_SUCCESS);
+    packstream::encode_value(&mut msg, &BoltValue::Map(metadata));
+    append_chunked(out, &msg);
+}
+
+/// Serialize `data` into Bolt chunked framing and append to `out`.
+fn append_chunked(out: &mut BytesMut, data: &[u8]) {
+    for chunk in data.chunks(MAX_CHUNK_SIZE) {
+        out.put_u16(chunk.len() as u16);
+        out.extend_from_slice(chunk);
+    }
+    out.put_u16(0); // end marker
 }
 
 async fn send_ignored(stream: &mut TcpStream) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/sparrowdb-bolt/src/handler.rs
+++ b/crates/sparrowdb-bolt/src/handler.rs
@@ -1,0 +1,339 @@
+//! Per-connection Bolt message handler.
+//!
+//! Implements the Bolt v4.x state machine: CONNECTED → READY → STREAMING.
+
+use crate::packstream::{self, BoltValue};
+use bytes::{BufMut, BytesMut};
+use sparrowdb::GraphDb;
+use sparrowdb_execution::{QueryResult, Value};
+use std::collections::HashMap;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+/// Bolt magic preamble (4 bytes).
+const BOLT_MAGIC: [u8; 4] = [0x60, 0x60, 0xB0, 0x17];
+
+/// State machine for a single connection.
+enum State {
+    Connected,
+    Ready,
+    Streaming { result: QueryResult, cursor: usize },
+    Failed,
+}
+
+pub async fn handle_connection(mut stream: TcpStream, db: GraphDb) {
+    let peer = stream
+        .peer_addr()
+        .map(|a| a.to_string())
+        .unwrap_or_else(|_| "unknown".into());
+    tracing::info!("new connection from {peer}");
+
+    if let Err(e) = handle_inner(&mut stream, &db).await {
+        tracing::debug!("connection {peer} ended: {e}");
+    }
+}
+
+async fn handle_inner(
+    stream: &mut TcpStream,
+    db: &GraphDb,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // ── 1. Handshake ────────────────────────────────────────────────
+
+    let mut preamble = [0u8; 20];
+    stream.read_exact(&mut preamble).await?;
+
+    if preamble[..4] != BOLT_MAGIC {
+        return Err("invalid bolt magic".into());
+    }
+
+    // Parse 4 version proposals (each 4 bytes).
+    // Bolt 4.x version encoding: [range, minor, major, 0]
+    // e.g. [4, 0, 4, 0] means versions 4.0 through 4.4
+    // We support Bolt 4.x — pick the best match.
+    let mut selected: Option<[u8; 4]> = None;
+    for i in 0..4 {
+        let off = 4 + i * 4;
+        let proposal = &preamble[off..off + 4];
+        let major = proposal[2] as u16; // 3rd byte = major in Bolt 4+ encoding
+        let minor = proposal[1];
+        let range = proposal[0];
+
+        if major == 4 {
+            // Accept any Bolt 4.x
+            selected = Some([0, minor, major as u8, 0]);
+            break;
+        }
+        // Also check the older encoding where major is in byte[3]
+        if proposal[3] == 4 || (proposal[3] == 0 && proposal[2] == 4) {
+            selected = Some([0, 0, 4, 0]);
+            break;
+        }
+        // Check if any version in range matches major 4
+        if major >= 1 && major <= 4 {
+            selected = Some([0, 0, 4, 0]);
+            break;
+        }
+        let _ = range; // suppress unused warning
+    }
+
+    let version_bytes = match selected {
+        Some(v) => v,
+        None => {
+            // No supported version — send zeroes and close.
+            stream.write_all(&[0, 0, 0, 0]).await?;
+            return Ok(());
+        }
+    };
+
+    stream.write_all(&version_bytes).await?;
+    tracing::info!("negotiated Bolt {}.{}", version_bytes[2], version_bytes[1]);
+
+    // ── 2. Message loop ─────────────────────────────────────────────
+
+    let mut state = State::Connected;
+
+    loop {
+        // Read one chunked message.
+        let msg_bytes = match read_chunked_message(stream).await {
+            Ok(b) if b.is_empty() => return Ok(()), // clean close
+            Ok(b) => b,
+            Err(e) => return Err(e),
+        };
+
+        // Decode struct header (signature tells us the message type).
+        let mut slice: &[u8] = &msg_bytes;
+        let (n_fields, sig) = packstream::decode_struct_header(&mut slice)?;
+
+        // Decode fields.
+        let mut fields = Vec::with_capacity(n_fields as usize);
+        for _ in 0..n_fields {
+            fields.push(packstream::decode_value(&mut slice)?);
+        }
+
+        match sig {
+            packstream::SIG_HELLO => {
+                // Accept any credentials.
+                let meta = hello_success_meta();
+                send_success(stream, meta).await?;
+                state = State::Ready;
+            }
+            packstream::SIG_LOGON => {
+                // Bolt 5.1+ LOGON — accept any credentials.
+                send_success(stream, HashMap::new()).await?;
+                // stay in Ready
+            }
+            packstream::SIG_GOODBYE => {
+                tracing::debug!("GOODBYE received");
+                return Ok(());
+            }
+            packstream::SIG_RESET => {
+                state = State::Ready;
+                send_success(stream, HashMap::new()).await?;
+            }
+            packstream::SIG_RUN => {
+                if matches!(state, State::Failed) {
+                    send_ignored(stream).await?;
+                    continue;
+                }
+
+                let query = match fields.first() {
+                    Some(BoltValue::String(s)) => s.clone(),
+                    _ => {
+                        send_failure(stream, "Request.Invalid", "missing query string").await?;
+                        state = State::Failed;
+                        continue;
+                    }
+                };
+
+                tracing::info!("RUN: {query}");
+
+                match db.execute(&query) {
+                    Ok(result) => {
+                        let mut meta = HashMap::new();
+                        let field_names: Vec<BoltValue> = result
+                            .columns
+                            .iter()
+                            .map(|c| BoltValue::String(c.clone()))
+                            .collect();
+                        meta.insert("fields".into(), BoltValue::List(field_names));
+
+                        send_success(stream, meta).await?;
+                        state = State::Streaming { result, cursor: 0 };
+                    }
+                    Err(e) => {
+                        tracing::warn!("query error: {e}");
+                        send_failure(stream, "SparrowDB.ExecutionError", &e.to_string()).await?;
+                        state = State::Failed;
+                    }
+                }
+            }
+            packstream::SIG_PULL => {
+                if matches!(state, State::Failed) {
+                    send_ignored(stream).await?;
+                    continue;
+                }
+
+                match &state {
+                    State::Streaming { result, cursor } => {
+                        let cursor = *cursor;
+                        // Send all remaining records.
+                        for row in &result.rows[cursor..] {
+                            let bolt_row: Vec<BoltValue> =
+                                row.iter().map(sparrow_to_bolt).collect();
+                            send_record(stream, bolt_row).await?;
+                        }
+                        let mut meta = HashMap::new();
+                        meta.insert("has_more".into(), BoltValue::Boolean(false));
+                        send_success(stream, meta).await?;
+                        state = State::Ready;
+                    }
+                    _ => {
+                        send_success(stream, HashMap::new()).await?;
+                    }
+                }
+            }
+            packstream::SIG_DISCARD => {
+                // Discard results — just transition back to READY.
+                state = State::Ready;
+                let mut meta = HashMap::new();
+                meta.insert("has_more".into(), BoltValue::Boolean(false));
+                send_success(stream, meta).await?;
+            }
+            packstream::SIG_BEGIN => {
+                // Auto-commit only — accept BEGIN but no real tx management.
+                send_success(stream, HashMap::new()).await?;
+                state = State::Ready;
+            }
+            packstream::SIG_COMMIT => {
+                send_success(stream, HashMap::new()).await?;
+                state = State::Ready;
+            }
+            packstream::SIG_ROLLBACK => {
+                send_success(stream, HashMap::new()).await?;
+                state = State::Ready;
+            }
+            other => {
+                tracing::warn!("unknown message signature: 0x{other:02X}");
+                send_failure(stream, "Request.Invalid", "unknown message type").await?;
+                state = State::Failed;
+            }
+        }
+    }
+}
+
+// ── Chunked transport ───────────────────────────────────────────────
+
+/// Read a full chunked message from the stream.
+///
+/// Bolt chunking: `[u16 len][data]...  [0x0000]`
+/// Chunks are concatenated until a zero-length chunk is seen.
+async fn read_chunked_message(
+    stream: &mut TcpStream,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let mut result = Vec::new();
+    loop {
+        let mut len_buf = [0u8; 2];
+        stream.read_exact(&mut len_buf).await?;
+        let chunk_len = u16::from_be_bytes(len_buf) as usize;
+        if chunk_len == 0 {
+            break;
+        }
+        let mut chunk = vec![0u8; chunk_len];
+        stream.read_exact(&mut chunk).await?;
+        result.extend_from_slice(&chunk);
+    }
+    Ok(result)
+}
+
+/// Write a message using chunked transport.
+async fn write_chunked_message(
+    stream: &mut TcpStream,
+    data: &[u8],
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Send as a single chunk (messages are typically small).
+    let len = data.len() as u16;
+    let mut out = BytesMut::with_capacity(2 + data.len() + 2);
+    out.put_u16(len);
+    out.extend_from_slice(data);
+    out.put_u16(0); // end marker
+    stream.write_all(&out).await?;
+    stream.flush().await?;
+    Ok(())
+}
+
+// ── Message senders ─────────────────────────────────────────────────
+
+async fn send_success(
+    stream: &mut TcpStream,
+    metadata: HashMap<String, BoltValue>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut buf = BytesMut::new();
+    packstream::encode_struct_header(&mut buf, 1, packstream::SIG_SUCCESS);
+    let val = BoltValue::Map(metadata);
+    packstream::encode_value(&mut buf, &val);
+    write_chunked_message(stream, &buf).await
+}
+
+async fn send_failure(
+    stream: &mut TcpStream,
+    code: &str,
+    message: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut meta = HashMap::new();
+    meta.insert("code".into(), BoltValue::String(code.into()));
+    meta.insert("message".into(), BoltValue::String(message.into()));
+
+    let mut buf = BytesMut::new();
+    packstream::encode_struct_header(&mut buf, 1, packstream::SIG_FAILURE);
+    packstream::encode_value(&mut buf, &BoltValue::Map(meta));
+    write_chunked_message(stream, &buf).await
+}
+
+async fn send_record(
+    stream: &mut TcpStream,
+    fields: Vec<BoltValue>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut buf = BytesMut::new();
+    packstream::encode_struct_header(&mut buf, 1, packstream::SIG_RECORD);
+    packstream::encode_value(&mut buf, &BoltValue::List(fields));
+    write_chunked_message(stream, &buf).await
+}
+
+async fn send_ignored(stream: &mut TcpStream) -> Result<(), Box<dyn std::error::Error>> {
+    let mut buf = BytesMut::new();
+    // IGNORED = 0x7E, struct with 0 fields
+    packstream::encode_struct_header(&mut buf, 0, 0x7E);
+    write_chunked_message(stream, &buf).await
+}
+
+// ── Value mapping ───────────────────────────────────────────────────
+
+fn sparrow_to_bolt(val: &Value) -> BoltValue {
+    match val {
+        Value::Null => BoltValue::Null,
+        Value::Int64(n) => BoltValue::Integer(*n),
+        Value::Float64(f) => BoltValue::Float(*f),
+        Value::Bool(b) => BoltValue::Boolean(*b),
+        Value::String(s) => BoltValue::String(s.clone()),
+        Value::NodeRef(id) => BoltValue::Integer(id.0 as i64),
+        Value::EdgeRef(id) => BoltValue::Integer(id.0 as i64),
+        Value::List(items) => BoltValue::List(items.iter().map(sparrow_to_bolt).collect()),
+        Value::Map(pairs) => {
+            let mut map = HashMap::new();
+            for (k, v) in pairs {
+                map.insert(k.clone(), sparrow_to_bolt(v));
+            }
+            BoltValue::Map(map)
+        }
+    }
+}
+
+fn hello_success_meta() -> HashMap<String, BoltValue> {
+    let mut meta = HashMap::new();
+    meta.insert("server".into(), BoltValue::String("SparrowDB/0.1".into()));
+    meta.insert(
+        "connection_id".into(),
+        BoltValue::String("sparrowdb-bolt-0".into()),
+    );
+    meta
+}

--- a/crates/sparrowdb-bolt/src/lib.rs
+++ b/crates/sparrowdb-bolt/src/lib.rs
@@ -1,0 +1,9 @@
+//! SparrowDB Bolt Protocol Server library.
+//!
+//! Provides a Bolt v4.x TCP server that routes Cypher queries to a SparrowDB
+//! database instance.
+
+pub mod handler;
+pub mod packstream;
+
+pub use handler::handle_connection;

--- a/crates/sparrowdb-bolt/src/main.rs
+++ b/crates/sparrowdb-bolt/src/main.rs
@@ -1,0 +1,51 @@
+//! SparrowDB Bolt Protocol Server
+//!
+//! Accepts connections from Bolt-compatible clients (gdotv, Neo4j Browser, etc.)
+//! and routes Cypher queries to a SparrowDB database.
+
+use clap::Parser;
+use sparrowdb::GraphDb;
+use std::path::PathBuf;
+use tokio::net::TcpListener;
+
+#[derive(Parser, Debug)]
+#[command(name = "sparrowdb-bolt", about = "Bolt protocol server for SparrowDB")]
+struct Args {
+    /// Path to the SparrowDB database directory.
+    #[arg(long, env = "SPARROWDB_PATH")]
+    db_path: PathBuf,
+
+    /// Host to bind to.
+    #[arg(long, default_value = "0.0.0.0")]
+    host: String,
+
+    /// Port to listen on.
+    #[arg(long, default_value_t = 7687)]
+    port: u16,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "sparrowdb_bolt=info".into()),
+        )
+        .init();
+
+    let args = Args::parse();
+    let db = GraphDb::open(&args.db_path)?;
+    tracing::info!("opened database at {:?}", args.db_path);
+
+    let bind_addr = format!("{}:{}", args.host, args.port);
+    let listener = TcpListener::bind(&bind_addr).await?;
+    tracing::info!("bolt server listening on {bind_addr}");
+
+    loop {
+        let (stream, _addr) = listener.accept().await?;
+        let db = db.clone();
+        tokio::spawn(async move {
+            sparrowdb_bolt::handle_connection(stream, db).await;
+        });
+    }
+}

--- a/crates/sparrowdb-bolt/src/main.rs
+++ b/crates/sparrowdb-bolt/src/main.rs
@@ -6,7 +6,12 @@
 use clap::Parser;
 use sparrowdb::GraphDb;
 use std::path::PathBuf;
+use std::sync::Arc;
 use tokio::net::TcpListener;
+use tokio::sync::Semaphore;
+
+/// Maximum number of concurrent Bolt connections.
+const MAX_CONNECTIONS: usize = 256;
 
 #[derive(Parser, Debug)]
 #[command(name = "sparrowdb-bolt", about = "Bolt protocol server for SparrowDB")]
@@ -41,10 +46,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let listener = TcpListener::bind(&bind_addr).await?;
     tracing::info!("bolt server listening on {bind_addr}");
 
+    let semaphore = Arc::new(Semaphore::new(MAX_CONNECTIONS));
+
     loop {
         let (stream, _addr) = listener.accept().await?;
         let db = db.clone();
+        let permit = semaphore.clone().acquire_owned().await?;
         tokio::spawn(async move {
+            let _permit = permit; // released when the connection closes
             sparrowdb_bolt::handle_connection(stream, db).await;
         });
     }

--- a/crates/sparrowdb-bolt/src/packstream.rs
+++ b/crates/sparrowdb-bolt/src/packstream.rs
@@ -1,0 +1,395 @@
+//! PackStream v1 encoding / decoding.
+//!
+//! PackStream is a binary serialization format used by the Bolt protocol.
+//! Reference: <https://neo4j.com/docs/bolt/current/packstream/>
+
+use bytes::{Buf, BufMut, BytesMut};
+use std::collections::HashMap;
+
+// ── Value type ──────────────────────────────────────────────────────
+
+/// A Bolt-compatible value.
+#[derive(Debug, Clone, PartialEq)]
+pub enum BoltValue {
+    Null,
+    Boolean(bool),
+    Integer(i64),
+    Float(f64),
+    String(String),
+    List(Vec<BoltValue>),
+    Map(HashMap<String, BoltValue>),
+}
+
+// ── PackStream markers ──────────────────────────────────────────────
+
+const TINY_STRING_NIBBLE: u8 = 0x80;
+const TINY_LIST_NIBBLE: u8 = 0x90;
+const TINY_MAP_NIBBLE: u8 = 0xA0;
+
+const NULL: u8 = 0xC0;
+const FLOAT_64: u8 = 0xC1;
+const FALSE: u8 = 0xC2;
+const TRUE: u8 = 0xC3;
+const INT_8: u8 = 0xC8;
+const INT_16: u8 = 0xC9;
+const INT_32: u8 = 0xCA;
+const INT_64: u8 = 0xCB;
+const STRING_8: u8 = 0xD0;
+const STRING_16: u8 = 0xD1;
+const STRING_32: u8 = 0xD2;
+const LIST_8: u8 = 0xD4;
+const LIST_16: u8 = 0xD5;
+const LIST_32: u8 = 0xD6;
+const MAP_8: u8 = 0xD8;
+const MAP_16: u8 = 0xD9;
+const MAP_32: u8 = 0xDA;
+const TINY_STRUCT_NIBBLE: u8 = 0xB0;
+
+// Bolt message signature bytes
+pub const SIG_SUCCESS: u8 = 0x70;
+pub const SIG_FAILURE: u8 = 0x7F;
+pub const SIG_RECORD: u8 = 0x71;
+pub const SIG_HELLO: u8 = 0x01;
+pub const SIG_LOGON: u8 = 0x6A;
+pub const SIG_RUN: u8 = 0x10;
+pub const SIG_PULL: u8 = 0x3F;
+pub const SIG_DISCARD: u8 = 0x2F;
+pub const SIG_RESET: u8 = 0x0F;
+pub const SIG_GOODBYE: u8 = 0x02;
+pub const SIG_BEGIN: u8 = 0x11;
+pub const SIG_COMMIT: u8 = 0x12;
+pub const SIG_ROLLBACK: u8 = 0x13;
+
+// ── Encoding ────────────────────────────────────────────────────────
+
+pub fn encode_value(buf: &mut BytesMut, val: &BoltValue) {
+    match val {
+        BoltValue::Null => buf.put_u8(NULL),
+        BoltValue::Boolean(b) => buf.put_u8(if *b { TRUE } else { FALSE }),
+        BoltValue::Integer(n) => encode_integer(buf, *n),
+        BoltValue::Float(f) => {
+            buf.put_u8(FLOAT_64);
+            buf.put_f64(*f);
+        }
+        BoltValue::String(s) => encode_string(buf, s),
+        BoltValue::List(items) => {
+            encode_list_header(buf, items.len());
+            for item in items {
+                encode_value(buf, item);
+            }
+        }
+        BoltValue::Map(map) => {
+            encode_map_header(buf, map.len());
+            for (k, v) in map {
+                encode_string(buf, k);
+                encode_value(buf, v);
+            }
+        }
+    }
+}
+
+fn encode_integer(buf: &mut BytesMut, n: i64) {
+    if (-16..=127).contains(&n) {
+        buf.put_i8(n as i8);
+    } else if i8::MIN as i64 <= n && n <= i8::MAX as i64 {
+        buf.put_u8(INT_8);
+        buf.put_i8(n as i8);
+    } else if i16::MIN as i64 <= n && n <= i16::MAX as i64 {
+        buf.put_u8(INT_16);
+        buf.put_i16(n as i16);
+    } else if i32::MIN as i64 <= n && n <= i32::MAX as i64 {
+        buf.put_u8(INT_32);
+        buf.put_i32(n as i32);
+    } else {
+        buf.put_u8(INT_64);
+        buf.put_i64(n);
+    }
+}
+
+fn encode_string(buf: &mut BytesMut, s: &str) {
+    let len = s.len();
+    if len < 16 {
+        buf.put_u8(TINY_STRING_NIBBLE | len as u8);
+    } else if len <= 255 {
+        buf.put_u8(STRING_8);
+        buf.put_u8(len as u8);
+    } else if len <= 65535 {
+        buf.put_u8(STRING_16);
+        buf.put_u16(len as u16);
+    } else {
+        buf.put_u8(STRING_32);
+        buf.put_u32(len as u32);
+    }
+    buf.extend_from_slice(s.as_bytes());
+}
+
+fn encode_list_header(buf: &mut BytesMut, len: usize) {
+    if len < 16 {
+        buf.put_u8(TINY_LIST_NIBBLE | len as u8);
+    } else if len <= 255 {
+        buf.put_u8(LIST_8);
+        buf.put_u8(len as u8);
+    } else if len <= 65535 {
+        buf.put_u8(LIST_16);
+        buf.put_u16(len as u16);
+    } else {
+        buf.put_u8(LIST_32);
+        buf.put_u32(len as u32);
+    }
+}
+
+fn encode_map_header(buf: &mut BytesMut, len: usize) {
+    if len < 16 {
+        buf.put_u8(TINY_MAP_NIBBLE | len as u8);
+    } else if len <= 255 {
+        buf.put_u8(MAP_8);
+        buf.put_u8(len as u8);
+    } else if len <= 65535 {
+        buf.put_u8(MAP_16);
+        buf.put_u16(len as u16);
+    } else {
+        buf.put_u8(MAP_32);
+        buf.put_u32(len as u32);
+    }
+}
+
+/// Encode a Bolt struct header (marker + signature byte).
+pub fn encode_struct_header(buf: &mut BytesMut, num_fields: u8, signature: u8) {
+    buf.put_u8(TINY_STRUCT_NIBBLE | num_fields);
+    buf.put_u8(signature);
+}
+
+// ── Decoding ────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub enum DecodeError {
+    UnexpectedEnd,
+    InvalidMarker(u8),
+    InvalidUtf8,
+}
+
+impl std::fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DecodeError::UnexpectedEnd => write!(f, "unexpected end of data"),
+            DecodeError::InvalidMarker(m) => write!(f, "invalid marker: 0x{m:02X}"),
+            DecodeError::InvalidUtf8 => write!(f, "invalid UTF-8 in string"),
+        }
+    }
+}
+
+impl std::error::Error for DecodeError {}
+
+pub fn decode_value(buf: &mut &[u8]) -> Result<BoltValue, DecodeError> {
+    if buf.is_empty() {
+        return Err(DecodeError::UnexpectedEnd);
+    }
+    let marker = buf[0];
+    match marker {
+        NULL => {
+            buf.advance(1);
+            Ok(BoltValue::Null)
+        }
+        TRUE => {
+            buf.advance(1);
+            Ok(BoltValue::Boolean(true))
+        }
+        FALSE => {
+            buf.advance(1);
+            Ok(BoltValue::Boolean(false))
+        }
+        FLOAT_64 => {
+            buf.advance(1);
+            if buf.remaining() < 8 {
+                return Err(DecodeError::UnexpectedEnd);
+            }
+            Ok(BoltValue::Float(buf.get_f64()))
+        }
+        INT_8 => {
+            buf.advance(1);
+            if buf.remaining() < 1 {
+                return Err(DecodeError::UnexpectedEnd);
+            }
+            Ok(BoltValue::Integer(buf.get_i8() as i64))
+        }
+        INT_16 => {
+            buf.advance(1);
+            if buf.remaining() < 2 {
+                return Err(DecodeError::UnexpectedEnd);
+            }
+            Ok(BoltValue::Integer(buf.get_i16() as i64))
+        }
+        INT_32 => {
+            buf.advance(1);
+            if buf.remaining() < 4 {
+                return Err(DecodeError::UnexpectedEnd);
+            }
+            Ok(BoltValue::Integer(buf.get_i32() as i64))
+        }
+        INT_64 => {
+            buf.advance(1);
+            if buf.remaining() < 8 {
+                return Err(DecodeError::UnexpectedEnd);
+            }
+            Ok(BoltValue::Integer(buf.get_i64()))
+        }
+        // Tiny int: -16..=127 stored directly
+        m if (m as i8) >= -16 && !matches!(m, 0x80..=0xEF) => {
+            buf.advance(1);
+            Ok(BoltValue::Integer(m as i8 as i64))
+        }
+        // Tiny string: 0x80..=0x8F
+        m if (0x80..=0x8F).contains(&m) => {
+            buf.advance(1);
+            let len = (m & 0x0F) as usize;
+            decode_string_body(buf, len)
+        }
+        STRING_8 => {
+            buf.advance(1);
+            if buf.remaining() < 1 {
+                return Err(DecodeError::UnexpectedEnd);
+            }
+            let len = buf.get_u8() as usize;
+            decode_string_body(buf, len)
+        }
+        STRING_16 => {
+            buf.advance(1);
+            if buf.remaining() < 2 {
+                return Err(DecodeError::UnexpectedEnd);
+            }
+            let len = buf.get_u16() as usize;
+            decode_string_body(buf, len)
+        }
+        STRING_32 => {
+            buf.advance(1);
+            if buf.remaining() < 4 {
+                return Err(DecodeError::UnexpectedEnd);
+            }
+            let len = buf.get_u32() as usize;
+            decode_string_body(buf, len)
+        }
+        // Tiny list: 0x90..=0x9F
+        m if (0x90..=0x9F).contains(&m) => {
+            buf.advance(1);
+            let len = (m & 0x0F) as usize;
+            decode_list_body(buf, len)
+        }
+        LIST_8 => {
+            buf.advance(1);
+            if buf.remaining() < 1 {
+                return Err(DecodeError::UnexpectedEnd);
+            }
+            let len = buf.get_u8() as usize;
+            decode_list_body(buf, len)
+        }
+        LIST_16 => {
+            buf.advance(1);
+            if buf.remaining() < 2 {
+                return Err(DecodeError::UnexpectedEnd);
+            }
+            let len = buf.get_u16() as usize;
+            decode_list_body(buf, len)
+        }
+        LIST_32 => {
+            buf.advance(1);
+            if buf.remaining() < 4 {
+                return Err(DecodeError::UnexpectedEnd);
+            }
+            let len = buf.get_u32() as usize;
+            decode_list_body(buf, len)
+        }
+        // Tiny map: 0xA0..=0xAF
+        m if (0xA0..=0xAF).contains(&m) => {
+            buf.advance(1);
+            let len = (m & 0x0F) as usize;
+            decode_map_body(buf, len)
+        }
+        MAP_8 => {
+            buf.advance(1);
+            if buf.remaining() < 1 {
+                return Err(DecodeError::UnexpectedEnd);
+            }
+            let len = buf.get_u8() as usize;
+            decode_map_body(buf, len)
+        }
+        MAP_16 => {
+            buf.advance(1);
+            if buf.remaining() < 2 {
+                return Err(DecodeError::UnexpectedEnd);
+            }
+            let len = buf.get_u16() as usize;
+            decode_map_body(buf, len)
+        }
+        MAP_32 => {
+            buf.advance(1);
+            if buf.remaining() < 4 {
+                return Err(DecodeError::UnexpectedEnd);
+            }
+            let len = buf.get_u32() as usize;
+            decode_map_body(buf, len)
+        }
+        // Tiny struct: 0xB0..=0xBF — decode as map (skip signature)
+        m if (0xB0..=0xBF).contains(&m) => {
+            buf.advance(1);
+            let n_fields = (m & 0x0F) as usize;
+            // skip signature byte
+            if buf.is_empty() {
+                return Err(DecodeError::UnexpectedEnd);
+            }
+            buf.advance(1);
+            // decode fields as a list (for struct values)
+            let mut items = Vec::with_capacity(n_fields);
+            for _ in 0..n_fields {
+                items.push(decode_value(buf)?);
+            }
+            Ok(BoltValue::List(items))
+        }
+        other => Err(DecodeError::InvalidMarker(other)),
+    }
+}
+
+fn decode_string_body(buf: &mut &[u8], len: usize) -> Result<BoltValue, DecodeError> {
+    if buf.remaining() < len {
+        return Err(DecodeError::UnexpectedEnd);
+    }
+    let bytes = &buf[..len];
+    let s = std::str::from_utf8(bytes).map_err(|_| DecodeError::InvalidUtf8)?;
+    let result = s.to_string();
+    buf.advance(len);
+    Ok(BoltValue::String(result))
+}
+
+fn decode_list_body(buf: &mut &[u8], len: usize) -> Result<BoltValue, DecodeError> {
+    let mut items = Vec::with_capacity(len);
+    for _ in 0..len {
+        items.push(decode_value(buf)?);
+    }
+    Ok(BoltValue::List(items))
+}
+
+fn decode_map_body(buf: &mut &[u8], len: usize) -> Result<BoltValue, DecodeError> {
+    let mut map = HashMap::with_capacity(len);
+    for _ in 0..len {
+        let key = match decode_value(buf)? {
+            BoltValue::String(s) => s,
+            _ => return Err(DecodeError::InvalidMarker(0)),
+        };
+        let val = decode_value(buf)?;
+        map.insert(key, val);
+    }
+    Ok(BoltValue::Map(map))
+}
+
+/// Decode a struct header: returns (num_fields, signature).
+pub fn decode_struct_header(buf: &mut &[u8]) -> Result<(u8, u8), DecodeError> {
+    if buf.remaining() < 2 {
+        return Err(DecodeError::UnexpectedEnd);
+    }
+    let marker = buf.get_u8();
+    if marker & 0xF0 != TINY_STRUCT_NIBBLE {
+        return Err(DecodeError::InvalidMarker(marker));
+    }
+    let n_fields = marker & 0x0F;
+    let signature = buf.get_u8();
+    Ok((n_fields, signature))
+}

--- a/crates/sparrowdb-bolt/src/packstream.rs
+++ b/crates/sparrowdb-bolt/src/packstream.rs
@@ -359,8 +359,12 @@ fn decode_string_body(buf: &mut &[u8], len: usize) -> Result<BoltValue, DecodeEr
     Ok(BoltValue::String(result))
 }
 
+/// Maximum number of elements pre-allocated from an untrusted network length.
+/// Larger collections grow dynamically via `push`.
+const MAX_PREALLOC: usize = 64;
+
 fn decode_list_body(buf: &mut &[u8], len: usize) -> Result<BoltValue, DecodeError> {
-    let mut items = Vec::with_capacity(len);
+    let mut items = Vec::with_capacity(len.min(MAX_PREALLOC));
     for _ in 0..len {
         items.push(decode_value(buf)?);
     }
@@ -368,7 +372,7 @@ fn decode_list_body(buf: &mut &[u8], len: usize) -> Result<BoltValue, DecodeErro
 }
 
 fn decode_map_body(buf: &mut &[u8], len: usize) -> Result<BoltValue, DecodeError> {
-    let mut map = HashMap::with_capacity(len);
+    let mut map = HashMap::with_capacity(len.min(MAX_PREALLOC));
     for _ in 0..len {
         let key = match decode_value(buf)? {
             BoltValue::String(s) => s,

--- a/crates/sparrowdb-bolt/tests/bolt_integration.rs
+++ b/crates/sparrowdb-bolt/tests/bolt_integration.rs
@@ -234,19 +234,11 @@ async fn start_server(db: GraphDb) -> u16 {
     let port = listener.local_addr().unwrap().port();
 
     tokio::spawn(async move {
-        loop {
-            match listener.accept().await {
-                Ok((stream, _)) => {
-                    let db = db.clone();
-                    tokio::spawn(async move {
-                        // Import the handler module via the binary crate.
-                        // Since we can't import from a bin crate, we'll inline
-                        // the connection handler via the library path.
-                        sparrowdb_bolt::handle_connection(stream, db).await;
-                    });
-                }
-                Err(_) => break,
-            }
+        while let Ok((stream, _)) = listener.accept().await {
+            let db = db.clone();
+            tokio::spawn(async move {
+                sparrowdb_bolt::handle_connection(stream, db).await;
+            });
         }
     });
 

--- a/crates/sparrowdb-bolt/tests/bolt_integration.rs
+++ b/crates/sparrowdb-bolt/tests/bolt_integration.rs
@@ -1,0 +1,399 @@
+//! Integration test: start a Bolt server, connect with a raw TCP client,
+//! execute Cypher queries, and verify results.
+
+use bytes::{Buf, BufMut, BytesMut};
+use sparrowdb::GraphDb;
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+// ── Minimal PackStream helpers (client-side) ────────────────────────
+
+fn encode_struct_header(buf: &mut BytesMut, n_fields: u8, sig: u8) {
+    buf.put_u8(0xB0 | n_fields);
+    buf.put_u8(sig);
+}
+
+fn encode_string(buf: &mut BytesMut, s: &str) {
+    let len = s.len();
+    if len < 16 {
+        buf.put_u8(0x80 | len as u8);
+    } else if len <= 255 {
+        buf.put_u8(0xD0);
+        buf.put_u8(len as u8);
+    } else {
+        buf.put_u8(0xD1);
+        buf.put_u16(len as u16);
+    }
+    buf.extend_from_slice(s.as_bytes());
+}
+
+fn encode_map_header(buf: &mut BytesMut, len: usize) {
+    if len < 16 {
+        buf.put_u8(0xA0 | len as u8);
+    } else {
+        buf.put_u8(0xD8);
+        buf.put_u8(len as u8);
+    }
+}
+
+fn encode_tiny_map(buf: &mut BytesMut, entries: &[(&str, &str)]) {
+    encode_map_header(buf, entries.len());
+    for (k, v) in entries {
+        encode_string(buf, k);
+        encode_string(buf, v);
+    }
+}
+
+fn encode_empty_map(buf: &mut BytesMut) {
+    buf.put_u8(0xA0); // tiny map, 0 entries
+}
+
+/// Send a chunked message.
+async fn send_msg(stream: &mut TcpStream, data: &[u8]) {
+    let mut out = BytesMut::new();
+    out.put_u16(data.len() as u16);
+    out.extend_from_slice(data);
+    out.put_u16(0); // end marker
+    stream.write_all(&out).await.unwrap();
+    stream.flush().await.unwrap();
+}
+
+/// Read one chunked message.
+async fn recv_msg(stream: &mut TcpStream) -> Vec<u8> {
+    let mut result = Vec::new();
+    loop {
+        let mut len_buf = [0u8; 2];
+        stream.read_exact(&mut len_buf).await.unwrap();
+        let chunk_len = u16::from_be_bytes(len_buf) as usize;
+        if chunk_len == 0 {
+            break;
+        }
+        let mut chunk = vec![0u8; chunk_len];
+        stream.read_exact(&mut chunk).await.unwrap();
+        result.extend_from_slice(&chunk);
+    }
+    result
+}
+
+/// Decode a struct header from raw bytes.
+fn decode_struct_header(data: &[u8]) -> (u8, u8, usize) {
+    let marker = data[0];
+    let n_fields = marker & 0x0F;
+    let sig = data[1];
+    (n_fields, sig, 2)
+}
+
+/// Simple value decoder for test assertions.
+#[derive(Debug, Clone, PartialEq)]
+enum TestValue {
+    Null,
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    Str(String),
+    List(Vec<TestValue>),
+    Map(HashMap<String, TestValue>),
+}
+
+fn decode_value(buf: &mut &[u8]) -> TestValue {
+    if buf.is_empty() {
+        panic!("unexpected end of data");
+    }
+    let marker = buf[0];
+    match marker {
+        0xC0 => {
+            buf.advance(1);
+            TestValue::Null
+        }
+        0xC2 => {
+            buf.advance(1);
+            TestValue::Bool(false)
+        }
+        0xC3 => {
+            buf.advance(1);
+            TestValue::Bool(true)
+        }
+        0xC1 => {
+            buf.advance(1);
+            TestValue::Float(buf.get_f64())
+        }
+        0xC8 => {
+            buf.advance(1);
+            TestValue::Int(buf.get_i8() as i64)
+        }
+        0xC9 => {
+            buf.advance(1);
+            TestValue::Int(buf.get_i16() as i64)
+        }
+        0xCA => {
+            buf.advance(1);
+            TestValue::Int(buf.get_i32() as i64)
+        }
+        0xCB => {
+            buf.advance(1);
+            TestValue::Int(buf.get_i64())
+        }
+        m if (0x80..=0x8F).contains(&m) => {
+            buf.advance(1);
+            let len = (m & 0x0F) as usize;
+            let s = std::str::from_utf8(&buf[..len]).unwrap().to_string();
+            buf.advance(len);
+            TestValue::Str(s)
+        }
+        0xD0 => {
+            buf.advance(1);
+            let len = buf.get_u8() as usize;
+            let s = std::str::from_utf8(&buf[..len]).unwrap().to_string();
+            buf.advance(len);
+            TestValue::Str(s)
+        }
+        0xD1 => {
+            buf.advance(1);
+            let len = buf.get_u16() as usize;
+            let s = std::str::from_utf8(&buf[..len]).unwrap().to_string();
+            buf.advance(len);
+            TestValue::Str(s)
+        }
+        m if (0x90..=0x9F).contains(&m) => {
+            buf.advance(1);
+            let len = (m & 0x0F) as usize;
+            let mut items = Vec::new();
+            for _ in 0..len {
+                items.push(decode_value(buf));
+            }
+            TestValue::List(items)
+        }
+        m if (0xA0..=0xAF).contains(&m) => {
+            buf.advance(1);
+            let len = (m & 0x0F) as usize;
+            let mut map = HashMap::new();
+            for _ in 0..len {
+                let key = match decode_value(buf) {
+                    TestValue::Str(s) => s,
+                    other => panic!("expected string key, got {other:?}"),
+                };
+                let val = decode_value(buf);
+                map.insert(key, val);
+            }
+            TestValue::Map(map)
+        }
+        0xD8 => {
+            buf.advance(1);
+            let len = buf.get_u8() as usize;
+            let mut map = HashMap::new();
+            for _ in 0..len {
+                let key = match decode_value(buf) {
+                    TestValue::Str(s) => s,
+                    other => panic!("expected string key, got {other:?}"),
+                };
+                let val = decode_value(buf);
+                map.insert(key, val);
+            }
+            TestValue::Map(map)
+        }
+        // Struct — decode as list of fields (skip sig)
+        m if (0xB0..=0xBF).contains(&m) => {
+            buf.advance(1);
+            let n = (m & 0x0F) as usize;
+            let _sig = buf.get_u8();
+            let mut items = Vec::new();
+            for _ in 0..n {
+                items.push(decode_value(buf));
+            }
+            TestValue::List(items)
+        }
+        // Tiny int
+        m => {
+            buf.advance(1);
+            TestValue::Int(m as i8 as i64)
+        }
+    }
+}
+
+/// Receive a message and return its signature + decoded fields.
+async fn recv_and_decode(stream: &mut TcpStream) -> (u8, Vec<TestValue>) {
+    let raw = recv_msg(stream).await;
+    let (n_fields, sig, offset) = decode_struct_header(&raw);
+    let mut slice: &[u8] = &raw[offset..];
+    let mut fields = Vec::new();
+    for _ in 0..n_fields {
+        fields.push(decode_value(&mut slice));
+    }
+    (sig, fields)
+}
+
+const SIG_SUCCESS: u8 = 0x70;
+const SIG_RECORD: u8 = 0x71;
+const SIG_FAILURE: u8 = 0x7F;
+
+/// Start the server on a random port, return the port.
+async fn start_server(db: GraphDb) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    tokio::spawn(async move {
+        loop {
+            match listener.accept().await {
+                Ok((stream, _)) => {
+                    let db = db.clone();
+                    tokio::spawn(async move {
+                        // Import the handler module via the binary crate.
+                        // Since we can't import from a bin crate, we'll inline
+                        // the connection handler via the library path.
+                        sparrowdb_bolt::handle_connection(stream, db).await;
+                    });
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    port
+}
+
+/// Perform the Bolt handshake.
+async fn do_handshake(stream: &mut TcpStream) {
+    // Send preamble: magic + 4 version proposals
+    let mut preamble = Vec::new();
+    preamble.extend_from_slice(&[0x60, 0x60, 0xB0, 0x17]); // magic
+                                                           // Version proposal 1: Bolt 4.4 (range=4, minor=0, major=4, padding=0)
+    preamble.extend_from_slice(&[4, 0, 4, 0]);
+    // Remaining 3 proposals: zeroes
+    preamble.extend_from_slice(&[0, 0, 0, 0]);
+    preamble.extend_from_slice(&[0, 0, 0, 0]);
+    preamble.extend_from_slice(&[0, 0, 0, 0]);
+    stream.write_all(&preamble).await.unwrap();
+
+    // Read 4-byte version response
+    let mut version = [0u8; 4];
+    stream.read_exact(&mut version).await.unwrap();
+    assert_eq!(version[2], 4, "should negotiate Bolt 4.x");
+}
+
+/// Send HELLO message.
+async fn do_hello(stream: &mut TcpStream) {
+    let mut buf = BytesMut::new();
+    encode_struct_header(&mut buf, 1, 0x01); // HELLO
+    encode_tiny_map(&mut buf, &[("user_agent", "sparrowdb-test/1.0")]);
+    send_msg(stream, &buf).await;
+
+    let (sig, _) = recv_and_decode(stream).await;
+    assert_eq!(sig, SIG_SUCCESS, "HELLO should return SUCCESS");
+}
+
+/// Send RUN + PULL and return all records.
+async fn run_query(stream: &mut TcpStream, query: &str) -> (u8, Vec<Vec<TestValue>>) {
+    // RUN
+    let mut buf = BytesMut::new();
+    encode_struct_header(&mut buf, 2, 0x10); // RUN
+    encode_string(&mut buf, query);
+    encode_empty_map(&mut buf); // params
+    send_msg(stream, &buf).await;
+
+    let (sig, _fields) = recv_and_decode(stream).await;
+    if sig == SIG_FAILURE {
+        return (sig, vec![]);
+    }
+    assert_eq!(sig, SIG_SUCCESS, "RUN should return SUCCESS");
+
+    // PULL
+    let mut buf = BytesMut::new();
+    encode_struct_header(&mut buf, 1, 0x3F); // PULL
+    encode_empty_map(&mut buf); // metadata
+    send_msg(stream, &buf).await;
+
+    // Read records
+    let mut records = Vec::new();
+    loop {
+        let (sig, fields) = recv_and_decode(stream).await;
+        if sig == SIG_RECORD {
+            // RECORD has one field: a list of values
+            if let Some(TestValue::List(row)) = fields.into_iter().next() {
+                records.push(row);
+            }
+        } else {
+            // SUCCESS or FAILURE
+            return (sig, records);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_bolt_create_and_match() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+
+    let port = start_server(db).await;
+
+    // Give server a moment to start
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
+
+    do_handshake(&mut stream).await;
+    do_hello(&mut stream).await;
+
+    // CREATE a node
+    let (sig, records) =
+        run_query(&mut stream, "CREATE (n:Test {name: 'hello'}) RETURN n.name").await;
+    assert_eq!(sig, SIG_SUCCESS, "CREATE query should succeed");
+    assert_eq!(records.len(), 1, "should return 1 row");
+    assert_eq!(
+        records[0],
+        vec![TestValue::Str("hello".into())],
+        "should return the name"
+    );
+
+    // MATCH the node
+    let (sig, records) = run_query(&mut stream, "MATCH (n:Test) RETURN n.name").await;
+    assert_eq!(sig, SIG_SUCCESS, "MATCH query should succeed");
+    assert_eq!(records.len(), 1, "should find 1 node");
+    assert_eq!(
+        records[0],
+        vec![TestValue::Str("hello".into())],
+        "should return the name"
+    );
+
+    // Send GOODBYE
+    let mut buf = BytesMut::new();
+    encode_struct_header(&mut buf, 0, 0x02); // GOODBYE
+    send_msg(&mut stream, &buf).await;
+}
+
+#[tokio::test]
+async fn test_bolt_error_handling() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+
+    let port = start_server(db).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
+
+    do_handshake(&mut stream).await;
+    do_hello(&mut stream).await;
+
+    // Run an invalid query
+    let (sig, _) = run_query(&mut stream, "THIS IS NOT VALID CYPHER").await;
+    assert_eq!(sig, SIG_FAILURE, "invalid query should return FAILURE");
+
+    // After FAILURE, need RESET to continue
+    let mut buf = BytesMut::new();
+    encode_struct_header(&mut buf, 0, 0x0F); // RESET
+    send_msg(&mut stream, &buf).await;
+
+    let (sig, _) = recv_and_decode(&mut stream).await;
+    assert_eq!(sig, SIG_SUCCESS, "RESET should return SUCCESS");
+
+    // Now we should be able to run queries again
+    let (sig, records) = run_query(&mut stream, "RETURN 42 AS num").await;
+    assert_eq!(sig, SIG_SUCCESS);
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0], vec![TestValue::Int(42)]);
+}


### PR DESCRIPTION
## Summary
- New crate `sparrowdb-bolt` implementing a Bolt v4.x TCP server on port 7687
- Implements PackStream v1 encoding/decoding and chunked transport framing from scratch
- Full Bolt state machine: HELLO → READY → RUN/PULL → STREAMING with RESET/GOODBYE support
- Routes Cypher queries to `GraphDb::execute()` and maps SparrowDB `Value` types to Bolt wire values
- CLI binary with `--db-path`, `--host`, and `--port` args (env var `SPARROWDB_PATH` supported)
- Handles concurrent connections via `tokio::spawn` per connection
- Integration tests verify CREATE+RETURN, MATCH+RETURN, error handling, and RESET recovery

## Test plan
- [x] `cargo check -p sparrowdb-bolt` passes cleanly (no warnings)
- [x] `cargo test -p sparrowdb-bolt` passes (2 integration tests)
- [x] `cargo fmt --all` applied
- [ ] Manual test with gdotv connecting to `sparrowdb-bolt --db-path /tmp/testdb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Bolt protocol server implementation, enabling Neo4j-compatible driver connections to SparrowDB
  * Server supports Cypher query execution with configurable host and port settings
  * Includes connection state management and concurrent connection limits

* **Tests**
  * Added integration tests for Bolt protocol functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->