### PR TITLE
feat(cypher): general CALL { } subquery support (closes #290)

### DIFF
--- a/crates/sparrowdb-cypher/src/ast.rs
+++ b/crates/sparrowdb-cypher/src/ast.rs
@@ -377,6 +377,15 @@ pub enum PipelineStage {
     /// `UNWIND alias_expr AS new_alias` — unwind a list variable from the preceding
     /// WITH into individual rows.
     Unwind { alias: String, new_alias: String },
+    /// `CALL { [WITH var1, var2] inner_stmt }` — inline subquery stage (issue #290).
+    ///
+    /// For each outer row the `subquery` is executed (optionally seeded with the
+    /// imported variables) and the subquery's output columns are appended to the
+    /// outer row, producing a cross product / nested-loop join.
+    CallSubquery {
+        subquery: Box<Statement>,
+        imports: Vec<String>,
+    },
 }
 
 /// A multi-clause Cypher pipeline (SPA-134).
@@ -507,5 +516,20 @@ pub enum Statement {
     CreateConstraint {
         label: String,
         property: String,
+    },
+    /// `CALL { subquery } [RETURN …]` — standalone unit subquery (issue #290).
+    ///
+    /// A unit subquery (no `imports`) is executed independently once and its
+    /// output rows are extended with the optional trailing `RETURN` clause.
+    ///
+    /// When embedded inside a pipeline (as a `PipelineStage::CallSubquery`),
+    /// this variant is **not** used — use `PipelineStage::CallSubquery` instead.
+    CallSubquery {
+        /// The statement inside `{ … }`.
+        subquery: Box<Statement>,
+        /// Variables imported from the outer scope via `CALL { WITH x, y … }`.
+        imports: Vec<String>,
+        /// Optional trailing `RETURN` clause projecting subquery columns.
+        return_clause: Option<ReturnClause>,
     },
 }

--- a/crates/sparrowdb-cypher/src/ast.rs
+++ b/crates/sparrowdb-cypher/src/ast.rs
@@ -531,5 +531,13 @@ pub enum Statement {
         imports: Vec<String>,
         /// Optional trailing `RETURN` clause projecting subquery columns.
         return_clause: Option<ReturnClause>,
+        /// Optional `ORDER BY` on the outer RETURN (may be empty).
+        return_order_by: Vec<(Expr, SortDir)>,
+        /// Optional `SKIP` on the outer RETURN.
+        return_skip: Option<u64>,
+        /// Optional `LIMIT` on the outer RETURN.
+        return_limit: Option<u64>,
+        /// Whether the outer RETURN is `RETURN DISTINCT …`.
+        return_distinct: bool,
     },
 }

--- a/crates/sparrowdb-cypher/src/binder.rs
+++ b/crates/sparrowdb-cypher/src/binder.rs
@@ -74,6 +74,9 @@ pub fn bind(stmt: Statement, catalog: &Catalog) -> Result<BoundStatement> {
         // Pipeline: label binding is deferred to execution time (SPA-134).
         Statement::Pipeline(_) => {}
         Statement::CreateIndex { .. } | Statement::CreateConstraint { .. } => {}
+        // CALL { } subquery: label binding is deferred to the subquery's own
+        // execution path, which recurses through bind/execute internally.
+        Statement::CallSubquery { .. } => {}
     }
     Ok(BoundStatement { inner: stmt })
 }

--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -440,6 +440,13 @@ impl Parser {
                 // MATCH … OPTIONAL MATCH … RETURN
                 self.parse_match_optional_match_tail(patterns, None)
             }
+            Token::Call => {
+                // MATCH … CALL { } … RETURN — route into the pipeline engine.
+                // Consume CALL and parse as a pipeline with the CALL as first stage.
+                self.advance(); // consume CALL
+                let call_stage = self.parse_call_subquery_stage()?;
+                self.parse_pipeline_continuation(Some(patterns), None, None, vec![call_stage])
+            }
             other => Err(Error::InvalidArgument(format!(
                 "unexpected token after MATCH pattern: {:?}",
                 other
@@ -1083,6 +1090,12 @@ impl Parser {
                     let new_alias = self.expect_ident()?;
                     stages.push(PipelineStage::Unwind { alias, new_alias });
                 }
+                Token::Call => {
+                    // Parse a CALL { } subquery stage inside a pipeline.
+                    self.advance(); // consume CALL
+                    let stage = self.parse_call_subquery_stage()?;
+                    stages.push(stage);
+                }
                 Token::Return => {
                     // Terminal clause.
                     self.advance(); // consume RETURN
@@ -1159,7 +1172,7 @@ impl Parser {
                 }
                 other => {
                     return Err(Error::InvalidArgument(format!(
-                        "expected MATCH, WITH, UNWIND, or RETURN in pipeline, got {:?}",
+                        "expected MATCH, WITH, UNWIND, CALL, or RETURN in pipeline, got {:?}",
                         other
                     )))
                 }
@@ -2337,6 +2350,105 @@ impl Parser {
         Ok(items)
     }
 
+    // ── CALL { } subquery (issue #290) ──────────────────────────────────────
+
+    /// Entry point when we have already consumed `CALL` and see `{`.
+    ///
+    /// `imports` carries any variable names parsed from a preceding `WITH`
+    /// clause (correlated form).  For unit subqueries `imports` is empty.
+    fn parse_call_subquery(&mut self, imports: Vec<String>) -> Result<Statement> {
+        self.expect_tok(&Token::LBrace)?;
+        self.parse_call_subquery_body(imports)
+    }
+
+    /// Parse the body `[WITH imports] inner_stmt }` after the `{` has been consumed.
+    ///
+    /// Handles the optional `WITH var1, var2` import list at the start of the
+    /// subquery body (correlated form).  After the closing `}`, also looks for
+    /// an optional trailing `RETURN` clause for standalone usage.
+    fn parse_call_subquery_body(&mut self, pre_imports: Vec<String>) -> Result<Statement> {
+        // Parse optional WITH imports inside the brace (correlated form).
+        let imports = if pre_imports.is_empty() && matches!(self.peek(), Token::With) {
+            self.advance(); // consume WITH
+            let mut imports = Vec::new();
+            loop {
+                imports.push(self.expect_ident()?);
+                if matches!(self.peek(), Token::Comma) {
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+            imports
+        } else {
+            pre_imports
+        };
+
+        let subquery = self.parse_statement()?;
+        self.expect_tok(&Token::RBrace)?;
+
+        // Optional trailing RETURN clause for standalone `CALL { } RETURN ...`.
+        let return_clause = if matches!(self.peek(), Token::Return) {
+            self.advance(); // consume RETURN
+            let _distinct = if matches!(self.peek(), Token::Distinct) {
+                self.advance();
+                true
+            } else {
+                false
+            };
+            let items = self.parse_return_items()?;
+            Some(ReturnClause { items })
+        } else {
+            None
+        };
+
+        Ok(Statement::CallSubquery {
+            subquery: Box::new(subquery),
+            imports,
+            return_clause,
+        })
+    }
+
+    /// Parse a `CALL { [WITH imports] inner_stmt }` as a `PipelineStage`.
+    ///
+    /// Called from `parse_pipeline_continuation` when a `CALL` token is seen.
+    /// The leading `CALL` token must already have been consumed by the caller.
+    fn parse_call_subquery_stage(&mut self) -> Result<PipelineStage> {
+        // Check for correlated form: `CALL { WITH var1, var2 inner ... }`
+        // The `CALL` has already been consumed; now we decide based on next token.
+        //
+        // Correlated: `CALL { WITH x MATCH ... }`
+        // Unit:       `CALL { MATCH ... }`
+        //
+        // Both start with `{` here since `parse_pipeline_continuation` sees
+        // the token *before* consuming CALL.
+        self.expect_tok(&Token::LBrace)?;
+
+        // Parse optional WITH imports inside the brace.
+        let imports = if matches!(self.peek(), Token::With) {
+            self.advance(); // consume WITH
+            let mut imports = Vec::new();
+            loop {
+                imports.push(self.expect_ident()?);
+                if matches!(self.peek(), Token::Comma) {
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+            imports
+        } else {
+            vec![]
+        };
+
+        let subquery = self.parse_statement()?;
+        self.expect_tok(&Token::RBrace)?;
+        Ok(PipelineStage::CallSubquery {
+            subquery: Box::new(subquery),
+            imports,
+        })
+    }
+
     // ── CALL procedure(args) YIELD col [RETURN ...] ───────────────────────────
 
     /// Parse `CALL proc.name(args) YIELD col1, col2 [RETURN ...]`.
@@ -2348,6 +2460,13 @@ impl Parser {
     /// projects them further.
     fn parse_call(&mut self) -> Result<Statement> {
         self.expect_tok(&Token::Call)?;
+
+        // If the next token is `{`, this is a CALL { } subquery (issue #290),
+        // not a procedure call.  The WITH import list (for correlated form) lives
+        // *inside* the braces: `CALL { WITH n MATCH ... }`.
+        if matches!(self.peek(), Token::LBrace) {
+            return self.parse_call_subquery(vec![]);
+        }
 
         // Parse dotted procedure name: ident (. ident)*
         // Use advance_as_prop_name for all segments so that keyword tokens like

--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -416,6 +416,17 @@ impl Parser {
                         // MATCH … WHERE … MERGE (a)-[r:TYPE]->(b)
                         self.parse_match_merge_rel_tail(patterns, Some(where_expr))
                     }
+                    Token::Call => {
+                        // MATCH … WHERE … CALL { } … RETURN — pipeline with WHERE guard.
+                        self.advance(); // consume CALL
+                        let call_stage = self.parse_call_subquery_stage()?;
+                        self.parse_pipeline_continuation(
+                            Some(patterns),
+                            Some(where_expr),
+                            None,
+                            vec![call_stage],
+                        )
+                    }
                     _ => {
                         // Fall through to RETURN parsing with the parsed WHERE expr.
                         self.finish_match_return(patterns, Some(where_expr))
@@ -950,8 +961,8 @@ impl Parser {
                     distinct,
                 }))
             }
-            // Continuation clause: MATCH, WITH, or UNWIND → build Pipeline.
-            Token::Match | Token::With | Token::Unwind => {
+            // Continuation clause: MATCH, WITH, UNWIND, or CALL {} → build Pipeline.
+            Token::Match | Token::With | Token::Unwind | Token::Call => {
                 let first_with_stage = PipelineStage::With {
                     clause: with_clause,
                     order_by: with_order_by,
@@ -966,7 +977,7 @@ impl Parser {
                 )
             }
             other => Err(Error::InvalidArgument(format!(
-                "expected RETURN, MATCH, WITH, or UNWIND after WITH clause, got {:?}",
+                "expected RETURN, MATCH, WITH, UNWIND, or CALL after WITH clause, got {:?}",
                 other
             ))),
         }
@@ -2396,24 +2407,69 @@ impl Parser {
         self.expect_tok(&Token::RBrace)?;
 
         // Optional trailing RETURN clause for standalone `CALL { } RETURN ...`.
-        let return_clause = if matches!(self.peek(), Token::Return) {
-            self.advance(); // consume RETURN
-            let _distinct = if matches!(self.peek(), Token::Distinct) {
-                self.advance();
-                true
+        let (return_clause, return_distinct, return_order_by, return_skip, return_limit) =
+            if matches!(self.peek(), Token::Return) {
+                self.advance(); // consume RETURN
+                let distinct = if matches!(self.peek(), Token::Distinct) {
+                    self.advance();
+                    true
+                } else {
+                    false
+                };
+                let items = self.parse_return_items()?;
+                // Parse optional ORDER BY / SKIP / LIMIT modifiers.
+                let order_by = if matches!(self.peek(), Token::Order) {
+                    self.advance(); // consume ORDER
+                    self.expect_tok(&Token::By)?;
+                    self.parse_order_by_items()?
+                } else {
+                    vec![]
+                };
+                let skip = if matches!(self.peek(), Token::Skip) {
+                    self.advance();
+                    match self.advance().clone() {
+                        Token::Integer(n) if n >= 0 => Some(n as u64),
+                        _ => {
+                            return Err(Error::InvalidArgument(
+                                "SKIP expects a non-negative integer".into(),
+                            ))
+                        }
+                    }
+                } else {
+                    None
+                };
+                let limit = if matches!(self.peek(), Token::Limit) {
+                    self.advance();
+                    match self.advance().clone() {
+                        Token::Integer(n) if n > 0 => Some(n as u64),
+                        _ => {
+                            return Err(Error::InvalidArgument(
+                                "LIMIT expects a positive integer".into(),
+                            ))
+                        }
+                    }
+                } else {
+                    None
+                };
+                (
+                    Some(ReturnClause { items }),
+                    distinct,
+                    order_by,
+                    skip,
+                    limit,
+                )
             } else {
-                false
+                (None, false, vec![], None, None)
             };
-            let items = self.parse_return_items()?;
-            Some(ReturnClause { items })
-        } else {
-            None
-        };
 
         Ok(Statement::CallSubquery {
             subquery: Box::new(subquery),
             imports,
             return_clause,
+            return_order_by,
+            return_skip,
+            return_limit,
+            return_distinct,
         })
     }
 

--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -2352,6 +2352,23 @@ impl Parser {
 
     // ── CALL { } subquery (issue #290) ──────────────────────────────────────
 
+    /// Parse a comma-separated list of import identifiers after `WITH` inside a
+    /// subquery body.  The `WITH` keyword must already have been consumed.
+    ///
+    /// Returns the list of imported variable names.
+    fn parse_subquery_import_list(&mut self) -> Result<Vec<String>> {
+        let mut imports = Vec::new();
+        loop {
+            imports.push(self.expect_ident()?);
+            if matches!(self.peek(), Token::Comma) {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+        Ok(imports)
+    }
+
     /// Entry point when we have already consumed `CALL` and see `{`.
     ///
     /// `imports` carries any variable names parsed from a preceding `WITH`
@@ -2370,16 +2387,7 @@ impl Parser {
         // Parse optional WITH imports inside the brace (correlated form).
         let imports = if pre_imports.is_empty() && matches!(self.peek(), Token::With) {
             self.advance(); // consume WITH
-            let mut imports = Vec::new();
-            loop {
-                imports.push(self.expect_ident()?);
-                if matches!(self.peek(), Token::Comma) {
-                    self.advance();
-                } else {
-                    break;
-                }
-            }
-            imports
+            self.parse_subquery_import_list()?
         } else {
             pre_imports
         };
@@ -2427,16 +2435,7 @@ impl Parser {
         // Parse optional WITH imports inside the brace.
         let imports = if matches!(self.peek(), Token::With) {
             self.advance(); // consume WITH
-            let mut imports = Vec::new();
-            loop {
-                imports.push(self.expect_ident()?);
-                if matches!(self.peek(), Token::Comma) {
-                    self.advance();
-                } else {
-                    break;
-                }
-            }
-            imports
+            self.parse_subquery_import_list()?
         } else {
             vec![]
         };

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -857,6 +857,11 @@ impl Engine {
             Statement::CreateConstraint { label, property } => {
                 self.execute_create_constraint(&label, &property)
             }
+            Statement::CallSubquery {
+                subquery,
+                imports,
+                return_clause,
+            } => self.execute_call_subquery(&subquery, &imports, return_clause.as_ref()),
         }
     }
 
@@ -962,6 +967,7 @@ mod path;
 pub mod pipeline_exec;
 mod procedure;
 mod scan;
+mod subquery;
 
 // ── Free-standing prop-filter helper (usable without &self) ───────────────────
 
@@ -2720,7 +2726,7 @@ fn evaluate_aggregate_expr(
 }
 
 /// Returns `true` if any RETURN item is an aggregate expression.
-fn has_aggregate_in_return(items: &[ReturnItem]) -> bool {
+pub(crate) fn has_aggregate_in_return(items: &[ReturnItem]) -> bool {
     items.iter().any(|item| is_aggregate_expr(&item.expr))
 }
 

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -861,7 +861,19 @@ impl Engine {
                 subquery,
                 imports,
                 return_clause,
-            } => self.execute_call_subquery(&subquery, &imports, return_clause.as_ref()),
+                return_order_by,
+                return_skip,
+                return_limit,
+                return_distinct,
+            } => self.execute_call_subquery(
+                &subquery,
+                &imports,
+                return_clause.as_ref(),
+                &return_order_by,
+                return_skip,
+                return_limit,
+                return_distinct,
+            ),
         }
     }
 
@@ -875,6 +887,10 @@ impl Engine {
             // write-transaction path to ensure WAL durability and correct
             // single-writer semantics, regardless of whether edges are present.
             Statement::Create(_) => true,
+            // Recursively check CALL { } subqueries so that a mutation inside
+            // the braces is routed through the write-transaction path rather than
+            // being silently dispatched via the read path and failing late.
+            Statement::CallSubquery { subquery, .. } => Self::is_mutation(subquery),
             _ => false,
         }
     }

--- a/crates/sparrowdb-execution/src/engine/scan.rs
+++ b/crates/sparrowdb-execution/src/engine/scan.rs
@@ -7,28 +7,63 @@ impl Engine {
     /// Executes stages left-to-right, passing the intermediate row set from
     /// one stage to the next, then projects the final RETURN clause.
     pub(crate) fn execute_pipeline(&self, p: &PipelineStatement) -> Result<QueryResult> {
+        self.execute_pipeline_inner(p, None)
+    }
+
+    /// Execute a pipeline seeded with an explicit initial row set.
+    ///
+    /// Used by correlated `CALL { WITH imports … }` to inject outer row bindings
+    /// into the pipeline instead of scanning from the leading MATCH/UNWIND.
+    pub(crate) fn execute_pipeline_seeded(
+        &self,
+        p: &PipelineStatement,
+        seed_rows: Vec<HashMap<String, Value>>,
+    ) -> Result<QueryResult> {
+        self.execute_pipeline_inner(p, Some(seed_rows))
+    }
+
+    /// Shared implementation for [`execute_pipeline`] and [`execute_pipeline_seeded`].
+    fn execute_pipeline_inner(
+        &self,
+        p: &PipelineStatement,
+        seed_rows: Option<Vec<HashMap<String, Value>>>,
+    ) -> Result<QueryResult> {
         // Step 1: Produce the initial row set from the leading clause.
-        let mut current_rows: Vec<HashMap<String, Value>> =
-            if let Some((expr, alias)) = &p.leading_unwind {
-                // UNWIND-led pipeline: expand the list into individual rows.
-                let values = eval_list_expr(expr, &self.params)?;
-                values
-                    .into_iter()
-                    .map(|v| {
-                        let mut m = HashMap::new();
-                        m.insert(alias.clone(), v);
-                        m
-                    })
-                    .collect()
-            } else if let Some(ref patterns) = p.leading_match {
-                // MATCH-led pipeline: scan the graph.
-                // For the pipeline we need a dummy WithClause (scan will collect all
-                // col IDs needed by subsequent stages).  Use a wide scan that includes
-                // NodeRefs for EXISTS support.
-                self.collect_pipeline_match_rows(patterns, p.leading_where.as_ref())?
+        let mut current_rows: Vec<HashMap<String, Value>> = if let Some(seeds) = seed_rows {
+            // Seeded pipeline (correlated subquery): start from outer bindings.
+            if let Some(ref patterns) = p.leading_match {
+                // Re-traverse graph for each seeded binding using the pipeline MATCH runner.
+                let where_clause = p.leading_where.as_ref();
+                let mut rows = Vec::new();
+                for binding in &seeds {
+                    let new_rows =
+                        self.execute_pipeline_match_stage(patterns, where_clause, binding)?;
+                    rows.extend(new_rows);
+                }
+                rows
             } else {
-                vec![HashMap::new()]
-            };
+                seeds
+            }
+        } else if let Some((expr, alias)) = &p.leading_unwind {
+            // UNWIND-led pipeline: expand the list into individual rows.
+            let values = eval_list_expr(expr, &self.params)?;
+            values
+                .into_iter()
+                .map(|v| {
+                    let mut m = HashMap::new();
+                    m.insert(alias.clone(), v);
+                    m
+                })
+                .collect()
+        } else if let Some(ref patterns) = p.leading_match {
+            // MATCH-led pipeline: scan the graph.
+            // For the pipeline we need a dummy WithClause (scan will collect all
+            // col IDs needed by subsequent stages).  Use a wide scan that includes
+            // NodeRefs for EXISTS support.
+            self.collect_pipeline_match_rows(patterns, p.leading_where.as_ref())?
+        } else {
+            vec![HashMap::new()]
+        };
 
         // Step 2: Execute pipeline stages in order.
         for stage in &p.stages {
@@ -203,16 +238,24 @@ impl Engine {
             current_rows.truncate(lim as usize);
         }
 
-        let mut rows: Vec<Vec<Value>> = current_rows
-            .iter()
-            .map(|row_vals| {
-                p.return_clause
-                    .items
-                    .iter()
-                    .map(|item| self.eval_expr_graph(&item.expr, row_vals))
-                    .collect()
-            })
-            .collect();
+        let has_agg = has_aggregate_in_return(&p.return_clause.items);
+        let mut rows: Vec<Vec<Value>> = if has_agg {
+            // Aggregate RETURN items (COUNT, SUM, collect, etc.) need grouping.
+            // This handles correlated subqueries whose inner MATCH returns zero rows —
+            // aggregate functions must still produce one output row (e.g. count = 0).
+            self.aggregate_rows_graph(&current_rows, &p.return_clause.items)
+        } else {
+            current_rows
+                .iter()
+                .map(|row_vals| {
+                    p.return_clause
+                        .items
+                        .iter()
+                        .map(|item| self.eval_expr_graph(&item.expr, row_vals))
+                        .collect()
+                })
+                .collect()
+        };
 
         if p.distinct {
             deduplicate_rows(&mut rows);

--- a/crates/sparrowdb-execution/src/engine/scan.rs
+++ b/crates/sparrowdb-execution/src/engine/scan.rs
@@ -164,6 +164,11 @@ impl Engine {
                     }
                     current_rows = next_rows;
                 }
+                PipelineStage::CallSubquery { subquery, imports } => {
+                    // Execute a CALL { } subquery stage for each outer row.
+                    current_rows =
+                        self.execute_pipeline_call_subquery_stage(subquery, imports, current_rows)?;
+                }
             }
         }
 

--- a/crates/sparrowdb-execution/src/engine/subquery.rs
+++ b/crates/sparrowdb-execution/src/engine/subquery.rs
@@ -5,9 +5,7 @@
 
 use std::collections::HashMap;
 
-use sparrowdb_cypher::ast::{
-    PipelineStage, PipelineStatement, ReturnClause, Statement, WithClause,
-};
+use sparrowdb_cypher::ast::{PipelineStatement, ReturnClause, Statement};
 
 use super::*;
 use crate::types::{QueryResult, Value};
@@ -54,29 +52,39 @@ impl Engine {
                 })
                 .collect();
 
+            // Only build the env map if at least one RETURN item needs expression eval
+            // (non-Var expressions).  For the common case of bare variable projections
+            // we skip the per-row allocation entirely.
+            let needs_env = ret
+                .items
+                .iter()
+                .any(|item| !matches!(item.expr, sparrowdb_cypher::ast::Expr::Var(_)));
+
             let out_rows: Vec<Vec<Value>> = inner
                 .rows
                 .iter()
                 .map(|row| {
-                    // Build an env map from the inner row.
-                    let env: HashMap<String, Value> = inner
-                        .columns
-                        .iter()
-                        .zip(row.iter())
-                        .map(|(k, v)| (k.clone(), v.clone()))
-                        .collect();
+                    let env: Option<HashMap<String, Value>> = if needs_env {
+                        Some(
+                            inner
+                                .columns
+                                .iter()
+                                .zip(row.iter())
+                                .map(|(k, v)| (k.clone(), v.clone()))
+                                .collect(),
+                        )
+                    } else {
+                        None
+                    };
                     ret.items
                         .iter()
-                        .map(|item| {
-                            // Try direct column lookup first, then full expression eval.
-                            match &item.expr {
-                                sparrowdb_cypher::ast::Expr::Var(name) => col_idx
-                                    .get(name.as_str())
-                                    .and_then(|&i| row.get(i))
-                                    .cloned()
-                                    .unwrap_or(Value::Null),
-                                other => eval_expr(other, &env),
-                            }
+                        .map(|item| match &item.expr {
+                            sparrowdb_cypher::ast::Expr::Var(name) => col_idx
+                                .get(name.as_str())
+                                .and_then(|&i| row.get(i))
+                                .cloned()
+                                .unwrap_or(Value::Null),
+                            other => eval_expr(other, env.as_ref().expect("env present")),
                         })
                         .collect()
                 })
@@ -117,10 +125,13 @@ impl Engine {
             // Unit subquery: execute once, cross-join with every outer row.
             let inner = self.execute_read_stmt(subquery)?;
             let inner_col_names: Vec<&str> = inner.columns.iter().map(|s| s.as_str()).collect();
+            let inner_col_count = inner_col_names.len();
 
             for outer_row in &current_rows {
                 for inner_row in &inner.rows {
-                    let mut merged = outer_row.clone();
+                    // Pre-allocate to avoid repeated rehashing during inserts.
+                    let mut merged = HashMap::with_capacity(outer_row.len() + inner_col_count);
+                    merged.extend(outer_row.iter().map(|(k, v)| (k.clone(), v.clone())));
                     for (col, val) in inner_col_names.iter().zip(inner_row.iter()) {
                         merged.insert(col.to_string(), val.clone());
                     }
@@ -132,9 +143,11 @@ impl Engine {
             for outer_row in &current_rows {
                 let inner = self.execute_read_stmt_with_bindings(subquery, imports, outer_row)?;
                 let inner_col_names: Vec<&str> = inner.columns.iter().map(|s| s.as_str()).collect();
+                let inner_col_count = inner_col_names.len();
 
                 for inner_row in &inner.rows {
-                    let mut merged = outer_row.clone();
+                    let mut merged = HashMap::with_capacity(outer_row.len() + inner_col_count);
+                    merged.extend(outer_row.iter().map(|(k, v)| (k.clone(), v.clone())));
                     for (col, val) in inner_col_names.iter().zip(inner_row.iter()) {
                         merged.insert(col.to_string(), val.clone());
                     }
@@ -190,11 +203,11 @@ impl Engine {
             for key in imports {
                 let nid_key = format!("{key}.__node_id__");
                 if let Some(val) = outer_row.get(&nid_key) {
-                    b.insert(nid_key, val.clone());
+                    b.insert(nid_key.clone(), val.clone());
                 }
                 if let Some(nr @ Value::NodeRef(_)) = outer_row.get(key) {
                     b.insert(key.clone(), nr.clone());
-                    b.insert(format!("{key}.__node_id__"), nr.clone());
+                    b.insert(nid_key, nr.clone());
                 }
             }
             b
@@ -229,6 +242,22 @@ impl Engine {
                     self.execute_pipeline(p)
                 }
             }
+            // For these statement variants, correlated import injection is not
+            // supported (they have no leading MATCH we can seed).  If the caller
+            // supplied imports, return a clear error rather than silently ignoring
+            // the bindings and producing wrong results.
+            Statement::MatchWith(_)
+            | Statement::OptionalMatch(_)
+            | Statement::MatchOptionalMatch(_)
+            | Statement::Unwind(_)
+                if use_seeded =>
+            {
+                Err(sparrowdb_common::Error::InvalidArgument(
+                    "CALL { WITH … }: correlated imports are not supported for this subquery form; \
+                     use MATCH … RETURN … or a Pipeline inside CALL { }"
+                        .to_string(),
+                ))
+            }
             Statement::MatchWith(mw) => self.execute_match_with(mw),
             Statement::OptionalMatch(om) => self.execute_optional_match(om),
             Statement::MatchOptionalMatch(mom) => self.execute_match_optional_match(mom),
@@ -249,200 +278,7 @@ impl Engine {
             ))),
         }
     }
-
-    /// Execute a `PipelineStatement` seeded with an initial set of rows instead
-    /// of scanning from the leading MATCH/UNWIND clause.
-    ///
-    /// Used by correlated `CALL { WITH imports … }` to feed the outer row
-    /// binding directly into the pipeline's first MATCH stage.
-    fn execute_pipeline_seeded(
-        &self,
-        p: &PipelineStatement,
-        seed_rows: Vec<HashMap<String, Value>>,
-    ) -> Result<QueryResult> {
-        // Start from the seed rows rather than scanning the leading MATCH.
-        let mut current_rows = if let Some(ref patterns) = p.leading_match {
-            // Re-traverse graph for each seeded binding using the pipeline MATCH runner.
-            let where_clause = p.leading_where.as_ref();
-            let mut rows = Vec::new();
-            for binding in &seed_rows {
-                let new_rows =
-                    self.execute_pipeline_match_stage(patterns, where_clause, binding)?;
-                rows.extend(new_rows);
-            }
-            rows
-        } else {
-            seed_rows
-        };
-
-        // Execute subsequent pipeline stages (reuse existing logic).
-        for stage in &p.stages {
-            match stage {
-                PipelineStage::With {
-                    clause,
-                    order_by,
-                    skip,
-                    limit,
-                } => {
-                    current_rows =
-                        self.apply_with_stage(current_rows, clause, order_by, skip, limit)?;
-                }
-                PipelineStage::Match {
-                    patterns,
-                    where_clause,
-                } => {
-                    let mut next = Vec::new();
-                    for binding in &current_rows {
-                        let new_rows = self.execute_pipeline_match_stage(
-                            patterns,
-                            where_clause.as_ref(),
-                            binding,
-                        )?;
-                        next.extend(new_rows);
-                    }
-                    current_rows = next;
-                }
-                PipelineStage::Unwind { alias, new_alias } => {
-                    let mut next = Vec::new();
-                    for row in &current_rows {
-                        let list_val = row.get(alias.as_str()).cloned().unwrap_or(Value::Null);
-                        let items = match list_val {
-                            Value::List(v) => v,
-                            other => vec![other],
-                        };
-                        for item in items {
-                            let mut new_row = row.clone();
-                            new_row.insert(new_alias.clone(), item);
-                            next.push(new_row);
-                        }
-                    }
-                    current_rows = next;
-                }
-                PipelineStage::CallSubquery { subquery, imports } => {
-                    current_rows =
-                        self.execute_pipeline_call_subquery_stage(subquery, imports, current_rows)?;
-                }
-            }
-        }
-
-        // Project the RETURN clause.
-        let column_names = extract_return_column_names(&p.return_clause.items);
-        let has_agg = has_aggregate_in_return(&p.return_clause.items);
-        let mut rows: Vec<Vec<Value>> = if has_agg {
-            // Aggregate RETURN items (COUNT, SUM, collect, etc.) need grouping.
-            self.aggregate_rows_graph(&current_rows, &p.return_clause.items)
-        } else {
-            current_rows
-                .iter()
-                .map(|row_vals| {
-                    p.return_clause
-                        .items
-                        .iter()
-                        .map(|item| self.eval_expr_graph(&item.expr, row_vals))
-                        .collect()
-                })
-                .collect()
-        };
-
-        if p.distinct {
-            deduplicate_rows(&mut rows);
-        }
-
-        Ok(QueryResult {
-            columns: column_names,
-            rows,
-        })
-    }
-
-    // ── WITH stage helper (extracted for reuse in seeded pipeline) ────────────
-
-    /// Apply a `PipelineStage::With` to a set of current rows.
-    fn apply_with_stage(
-        &self,
-        mut current_rows: Vec<HashMap<String, Value>>,
-        clause: &WithClause,
-        order_by: &[(sparrowdb_cypher::ast::Expr, SortDir)],
-        skip: &Option<u64>,
-        limit: &Option<u64>,
-    ) -> Result<Vec<HashMap<String, Value>>> {
-        if !order_by.is_empty() {
-            current_rows.sort_by(|a, b| {
-                for (expr, dir) in order_by {
-                    let va = eval_expr(expr, a);
-                    let vb = eval_expr(expr, b);
-                    let cmp = compare_values(&va, &vb);
-                    let cmp = if *dir == SortDir::Desc {
-                        cmp.reverse()
-                    } else {
-                        cmp
-                    };
-                    if cmp != std::cmp::Ordering::Equal {
-                        return cmp;
-                    }
-                }
-                std::cmp::Ordering::Equal
-            });
-        }
-        if let Some(s) = skip {
-            let s = (*s as usize).min(current_rows.len());
-            current_rows.drain(0..s);
-        }
-        if let Some(l) = limit {
-            current_rows.truncate(*l as usize);
-        }
-
-        let has_agg = clause
-            .items
-            .iter()
-            .any(|item| is_aggregate_expr(&item.expr));
-        let next_rows = if has_agg {
-            let agg_rows = self.aggregate_with_items(&current_rows, &clause.items);
-            agg_rows
-                .into_iter()
-                .filter(|with_vals| {
-                    if let Some(ref where_expr) = clause.where_clause {
-                        let mut wv = with_vals.clone();
-                        wv.extend(self.dollar_params());
-                        self.eval_where_graph(where_expr, &wv)
-                    } else {
-                        true
-                    }
-                })
-                .map(|mut with_vals| {
-                    with_vals.extend(self.dollar_params());
-                    with_vals
-                })
-                .collect()
-        } else {
-            let mut next = Vec::new();
-            for row_vals in &current_rows {
-                let mut with_vals: HashMap<String, Value> = HashMap::new();
-                for item in &clause.items {
-                    let val = self.eval_expr_graph(&item.expr, row_vals);
-                    with_vals.insert(item.alias.clone(), val);
-                    if let sparrowdb_cypher::ast::Expr::Var(ref src_var) = item.expr {
-                        if let Some(nr @ Value::NodeRef(_)) = row_vals.get(src_var) {
-                            with_vals.insert(item.alias.clone(), nr.clone());
-                            with_vals.insert(format!("{}.__node_id__", item.alias), nr.clone());
-                        }
-                        let nid_key = format!("{src_var}.__node_id__");
-                        if let Some(nr) = row_vals.get(&nid_key) {
-                            with_vals.insert(format!("{}.__node_id__", item.alias), nr.clone());
-                        }
-                    }
-                }
-                if let Some(ref where_expr) = clause.where_clause {
-                    let mut wv = with_vals.clone();
-                    wv.extend(self.dollar_params());
-                    if !self.eval_where_graph(where_expr, &wv) {
-                        continue;
-                    }
-                }
-                with_vals.extend(self.dollar_params());
-                next.push(with_vals);
-            }
-            next
-        };
-        Ok(next_rows)
-    }
 }
+// NOTE: `execute_pipeline_seeded` lives in `scan.rs` as part of the shared pipeline
+// implementation.  Correlated subquery execution delegates to that method to avoid
+// duplicating the pipeline stage loop.

--- a/crates/sparrowdb-execution/src/engine/subquery.rs
+++ b/crates/sparrowdb-execution/src/engine/subquery.rs
@@ -23,23 +23,34 @@ impl Engine {
     /// MATCH) is not meaningful because there is no outer scope to import from.
     /// In that case the imports are silently ignored and the subquery runs as a
     /// unit subquery.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn execute_call_subquery(
         &self,
         subquery: &Statement,
         _imports: &[String],
         return_clause: Option<&ReturnClause>,
+        return_order_by: &[(sparrowdb_cypher::ast::Expr, SortDir)],
+        return_skip: Option<u64>,
+        return_limit: Option<u64>,
+        return_distinct: bool,
     ) -> Result<QueryResult> {
         // Execute the inner subquery statement.
         let inner = self.execute_read_stmt(subquery)?;
 
         if let Some(ret) = return_clause {
-            // Project the outer RETURN clause over the subquery's result rows.
-            // Build a name → column-index map from the inner result.
-            let col_idx: HashMap<&str, usize> = inner
-                .columns
+            // Build a row-map representation of the inner result so that both
+            // aggregate and scalar expressions can be evaluated uniformly.
+            let inner_row_maps: Vec<HashMap<String, Value>> = inner
+                .rows
                 .iter()
-                .enumerate()
-                .map(|(i, c)| (c.as_str(), i))
+                .map(|row| {
+                    inner
+                        .columns
+                        .iter()
+                        .zip(row.iter())
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect()
+                })
                 .collect();
 
             let out_cols: Vec<String> = ret
@@ -52,43 +63,93 @@ impl Engine {
                 })
                 .collect();
 
-            // Only build the env map if at least one RETURN item needs expression eval
-            // (non-Var expressions).  For the common case of bare variable projections
-            // we skip the per-row allocation entirely.
-            let needs_env = ret
-                .items
-                .iter()
-                .any(|item| !matches!(item.expr, sparrowdb_cypher::ast::Expr::Var(_)));
+            // Route aggregate RETURN items through the aggregate engine so that
+            // expressions like `count(*) AS c` collapse correctly (including the
+            // zero-row case which must still produce one output row).
+            let has_agg = has_aggregate_in_return(&ret.items);
+            let mut out_rows: Vec<Vec<Value>> = if has_agg {
+                self.aggregate_rows_graph(&inner_row_maps, &ret.items)
+            } else {
+                // Only build the env map if at least one item needs expression eval
+                // (non-Var expressions).  Bare variable projections skip allocation.
+                let needs_env = ret
+                    .items
+                    .iter()
+                    .any(|item| !matches!(item.expr, sparrowdb_cypher::ast::Expr::Var(_)));
 
-            let out_rows: Vec<Vec<Value>> = inner
-                .rows
-                .iter()
-                .map(|row| {
-                    let env: Option<HashMap<String, Value>> = if needs_env {
-                        Some(
-                            inner
-                                .columns
-                                .iter()
-                                .zip(row.iter())
-                                .map(|(k, v)| (k.clone(), v.clone()))
-                                .collect(),
-                        )
-                    } else {
-                        None
-                    };
-                    ret.items
-                        .iter()
-                        .map(|item| match &item.expr {
-                            sparrowdb_cypher::ast::Expr::Var(name) => col_idx
-                                .get(name.as_str())
-                                .and_then(|&i| row.get(i))
-                                .cloned()
-                                .unwrap_or(Value::Null),
-                            other => eval_expr(other, env.as_ref().expect("env present")),
-                        })
-                        .collect()
-                })
-                .collect();
+                // Build a col → index map for fast Var lookups.
+                let col_idx: HashMap<&str, usize> = inner
+                    .columns
+                    .iter()
+                    .enumerate()
+                    .map(|(i, c)| (c.as_str(), i))
+                    .collect();
+
+                inner
+                    .rows
+                    .iter()
+                    .zip(inner_row_maps.iter())
+                    .map(|(row, env_map)| {
+                        let env: Option<&HashMap<String, Value>> =
+                            if needs_env { Some(env_map) } else { None };
+                        ret.items
+                            .iter()
+                            .map(|item| match &item.expr {
+                                sparrowdb_cypher::ast::Expr::Var(name) => col_idx
+                                    .get(name.as_str())
+                                    .and_then(|&i| row.get(i))
+                                    .cloned()
+                                    .unwrap_or(Value::Null),
+                                other => eval_expr(other, env.expect("env built for non-Var expr")),
+                            })
+                            .collect()
+                    })
+                    .collect()
+            };
+
+            // Apply ORDER BY / SKIP / LIMIT / DISTINCT on the projected rows.
+            // These correspond to modifiers on the outer `RETURN` clause.
+            if !return_order_by.is_empty() {
+                // Build row-maps for ORDER BY evaluation (use the same column names).
+                let row_maps_for_sort: Vec<HashMap<String, Value>> = out_rows
+                    .iter()
+                    .map(|row| {
+                        out_cols
+                            .iter()
+                            .zip(row.iter())
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect()
+                    })
+                    .collect();
+                let mut indexed: Vec<(usize, &Vec<Value>)> = out_rows.iter().enumerate().collect();
+                indexed.sort_by(|(ia, _), (ib, _)| {
+                    for (expr, dir) in return_order_by {
+                        let va = eval_expr(expr, &row_maps_for_sort[*ia]);
+                        let vb = eval_expr(expr, &row_maps_for_sort[*ib]);
+                        let cmp = compare_values(&va, &vb);
+                        let cmp = if *dir == SortDir::Desc {
+                            cmp.reverse()
+                        } else {
+                            cmp
+                        };
+                        if cmp != std::cmp::Ordering::Equal {
+                            return cmp;
+                        }
+                    }
+                    std::cmp::Ordering::Equal
+                });
+                out_rows = indexed.into_iter().map(|(_, r)| r.clone()).collect();
+            }
+            if let Some(s) = return_skip {
+                let s = (s as usize).min(out_rows.len());
+                out_rows.drain(0..s);
+            }
+            if let Some(l) = return_limit {
+                out_rows.truncate(l as usize);
+            }
+            if return_distinct {
+                deduplicate_rows(&mut out_rows);
+            }
 
             Ok(QueryResult {
                 columns: out_cols,
@@ -271,7 +332,19 @@ impl Engine {
                 subquery,
                 imports: sub_imports,
                 return_clause,
-            } => self.execute_call_subquery(subquery, sub_imports, return_clause.as_ref()),
+                return_order_by,
+                return_skip,
+                return_limit,
+                return_distinct,
+            } => self.execute_call_subquery(
+                subquery,
+                sub_imports,
+                return_clause.as_ref(),
+                return_order_by,
+                *return_skip,
+                *return_limit,
+                *return_distinct,
+            ),
             other => Err(sparrowdb_common::Error::InvalidArgument(format!(
                 "CALL {{ }}: unsupported or mutating statement kind in subquery: {:?}",
                 std::mem::discriminant(other)

--- a/crates/sparrowdb-execution/src/engine/subquery.rs
+++ b/crates/sparrowdb-execution/src/engine/subquery.rs
@@ -1,0 +1,448 @@
+//! CALL { } subquery execution (issue #290).
+//!
+//! Handles both unit subqueries (no outer variable imports) and correlated
+//! subqueries (imports via `WITH` inside the braces).
+
+use std::collections::HashMap;
+
+use sparrowdb_cypher::ast::{
+    PipelineStage, PipelineStatement, ReturnClause, Statement, WithClause,
+};
+
+use super::*;
+use crate::types::{QueryResult, Value};
+
+impl Engine {
+    // ── Standalone CALL { } RETURN … ─────────────────────────────────────────
+
+    /// Execute a standalone `CALL { … } [RETURN …]` statement.
+    ///
+    /// For a unit subquery (`imports` is empty) the inner statement is executed
+    /// independently and its result rows are extended with the optional outer
+    /// `RETURN` clause.
+    ///
+    /// Note: correlated standalone form (`imports` non-empty without an outer
+    /// MATCH) is not meaningful because there is no outer scope to import from.
+    /// In that case the imports are silently ignored and the subquery runs as a
+    /// unit subquery.
+    pub(crate) fn execute_call_subquery(
+        &self,
+        subquery: &Statement,
+        _imports: &[String],
+        return_clause: Option<&ReturnClause>,
+    ) -> Result<QueryResult> {
+        // Execute the inner subquery statement.
+        let inner = self.execute_read_stmt(subquery)?;
+
+        if let Some(ret) = return_clause {
+            // Project the outer RETURN clause over the subquery's result rows.
+            // Build a name → column-index map from the inner result.
+            let col_idx: HashMap<&str, usize> = inner
+                .columns
+                .iter()
+                .enumerate()
+                .map(|(i, c)| (c.as_str(), i))
+                .collect();
+
+            let out_cols: Vec<String> = ret
+                .items
+                .iter()
+                .map(|item| {
+                    item.alias
+                        .clone()
+                        .unwrap_or_else(|| expr_to_col_name(&item.expr))
+                })
+                .collect();
+
+            let out_rows: Vec<Vec<Value>> = inner
+                .rows
+                .iter()
+                .map(|row| {
+                    // Build an env map from the inner row.
+                    let env: HashMap<String, Value> = inner
+                        .columns
+                        .iter()
+                        .zip(row.iter())
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect();
+                    ret.items
+                        .iter()
+                        .map(|item| {
+                            // Try direct column lookup first, then full expression eval.
+                            match &item.expr {
+                                sparrowdb_cypher::ast::Expr::Var(name) => col_idx
+                                    .get(name.as_str())
+                                    .and_then(|&i| row.get(i))
+                                    .cloned()
+                                    .unwrap_or(Value::Null),
+                                other => eval_expr(other, &env),
+                            }
+                        })
+                        .collect()
+                })
+                .collect();
+
+            Ok(QueryResult {
+                columns: out_cols,
+                rows: out_rows,
+            })
+        } else {
+            Ok(inner)
+        }
+    }
+
+    // ── Pipeline stage: PipelineStage::CallSubquery ───────────────────────────
+
+    /// Execute a `CALL { }` pipeline stage against a set of outer rows.
+    ///
+    /// For each outer row in `current_rows`:
+    ///   - Unit subquery (`imports` empty): run the inner statement once and
+    ///     cross-join its output with every outer row.
+    ///   - Correlated subquery (`imports` non-empty): inject imported variable
+    ///     bindings from the outer row into the inner statement's execution
+    ///     context, then append the inner result columns to the outer row.
+    ///
+    /// In both cases, if the inner subquery produces zero rows for a given outer
+    /// row, that outer row is **dropped** (inner-join semantics, consistent with
+    /// Neo4j's CALL { } behaviour).
+    pub(crate) fn execute_pipeline_call_subquery_stage(
+        &self,
+        subquery: &Statement,
+        imports: &[String],
+        current_rows: Vec<HashMap<String, Value>>,
+    ) -> Result<Vec<HashMap<String, Value>>> {
+        let mut next_rows: Vec<HashMap<String, Value>> = Vec::new();
+
+        if imports.is_empty() {
+            // Unit subquery: execute once, cross-join with every outer row.
+            let inner = self.execute_read_stmt(subquery)?;
+            let inner_col_names: Vec<&str> = inner.columns.iter().map(|s| s.as_str()).collect();
+
+            for outer_row in &current_rows {
+                for inner_row in &inner.rows {
+                    let mut merged = outer_row.clone();
+                    for (col, val) in inner_col_names.iter().zip(inner_row.iter()) {
+                        merged.insert(col.to_string(), val.clone());
+                    }
+                    next_rows.push(merged);
+                }
+            }
+        } else {
+            // Correlated subquery: re-execute for each outer row with imported bindings.
+            for outer_row in &current_rows {
+                let inner = self.execute_read_stmt_with_bindings(subquery, imports, outer_row)?;
+                let inner_col_names: Vec<&str> = inner.columns.iter().map(|s| s.as_str()).collect();
+
+                for inner_row in &inner.rows {
+                    let mut merged = outer_row.clone();
+                    for (col, val) in inner_col_names.iter().zip(inner_row.iter()) {
+                        merged.insert(col.to_string(), val.clone());
+                    }
+                    next_rows.push(merged);
+                }
+            }
+        }
+
+        Ok(next_rows)
+    }
+
+    // ── Read-only statement dispatch ─────────────────────────────────────────
+
+    /// Execute a read-only `Statement` from `&self`.
+    ///
+    /// Only non-mutating statement variants are supported.  Mutation statements
+    /// (`CREATE`, `MERGE`, etc.) return an error — they must go through
+    /// `GraphDb::execute` which owns a write transaction.
+    pub(crate) fn execute_read_stmt(&self, stmt: &Statement) -> Result<QueryResult> {
+        self.execute_read_stmt_with_bindings(stmt, &[], &HashMap::new())
+    }
+
+    /// Execute a read-only statement with optional imported variable bindings.
+    ///
+    /// `imports` names the subset of `outer_row` keys to inject as parameters
+    /// (unused for unit subqueries — pass an empty slice and empty map).
+    ///
+    /// For correlated execution the approach is to rewrite the subquery as a
+    /// single-stage pipeline that starts from the imported bindings.  This works
+    /// for the common case:
+    ///
+    /// ```cypher
+    /// CALL { WITH n MATCH (n)-[:KNOWS]->(f) RETURN count(f) AS fc }
+    /// ```
+    ///
+    /// where `n` is a `NodeRef` in `outer_row`.  We inject the outer binding as
+    /// the leading row-set and feed it into `execute_pipeline_match_stage`.
+    pub(crate) fn execute_read_stmt_with_bindings(
+        &self,
+        stmt: &Statement,
+        imports: &[String],
+        outer_row: &HashMap<String, Value>,
+    ) -> Result<QueryResult> {
+        // Build the outer binding map (empty for unit subqueries).
+        let outer_binding: HashMap<String, Value> = if imports.is_empty() {
+            HashMap::new()
+        } else {
+            let mut b: HashMap<String, Value> = imports
+                .iter()
+                .filter_map(|k| outer_row.get(k).map(|v| (k.clone(), v.clone())))
+                .collect();
+            // Carry __node_id__ sentinel entries used by the pipeline match stage.
+            for key in imports {
+                let nid_key = format!("{key}.__node_id__");
+                if let Some(val) = outer_row.get(&nid_key) {
+                    b.insert(nid_key, val.clone());
+                }
+                if let Some(nr @ Value::NodeRef(_)) = outer_row.get(key) {
+                    b.insert(key.clone(), nr.clone());
+                    b.insert(format!("{key}.__node_id__"), nr.clone());
+                }
+            }
+            b
+        };
+
+        let use_seeded = !outer_binding.is_empty();
+
+        match stmt {
+            Statement::Match(m) => {
+                if use_seeded {
+                    // Correlated: wrap in a one-stage pipeline seeded with outer binding.
+                    let p = PipelineStatement {
+                        leading_match: Some(m.pattern.clone()),
+                        leading_where: m.where_clause.clone(),
+                        leading_unwind: None,
+                        stages: vec![],
+                        return_clause: m.return_clause.clone(),
+                        return_order_by: m.order_by.clone(),
+                        return_skip: m.skip,
+                        return_limit: m.limit,
+                        distinct: m.distinct,
+                    };
+                    self.execute_pipeline_seeded(&p, vec![outer_binding])
+                } else {
+                    self.execute_match(m)
+                }
+            }
+            Statement::Pipeline(p) => {
+                if use_seeded {
+                    self.execute_pipeline_seeded(p, vec![outer_binding])
+                } else {
+                    self.execute_pipeline(p)
+                }
+            }
+            Statement::MatchWith(mw) => self.execute_match_with(mw),
+            Statement::OptionalMatch(om) => self.execute_optional_match(om),
+            Statement::MatchOptionalMatch(mom) => self.execute_match_optional_match(mom),
+            Statement::Unwind(u) => self.execute_unwind(u),
+            Statement::Call(c) => self.execute_call(c),
+            Statement::Checkpoint | Statement::Optimize => Ok(QueryResult::empty(vec![])),
+            Statement::CreateIndex { .. } | Statement::CreateConstraint { .. } => {
+                Ok(QueryResult::empty(vec![]))
+            }
+            Statement::CallSubquery {
+                subquery,
+                imports: sub_imports,
+                return_clause,
+            } => self.execute_call_subquery(subquery, sub_imports, return_clause.as_ref()),
+            other => Err(sparrowdb_common::Error::InvalidArgument(format!(
+                "CALL {{ }}: unsupported or mutating statement kind in subquery: {:?}",
+                std::mem::discriminant(other)
+            ))),
+        }
+    }
+
+    /// Execute a `PipelineStatement` seeded with an initial set of rows instead
+    /// of scanning from the leading MATCH/UNWIND clause.
+    ///
+    /// Used by correlated `CALL { WITH imports … }` to feed the outer row
+    /// binding directly into the pipeline's first MATCH stage.
+    fn execute_pipeline_seeded(
+        &self,
+        p: &PipelineStatement,
+        seed_rows: Vec<HashMap<String, Value>>,
+    ) -> Result<QueryResult> {
+        // Start from the seed rows rather than scanning the leading MATCH.
+        let mut current_rows = if let Some(ref patterns) = p.leading_match {
+            // Re-traverse graph for each seeded binding using the pipeline MATCH runner.
+            let where_clause = p.leading_where.as_ref();
+            let mut rows = Vec::new();
+            for binding in &seed_rows {
+                let new_rows =
+                    self.execute_pipeline_match_stage(patterns, where_clause, binding)?;
+                rows.extend(new_rows);
+            }
+            rows
+        } else {
+            seed_rows
+        };
+
+        // Execute subsequent pipeline stages (reuse existing logic).
+        for stage in &p.stages {
+            match stage {
+                PipelineStage::With {
+                    clause,
+                    order_by,
+                    skip,
+                    limit,
+                } => {
+                    current_rows =
+                        self.apply_with_stage(current_rows, clause, order_by, skip, limit)?;
+                }
+                PipelineStage::Match {
+                    patterns,
+                    where_clause,
+                } => {
+                    let mut next = Vec::new();
+                    for binding in &current_rows {
+                        let new_rows = self.execute_pipeline_match_stage(
+                            patterns,
+                            where_clause.as_ref(),
+                            binding,
+                        )?;
+                        next.extend(new_rows);
+                    }
+                    current_rows = next;
+                }
+                PipelineStage::Unwind { alias, new_alias } => {
+                    let mut next = Vec::new();
+                    for row in &current_rows {
+                        let list_val = row.get(alias.as_str()).cloned().unwrap_or(Value::Null);
+                        let items = match list_val {
+                            Value::List(v) => v,
+                            other => vec![other],
+                        };
+                        for item in items {
+                            let mut new_row = row.clone();
+                            new_row.insert(new_alias.clone(), item);
+                            next.push(new_row);
+                        }
+                    }
+                    current_rows = next;
+                }
+                PipelineStage::CallSubquery { subquery, imports } => {
+                    current_rows =
+                        self.execute_pipeline_call_subquery_stage(subquery, imports, current_rows)?;
+                }
+            }
+        }
+
+        // Project the RETURN clause.
+        let column_names = extract_return_column_names(&p.return_clause.items);
+        let has_agg = has_aggregate_in_return(&p.return_clause.items);
+        let mut rows: Vec<Vec<Value>> = if has_agg {
+            // Aggregate RETURN items (COUNT, SUM, collect, etc.) need grouping.
+            self.aggregate_rows_graph(&current_rows, &p.return_clause.items)
+        } else {
+            current_rows
+                .iter()
+                .map(|row_vals| {
+                    p.return_clause
+                        .items
+                        .iter()
+                        .map(|item| self.eval_expr_graph(&item.expr, row_vals))
+                        .collect()
+                })
+                .collect()
+        };
+
+        if p.distinct {
+            deduplicate_rows(&mut rows);
+        }
+
+        Ok(QueryResult {
+            columns: column_names,
+            rows,
+        })
+    }
+
+    // ── WITH stage helper (extracted for reuse in seeded pipeline) ────────────
+
+    /// Apply a `PipelineStage::With` to a set of current rows.
+    fn apply_with_stage(
+        &self,
+        mut current_rows: Vec<HashMap<String, Value>>,
+        clause: &WithClause,
+        order_by: &[(sparrowdb_cypher::ast::Expr, SortDir)],
+        skip: &Option<u64>,
+        limit: &Option<u64>,
+    ) -> Result<Vec<HashMap<String, Value>>> {
+        if !order_by.is_empty() {
+            current_rows.sort_by(|a, b| {
+                for (expr, dir) in order_by {
+                    let va = eval_expr(expr, a);
+                    let vb = eval_expr(expr, b);
+                    let cmp = compare_values(&va, &vb);
+                    let cmp = if *dir == SortDir::Desc {
+                        cmp.reverse()
+                    } else {
+                        cmp
+                    };
+                    if cmp != std::cmp::Ordering::Equal {
+                        return cmp;
+                    }
+                }
+                std::cmp::Ordering::Equal
+            });
+        }
+        if let Some(s) = skip {
+            let s = (*s as usize).min(current_rows.len());
+            current_rows.drain(0..s);
+        }
+        if let Some(l) = limit {
+            current_rows.truncate(*l as usize);
+        }
+
+        let has_agg = clause
+            .items
+            .iter()
+            .any(|item| is_aggregate_expr(&item.expr));
+        let next_rows = if has_agg {
+            let agg_rows = self.aggregate_with_items(&current_rows, &clause.items);
+            agg_rows
+                .into_iter()
+                .filter(|with_vals| {
+                    if let Some(ref where_expr) = clause.where_clause {
+                        let mut wv = with_vals.clone();
+                        wv.extend(self.dollar_params());
+                        self.eval_where_graph(where_expr, &wv)
+                    } else {
+                        true
+                    }
+                })
+                .map(|mut with_vals| {
+                    with_vals.extend(self.dollar_params());
+                    with_vals
+                })
+                .collect()
+        } else {
+            let mut next = Vec::new();
+            for row_vals in &current_rows {
+                let mut with_vals: HashMap<String, Value> = HashMap::new();
+                for item in &clause.items {
+                    let val = self.eval_expr_graph(&item.expr, row_vals);
+                    with_vals.insert(item.alias.clone(), val);
+                    if let sparrowdb_cypher::ast::Expr::Var(ref src_var) = item.expr {
+                        if let Some(nr @ Value::NodeRef(_)) = row_vals.get(src_var) {
+                            with_vals.insert(item.alias.clone(), nr.clone());
+                            with_vals.insert(format!("{}.__node_id__", item.alias), nr.clone());
+                        }
+                        let nid_key = format!("{src_var}.__node_id__");
+                        if let Some(nr) = row_vals.get(&nid_key) {
+                            with_vals.insert(format!("{}.__node_id__", item.alias), nr.clone());
+                        }
+                    }
+                }
+                if let Some(ref where_expr) = clause.where_clause {
+                    let mut wv = with_vals.clone();
+                    wv.extend(self.dollar_params());
+                    if !self.eval_where_graph(where_expr, &wv) {
+                        continue;
+                    }
+                }
+                with_vals.extend(self.dollar_params());
+                next.push(with_vals);
+            }
+            next
+        };
+        Ok(next_rows)
+    }
+}

--- a/crates/sparrowdb/tests/call_subquery.rs
+++ b/crates/sparrowdb/tests/call_subquery.rs
@@ -1,0 +1,220 @@
+//! End-to-end tests for CALL { } subquery support (issue #290).
+//!
+//! Covers:
+//! - Unit subquery: `CALL { MATCH … RETURN … } RETURN …`
+//! - Correlated subquery: `MATCH (p) CALL { WITH p MATCH (p)-[:R]->(f) RETURN count(f) AS fc } RETURN p.name, fc`
+
+use sparrowdb::open;
+use sparrowdb_execution::types::Value;
+
+fn make_db() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+// ── Unit subquery ─────────────────────────────────────────────────────────────
+
+/// Basic unit subquery: `CALL { MATCH (n:Person) RETURN n.name AS name } RETURN name`
+#[test]
+fn unit_subquery_returns_all_rows() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (a:Person {name: 'Alice'})").unwrap();
+    db.execute("CREATE (b:Person {name: 'Bob'})").unwrap();
+
+    let r = db
+        .execute("CALL { MATCH (n:Person) RETURN n.name AS name } RETURN name")
+        .expect("unit subquery must execute without error");
+
+    assert_eq!(r.rows.len(), 2, "should return two rows (Alice and Bob)");
+
+    let mut names: Vec<String> = r
+        .rows
+        .iter()
+        .map(|row| match &row[0] {
+            Value::String(s) => s.clone(),
+            other => panic!("expected String, got {:?}", other),
+        })
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["Alice", "Bob"]);
+}
+
+/// Unit subquery with no matching rows returns empty result.
+#[test]
+fn unit_subquery_empty_when_no_match() {
+    let (_dir, db) = make_db();
+    // No nodes created — subquery should produce zero rows.
+
+    let r = db
+        .execute("CALL { MATCH (n:Person) RETURN n.name AS name } RETURN name")
+        .expect("unit subquery on empty graph must not error");
+
+    assert_eq!(r.rows.len(), 0, "empty graph → empty subquery result");
+}
+
+/// Unit subquery with LIMIT inside the subquery.
+#[test]
+fn unit_subquery_with_limit() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (a:Person {name: 'Alice'})").unwrap();
+    db.execute("CREATE (b:Person {name: 'Bob'})").unwrap();
+    db.execute("CREATE (c:Person {name: 'Carol'})").unwrap();
+
+    let r = db
+        .execute("CALL { MATCH (n:Person) RETURN n.name AS name LIMIT 2 } RETURN name")
+        .expect("unit subquery with LIMIT must execute");
+
+    assert_eq!(
+        r.rows.len(),
+        2,
+        "LIMIT 2 inside subquery should produce 2 rows"
+    );
+}
+
+// ── Correlated subquery ───────────────────────────────────────────────────────
+
+/// Correlated subquery: count friends for each person.
+///
+/// Alice knows Bob → friendCount = 1
+/// Bob has no outgoing KNOWS → friendCount = 0 (inner join drops Bob's row if
+/// no friends; to get 0 we use a match that uses count — but the test for zero
+/// rows is that Bob's row is not in the result when there are no friends).
+///
+/// This test verifies the row with Alice has fc = 1.
+#[test]
+fn correlated_subquery_counts_friends() {
+    let (_dir, db) = make_db();
+
+    // Create Alice and Bob.
+    db.execute("CREATE (a:Person {name: 'Alice'})").unwrap();
+    db.execute("CREATE (b:Person {name: 'Bob'})").unwrap();
+    // Alice knows Bob.
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+
+    // Correlated: for each person, count how many they know.
+    // The inner RETURN uses count(f), which is an aggregate.  Even when the
+    // inner MATCH produces zero rows for a given outer row (Bob has no
+    // outgoing KNOWS), the aggregate collapses to fc=0 and that outer row is
+    // still included (standard Cypher/Neo4j aggregate semantics).
+    let r = db
+        .execute(
+            "MATCH (p:Person) \
+             CALL { WITH p MATCH (p)-[:KNOWS]->(f:Person) RETURN count(f) AS fc } \
+             RETURN p.name, fc",
+        )
+        .expect("correlated subquery must execute without error");
+
+    // Alice has 1 friend → fc=1.  Bob has 0 friends → fc=0 (aggregate over
+    // empty set).  Both outer rows survive because count() always produces
+    // exactly one output row.
+    assert_eq!(
+        r.rows.len(),
+        2,
+        "both Alice and Bob should appear (fc=1 and fc=0)"
+    );
+
+    // Find Alice's row and Bob's row by name.
+    let alice_row = r
+        .rows
+        .iter()
+        .find(|row| row[0] == Value::String("Alice".to_string()))
+        .expect("Alice's row must be present");
+    let bob_row = r
+        .rows
+        .iter()
+        .find(|row| row[0] == Value::String("Bob".to_string()))
+        .expect("Bob's row must be present");
+
+    assert_eq!(alice_row[1], Value::Int64(1), "Alice knows 1 person");
+    assert_eq!(bob_row[1], Value::Int64(0), "Bob knows 0 people");
+}
+
+/// Correlated subquery: collect friend names per person.
+#[test]
+fn correlated_subquery_collects_friend_names() {
+    let (_dir, db) = make_db();
+
+    db.execute("CREATE (a:Person {name: 'Alice'})").unwrap();
+    db.execute("CREATE (b:Person {name: 'Bob'})").unwrap();
+    db.execute("CREATE (c:Person {name: 'Carol'})").unwrap();
+    // Alice → Bob, Alice → Carol
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+    db.execute(
+        "MATCH (a:Person {name: 'Alice'}), (c:Person {name: 'Carol'}) CREATE (a)-[:KNOWS]->(c)",
+    )
+    .unwrap();
+
+    let r = db
+        .execute(
+            "MATCH (p:Person {name: 'Alice'}) \
+             CALL { WITH p MATCH (p)-[:KNOWS]->(f:Person) RETURN f.name AS fname } \
+             RETURN p.name, fname",
+        )
+        .expect("correlated subquery collect must execute");
+
+    // 2 rows: (Alice, Bob) and (Alice, Carol).
+    assert_eq!(r.rows.len(), 2, "Alice knows 2 people → 2 rows");
+    let mut friend_names: Vec<String> = r
+        .rows
+        .iter()
+        .map(|row| match &row[1] {
+            Value::String(s) => s.clone(),
+            other => panic!("expected String, got {:?}", other),
+        })
+        .collect();
+    friend_names.sort();
+    assert_eq!(friend_names, vec!["Bob", "Carol"]);
+}
+
+// ── Parser tests ──────────────────────────────────────────────────────────────
+
+/// Verify that procedure CALL syntax is still parsed correctly.
+#[test]
+fn procedure_call_still_works() {
+    use sparrowdb_cypher::parser::parse;
+
+    let stmt = parse("CALL db.schema() YIELD type, name RETURN type, name").unwrap();
+    assert!(
+        matches!(stmt, sparrowdb_cypher::ast::Statement::Call(_)),
+        "procedure CALL must still parse as Statement::Call"
+    );
+}
+
+/// Verify that `CALL { }` is parsed as `Statement::CallSubquery`.
+#[test]
+fn call_subquery_parses_as_call_subquery_variant() {
+    use sparrowdb_cypher::parser::parse;
+
+    let stmt = parse("CALL { MATCH (n:Person) RETURN n.name AS name } RETURN name").unwrap();
+    assert!(
+        matches!(stmt, sparrowdb_cypher::ast::Statement::CallSubquery { .. }),
+        "CALL {{ }} must parse as Statement::CallSubquery, got {:?}",
+        std::mem::discriminant(&stmt)
+    );
+}
+
+/// Verify that the correlated form `CALL { WITH n ... }` parses correctly.
+#[test]
+fn correlated_call_subquery_parses() {
+    use sparrowdb_cypher::parser::parse;
+
+    let stmt = parse(
+        "MATCH (p:Person) \
+         CALL { WITH p MATCH (p)-[:KNOWS]->(f:Person) RETURN count(f) AS fc } \
+         RETURN p.name, fc",
+    )
+    .unwrap();
+    assert!(
+        matches!(stmt, sparrowdb_cypher::ast::Statement::Pipeline(_)),
+        "MATCH … CALL {{ }} … RETURN must parse as a Pipeline"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `CALL { }` unit subquery: executes inner statement independently, extends outer result
- Adds correlated `CALL { WITH var ... }` subquery: seeds inner execution with outer row bindings
- Aggregate-aware: inner RETURN with `count()` / `sum()` etc. routes through aggregate engine (Neo4j-compatible zero-row semantics)

## New files
- `crates/sparrowdb-execution/src/engine/subquery.rs` — subquery execution
- `crates/sparrowdb/tests/call_subquery.rs` — 8 e2e tests

## Modified files
- `ast.rs` — `CallSubquery` AST variants
- `parser.rs` — subquery parse logic  
- `binder.rs` — exhaustive match arm
- `engine/mod.rs` — dispatch + `has_aggregate_in_return` visibility
- `engine/scan.rs` — pipeline stage dispatch

## Test plan
- [ ] `cargo test -p sparrowdb --test call_subquery` — 8 tests pass
- [ ] `cargo check --workspace` passes
- [ ] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CALL { } subquery support in Cypher queries, enabling nested query execution with optional variable imports and both unit-level and row-correlated execution across outer result sets.

* **Tests**
  * Added comprehensive test coverage for subquery functionality, including unit subqueries, correlated subqueries with aggregation, LIMIT operations, and parser validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->