### PR TITLE
feat(fts): BM25 full-text index + query functions (closes #395)

### DIFF
--- a/crates/sparrowdb-cypher/src/ast.rs
+++ b/crates/sparrowdb-cypher/src/ast.rs
@@ -540,4 +540,11 @@ pub enum Statement {
         /// Whether the outer RETURN is `RETURN DISTINCT …`.
         return_distinct: bool,
     },
+    /// `CREATE FULLTEXT INDEX [name] FOR (n:Label) ON (n.property)` — BM25 FTS index (issue #395).
+    CreateFulltextIndex {
+        /// Optional user-supplied index name (currently stored but not used for lookup).
+        name: Option<String>,
+        label: String,
+        property: String,
+    },
 }

--- a/crates/sparrowdb-cypher/src/binder.rs
+++ b/crates/sparrowdb-cypher/src/binder.rs
@@ -73,7 +73,9 @@ pub fn bind(stmt: Statement, catalog: &Catalog) -> Result<BoundStatement> {
         Statement::Call(_) => {}
         // Pipeline: label binding is deferred to execution time (SPA-134).
         Statement::Pipeline(_) => {}
-        Statement::CreateIndex { .. } | Statement::CreateConstraint { .. } => {}
+        Statement::CreateIndex { .. }
+        | Statement::CreateConstraint { .. }
+        | Statement::CreateFulltextIndex { .. } => {}
         // CALL { } subquery: label binding is deferred to the subquery's own
         // execution path, which recurses through bind/execute internally.
         Statement::CallSubquery { .. } => {}

--- a/crates/sparrowdb-cypher/src/lexer.rs
+++ b/crates/sparrowdb-cypher/src/lexer.rs
@@ -58,6 +58,8 @@ pub enum Token {
     On,
     Constraint,
     Assert,
+    Fulltext,
+    For,
 
     // Punctuation
     LParen,    // (
@@ -387,6 +389,8 @@ fn keyword_or_ident(word: String) -> Token {
         "ON" => Token::On,
         "CONSTRAINT" => Token::Constraint,
         "ASSERT" => Token::Assert,
+        "FULLTEXT" => Token::Fulltext,
+        "FOR" => Token::For,
         _ => Token::Ident(word),
     }
 }

--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -76,6 +76,8 @@ fn token_keyword_name(tok: &Token) -> Option<&'static str> {
         Token::On => Some("ON"),
         Token::Constraint => Some("CONSTRAINT"),
         Token::Assert => Some("ASSERT"),
+        Token::Fulltext => Some("FULLTEXT"),
+        Token::For => Some("FOR"),
         _ => None,
     }
 }
@@ -259,6 +261,8 @@ impl Parser {
             Token::On => Ok("on".into()),
             Token::Constraint => Ok("constraint".into()),
             Token::Assert => Ok("assert".into()),
+            Token::Fulltext => Ok("fulltext".into()),
+            Token::For => Ok("for".into()),
             other => Err(Error::InvalidArgument(format!(
                 "expected property name, got {:?}",
                 other
@@ -1351,6 +1355,11 @@ impl Parser {
             self.advance();
             return self.parse_create_constraint();
         }
+        // CREATE FULLTEXT INDEX [name] FOR (n:Label) ON (n.prop)
+        if matches!(self.peek(), Token::Fulltext) {
+            self.advance(); // consume FULLTEXT
+            return self.parse_create_fulltext_index();
+        }
         let mut body = self.parse_create_body()?;
         // Check for optional RETURN clause (issue #366).
         if matches!(self.peek(), Token::Return) {
@@ -1399,6 +1408,62 @@ impl Parser {
             }
         }
         Ok(Statement::CreateConstraint { label, property })
+    }
+
+    /// Parse `CREATE FULLTEXT INDEX [name] FOR (n:Label) ON (n.property)`.
+    ///
+    /// The optional `name` is an unquoted identifier that appears immediately
+    /// after `INDEX`.  If the next token is `FOR` the name is omitted.
+    ///
+    /// Grammar:
+    /// ```text
+    /// CREATE FULLTEXT INDEX [<name>] FOR (<var>:<Label>) ON (<var>.<prop>)
+    /// ```
+    fn parse_create_fulltext_index(&mut self) -> Result<Statement> {
+        // Expect "INDEX"
+        self.expect_tok(&Token::Index)?;
+
+        // Optional name: present if next token is an Ident *and* the one after
+        // is not FOR (i.e. the name is followed by FOR).
+        let name: Option<String> = match self.peek().clone() {
+            Token::Ident(s) => {
+                // Peek ahead: if the token after the ident is FOR, consume name.
+                self.advance();
+                Some(s)
+            }
+            Token::For => None,
+            other => {
+                return Err(Error::InvalidArgument(format!(
+                    "CREATE FULLTEXT INDEX: expected index name or FOR, got {other:?}"
+                )))
+            }
+        };
+
+        // Expect FOR
+        self.expect_tok(&Token::For)?;
+
+        // Expect `(var:Label)`
+        self.expect_tok(&Token::LParen)?;
+        let _var = self.expect_ident()?; // e.g. "n" — consumed but not used
+        self.expect_tok(&Token::Colon)?;
+        let label = self.expect_label_or_type()?;
+        self.expect_tok(&Token::RParen)?;
+
+        // Expect ON
+        self.expect_tok(&Token::On)?;
+
+        // Expect `(var.property)`
+        self.expect_tok(&Token::LParen)?;
+        let _prop_var = self.expect_ident()?; // e.g. "n" — consumed but not used
+        self.expect_tok(&Token::Dot)?;
+        let property = self.advance_as_prop_name()?;
+        self.expect_tok(&Token::RParen)?;
+
+        Ok(Statement::CreateFulltextIndex {
+            name,
+            label,
+            property,
+        })
     }
 
     // ── UNWIND ────────────────────────────────────────────────────────────────

--- a/crates/sparrowdb-execution/src/engine/expr.rs
+++ b/crates/sparrowdb-execution/src/engine/expr.rs
@@ -79,10 +79,9 @@ impl Engine {
             &label,
             &property,
         ) {
-            Ok(idx) => {
-                let results = idx.search(&query, usize::MAX);
-                Value::Bool(results.iter().any(|(id, _)| *id == node_id))
-            }
+            // Use matches_query for a fast O(|terms| * avg_postings) membership
+            // check instead of computing and sorting all BM25 scores.
+            Ok(idx) => Value::Bool(idx.matches_query(node_id, &query)),
             Err(_) => Value::Bool(false),
         }
     }

--- a/crates/sparrowdb-execution/src/engine/expr.rs
+++ b/crates/sparrowdb-execution/src/engine/expr.rs
@@ -2,6 +2,164 @@
 use super::*;
 
 impl Engine {
+    // ── FTS scalar functions ──────────────────────────────────────────────────
+
+    /// Evaluate `full_text_search(label, property, query)`.
+    ///
+    /// Returns `Value::Bool(true)` if the current node's ID appears in the BM25
+    /// results for `(label, property, query)`.  The current node is resolved by
+    /// scanning `vals` for any `__node_id__` entry that matches the given label.
+    ///
+    /// Returns `Value::Bool(false)` when no matching entry is found or the FTS
+    /// index does not exist for the pair.
+    fn eval_full_text_search(&self, args: &[Expr], vals: &HashMap<String, Value>) -> Value {
+        if args.len() != 3 {
+            return Value::Bool(false);
+        }
+        let label_val = eval_expr(&args[0], vals);
+        let prop_val = eval_expr(&args[1], vals);
+        let query_val = eval_expr(&args[2], vals);
+
+        let (Value::String(label), Value::String(property), Value::String(query)) =
+            (label_val, prop_val, query_val)
+        else {
+            return Value::Bool(false);
+        };
+
+        // Locate the current node's ID for the given label.
+        //
+        // During WHERE evaluation (`execute_scan`) the NodeRef is stored under
+        // the plain variable name (e.g. "n").  During aggregation / eval path
+        // it is also stored under "{var}.__node_id__".  We accept both.
+        let expected_lid: Option<u32> = self
+            .snapshot
+            .catalog
+            .get_label(&label)
+            .ok()
+            .flatten()
+            .map(|id| id as u32);
+
+        let node_id: u64 = {
+            let mut found = None;
+
+            // Pass 1: prefer explicit __node_id__ keys.
+            for (k, v) in vals.iter() {
+                if k.ends_with(".__node_id__") {
+                    if let Value::NodeRef(nid) = v {
+                        let label_id_from_node = (nid.0 >> 32) as u32;
+                        if expected_lid.is_none_or(|eid| label_id_from_node == eid) {
+                            found = Some(nid.0);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Pass 2: fall back to any plain NodeRef entry matching the label.
+            if found.is_none() {
+                for (_k, v) in vals.iter() {
+                    if let Value::NodeRef(nid) = v {
+                        let label_id_from_node = (nid.0 >> 32) as u32;
+                        if expected_lid.is_none_or(|eid| label_id_from_node == eid) {
+                            found = Some(nid.0);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            match found {
+                Some(id) => id,
+                None => return Value::Bool(false),
+            }
+        };
+
+        if !sparrowdb_storage::fts_index::FtsIndex::exists(
+            &self.snapshot.db_root,
+            &label,
+            &property,
+        ) {
+            return Value::Bool(false);
+        }
+
+        match sparrowdb_storage::fts_index::FtsIndex::open(
+            &self.snapshot.db_root,
+            &label,
+            &property,
+        ) {
+            Ok(idx) => {
+                let results = idx.search(&query, usize::MAX);
+                Value::Bool(results.iter().any(|(id, _)| *id == node_id))
+            }
+            Err(_) => Value::Bool(false),
+        }
+    }
+
+    /// Evaluate `bm25_score(prop_expr, query)`.
+    ///
+    /// When `prop_expr` is a `PropAccess { var, prop }`, the BM25 score is
+    /// looked up from the persisted FTS index for that `(inferred_label, prop)`
+    /// pair.  Otherwise (bare string), returns 0.0.
+    fn eval_bm25_score(&self, args: &[Expr], vals: &HashMap<String, Value>) -> Value {
+        if args.len() != 2 {
+            return Value::Float64(0.0);
+        }
+
+        let query_val = eval_expr(&args[1], vals);
+        let Value::String(query) = query_val else {
+            return Value::Float64(0.0);
+        };
+
+        // Extract (var, prop) from the first argument.
+        let (var_name, prop_name) = match &args[0] {
+            Expr::PropAccess { var, prop } => (var.clone(), prop.clone()),
+            _ => return Value::Float64(0.0),
+        };
+
+        // Resolve the node_id and label for this variable.
+        let node_id_key = format!("{var_name}.__node_id__");
+        let node_id: u64 = match vals.get(&node_id_key) {
+            Some(Value::NodeRef(nid)) => nid.0,
+            _ => {
+                // Fallback: look for a var entry that is a NodeRef.
+                match vals.get(var_name.as_str()) {
+                    Some(Value::NodeRef(nid)) => nid.0,
+                    _ => return Value::Float64(0.0),
+                }
+            }
+        };
+
+        // Infer the label from the node_id (high 32 bits = label_id).
+        let label_id = (node_id >> 32) as u32;
+        let label = match self.snapshot.catalog.list_labels() {
+            Ok(labels) => match labels.into_iter().find(|(id, _)| *id as u32 == label_id) {
+                Some((_, name)) => name,
+                None => return Value::Float64(0.0),
+            },
+            Err(_) => return Value::Float64(0.0),
+        };
+
+        if !sparrowdb_storage::fts_index::FtsIndex::exists(
+            &self.snapshot.db_root,
+            &label,
+            &prop_name,
+        ) {
+            return Value::Float64(0.0);
+        }
+
+        match sparrowdb_storage::fts_index::FtsIndex::open(
+            &self.snapshot.db_root,
+            &label,
+            &prop_name,
+        ) {
+            Ok(idx) => {
+                let score = idx.score(node_id, &query);
+                Value::Float64(score as f64)
+            }
+            Err(_) => Value::Float64(0.0),
+        }
+    }
+
     // ── Property filter helpers ───────────────────────────────────────────────
 
     pub(crate) fn matches_prop_filter(
@@ -83,6 +241,11 @@ impl Engine {
                 }
                 Value::Null
             }
+            Expr::FnCall { name, args } => match name.to_ascii_lowercase().as_str() {
+                "full_text_search" => self.eval_full_text_search(args, vals),
+                "bm25_score" => self.eval_bm25_score(args, vals),
+                _ => eval_expr(expr, vals),
+            },
             _ => eval_expr(expr, vals),
         }
     }

--- a/crates/sparrowdb-execution/src/engine/expr.rs
+++ b/crates/sparrowdb-execution/src/engine/expr.rs
@@ -74,14 +74,6 @@ impl Engine {
             }
         };
 
-        if !sparrowdb_storage::fts_index::FtsIndex::exists(
-            &self.snapshot.db_root,
-            &label,
-            &property,
-        ) {
-            return Value::Bool(false);
-        }
-
         match sparrowdb_storage::fts_index::FtsIndex::open(
             &self.snapshot.db_root,
             &label,
@@ -138,14 +130,6 @@ impl Engine {
             },
             Err(_) => return Value::Float64(0.0),
         };
-
-        if !sparrowdb_storage::fts_index::FtsIndex::exists(
-            &self.snapshot.db_root,
-            &label,
-            &prop_name,
-        ) {
-            return Value::Float64(0.0);
-        }
 
         match sparrowdb_storage::fts_index::FtsIndex::open(
             &self.snapshot.db_root,

--- a/crates/sparrowdb-execution/src/engine/expr.rs
+++ b/crates/sparrowdb-execution/src/engine/expr.rs
@@ -74,15 +74,17 @@ impl Engine {
             }
         };
 
-        match sparrowdb_storage::fts_index::FtsIndex::open(
-            &self.snapshot.db_root,
-            &label,
-            &property,
-        ) {
-            // Use matches_query for a fast O(|terms| * avg_postings) membership
-            // check instead of computing and sorting all BM25 scores.
-            Ok(idx) => Value::Bool(idx.matches_query(node_id, &query)),
-            Err(_) => Value::Bool(false),
+        // Use the per-query FTS cache so the index is loaded from disk at most
+        // once per (label, property) pair regardless of how many rows are scanned.
+        match self.snapshot.fts_index(&label, &property) {
+            Some(cache) => {
+                let key = (label, property);
+                let idx = cache.get(&key).expect("key was just inserted");
+                // Use matches_query for a fast O(|terms|*avg_postings) membership
+                // check instead of computing and sorting all BM25 scores.
+                Value::Bool(idx.matches_query(node_id, &query))
+            }
+            None => Value::Bool(false),
         }
     }
 
@@ -130,16 +132,16 @@ impl Engine {
             Err(_) => return Value::Float64(0.0),
         };
 
-        match sparrowdb_storage::fts_index::FtsIndex::open(
-            &self.snapshot.db_root,
-            &label,
-            &prop_name,
-        ) {
-            Ok(idx) => {
+        // Use the per-query FTS cache so the index is loaded from disk at most
+        // once per (label, property) pair across all rows in the result set.
+        match self.snapshot.fts_index(&label, &prop_name) {
+            Some(cache) => {
+                let key = (label, prop_name);
+                let idx = cache.get(&key).expect("key was just inserted");
                 let score = idx.score(node_id, &query);
                 Value::Float64(score as f64)
             }
-            Err(_) => Value::Float64(0.0),
+            None => Value::Float64(0.0),
         }
     }
 

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -242,9 +242,48 @@ pub struct ReadSnapshot {
     rel_degree_stats: std::sync::OnceLock<HashMap<u32, DegreeStats>>,
     /// Shared edge-property cache (SPA-261).
     edge_props_cache: EdgePropsCache,
+    /// Per-query FTS index cache: loaded lazily on first `full_text_search` /
+    /// `bm25_score` call for a given `(label, property)` pair.
+    ///
+    /// Without this cache, every evaluated row causes a disk read + binary
+    /// decode of the index file.  With it the file is read at most once per
+    /// `(label, property)` pair per query.
+    fts_cache: std::sync::Mutex<HashMap<(String, String), sparrowdb_storage::fts_index::FtsIndex>>,
 }
 
 impl ReadSnapshot {
+    /// Return a reference to the FTS index for `(label, property)`, loading
+    /// it from disk the first time it is requested within this query.
+    ///
+    /// Subsequent calls for the same pair return the cached copy without any
+    /// I/O, so a WHERE clause that calls `full_text_search` or `bm25_score`
+    /// for N rows only deserialises the index file once.
+    ///
+    /// Returns `None` if the index file does not exist or cannot be opened.
+    pub fn fts_index(
+        &self,
+        label: &str,
+        property: &str,
+    ) -> Option<
+        std::sync::MutexGuard<
+            '_,
+            HashMap<(String, String), sparrowdb_storage::fts_index::FtsIndex>,
+        >,
+    > {
+        let key = (label.to_owned(), property.to_owned());
+        let mut cache = self.fts_cache.lock().ok()?;
+        if !cache.contains_key(&key) {
+            match sparrowdb_storage::fts_index::FtsIndex::open(&self.db_root, label, property) {
+                Ok(idx) => {
+                    cache.insert(key.clone(), idx);
+                }
+                Err(_) => return None,
+            }
+        }
+        // Return the guard so callers can borrow the cached index.
+        Some(cache)
+    }
+
     /// Return per-relationship-type out-degree statistics, computing them on
     /// first call and caching the result for all subsequent calls.
     ///
@@ -477,6 +516,7 @@ impl Engine {
             rel_degree_stats: std::sync::OnceLock::new(),
             edge_props_cache: shared_edge_props_cache
                 .unwrap_or_else(|| std::sync::Arc::new(std::sync::RwLock::new(HashMap::new()))),
+            fts_cache: std::sync::Mutex::new(HashMap::new()),
         };
 
         // If a shared cached index was provided, clone it out so we start

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -874,6 +874,11 @@ impl Engine {
                 return_limit,
                 return_distinct,
             ),
+            Statement::CreateFulltextIndex {
+                name,
+                label,
+                property,
+            } => self.execute_create_fulltext_index(name.as_deref(), &label, &property),
         }
     }
 

--- a/crates/sparrowdb-execution/src/engine/mutation.rs
+++ b/crates/sparrowdb-execution/src/engine/mutation.rs
@@ -909,6 +909,26 @@ impl Engine {
                     }
                 }
             }
+            // FTS auto-indexing: if a fulltext index is registered for any
+            // (label, property) pair of this node, insert the string value
+            // into the BM25 index so it is searchable immediately.
+            {
+                use sparrowdb_storage::fts_index::{FtsIndex, FtsRegistry};
+                let registry = FtsRegistry::load(&self.snapshot.db_root);
+                for entry in &node.props {
+                    if registry.contains(&label, &entry.key) {
+                        let val = eval_expr(&entry.value, &HashMap::new());
+                        if let Value::String(text) = val {
+                            if let Ok(mut idx) =
+                                FtsIndex::open(&self.snapshot.db_root, &label, &entry.key)
+                            {
+                                idx.insert(node_id.0, &text);
+                                let _ = idx.save();
+                            }
+                        }
+                    }
+                }
+            }
             // SPA-200: record secondary labels in the catalog side table.
             // The primary label is already encoded in `node_id`; secondary
             // labels are persisted here so that MATCH on secondary labels
@@ -980,6 +1000,26 @@ impl Engine {
         // Register the constraint.
         self.unique_constraints.insert((label_id, col_id));
 
+        Ok(QueryResult::empty(vec![]))
+    }
+
+    /// Execute `CREATE FULLTEXT INDEX [name] FOR (n:Label) ON (n.property)`.
+    ///
+    /// Creates (or overwrites) a BM25 full-text index on the given label+property
+    /// and registers it in the FTS registry so that `full_text_search()` and
+    /// `bm25_score()` can locate it.
+    pub(crate) fn execute_create_fulltext_index(
+        &mut self,
+        _name: Option<&str>,
+        label: &str,
+        property: &str,
+    ) -> Result<QueryResult> {
+        use sparrowdb_storage::fts_index::{FtsIndex, FtsRegistry};
+        // Create (or overwrite) the on-disk BM25 index.
+        FtsIndex::create(&self.snapshot.db_root, label, property)?;
+        // Register in the persistent registry.
+        let mut registry = FtsRegistry::load(&self.snapshot.db_root);
+        registry.register(&self.snapshot.db_root, label, property)?;
         Ok(QueryResult::empty(vec![]))
     }
 }

--- a/crates/sparrowdb-execution/src/engine/mutation.rs
+++ b/crates/sparrowdb-execution/src/engine/mutation.rs
@@ -923,7 +923,12 @@ impl Engine {
                                 FtsIndex::open(&self.snapshot.db_root, &label, &entry.key)
                             {
                                 idx.insert(node_id.0, &text);
-                                let _ = idx.save();
+                                if let Err(e) = idx.save() {
+                                    tracing::warn!(
+                                        "FTS index save failed for ({label}, {}): {e}",
+                                        entry.key
+                                    );
+                                }
                             }
                         }
                     }

--- a/crates/sparrowdb-execution/src/engine/mutation.rs
+++ b/crates/sparrowdb-execution/src/engine/mutation.rs
@@ -806,6 +806,14 @@ impl Engine {
     ///    same FNV-1a hash used by `WriteTx::merge_node`.
     /// 4. Write the node to the node store.
     pub(crate) fn execute_create(&mut self, create: &CreateStatement) -> Result<QueryResult> {
+        // Load the FTS registry once for the entire CREATE statement rather than
+        // once per node.  The registry is a small JSON file; loading it inside
+        // the loop would cause redundant disk reads in bulk CREATE statements.
+        let fts_registry = {
+            use sparrowdb_storage::fts_index::FtsRegistry;
+            FtsRegistry::load(&self.snapshot.db_root)
+        };
+
         for node in &create.nodes {
             // Resolve the primary label, creating it if absent.
             let label = node.labels.first().cloned().unwrap_or_default();
@@ -913,10 +921,9 @@ impl Engine {
             // (label, property) pair of this node, insert the string value
             // into the BM25 index so it is searchable immediately.
             {
-                use sparrowdb_storage::fts_index::{FtsIndex, FtsRegistry};
-                let registry = FtsRegistry::load(&self.snapshot.db_root);
+                use sparrowdb_storage::fts_index::FtsIndex;
                 for entry in &node.props {
-                    if registry.contains(&label, &entry.key) {
+                    if fts_registry.contains(&label, &entry.key) {
                         let val = eval_expr(&entry.value, &HashMap::new());
                         if let Value::String(text) = val {
                             if let Ok(mut idx) =

--- a/crates/sparrowdb-storage/src/fts_index.rs
+++ b/crates/sparrowdb-storage/src/fts_index.rs
@@ -1,0 +1,677 @@
+//! BM25 inverted full-text index for SparrowDB (issue #395).
+//!
+//! ## Index layout
+//!
+//! Each index covers one `(label, property)` pair and is stored under
+//! `{db_root}/fts/{label}__{property}.bin` as a `bincode`-serialised
+//! `FtsIndexData` struct.
+//!
+//! ## Tokeniser
+//! - Lowercase all text.
+//! - Split on any character that is **not** `[a-z0-9]` (i.e. whitespace and
+//!   all punctuation act as delimiters).
+//! - Discard tokens shorter than 2 characters.
+//! - No stemming in v1.
+//!
+//! ## BM25 formula
+//! ```text
+//! score(d, q) = Σ IDF(qi) * TF(qi,d) * (k1+1)
+//!                           ─────────────────────────────
+//!                           TF(qi,d) + k1*(1 − b + b*|d|/avgdl)
+//!
+//! IDF(qi) = ln( (N − df(qi) + 0.5) / (df(qi) + 0.5) + 1 )
+//! ```
+//! Default parameters: `k1 = 1.2`, `b = 0.75`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use sparrowdb_common::{Error, Result};
+
+// ── On-disk data ─────────────────────────────────────────────────────���────────
+
+/// Serialisable payload that is written to / read from disk.
+///
+/// Uses a simple binary format (length-prefixed lists) to avoid a `bincode`
+/// dependency in the storage crate — only `sparrowdb-common` is available here.
+/// The format is not encrypted (derived from node properties which are also
+/// unencrypted on disk).
+#[derive(Debug, Default, Clone)]
+struct FtsIndexData {
+    /// term → posting list: `Vec<(node_id, term_frequency)>`.
+    postings: HashMap<String, Vec<(u64, u32)>>,
+    /// node_id → document length (token count).
+    doc_lengths: HashMap<u64, u32>,
+    /// Total document count.
+    doc_count: u64,
+    /// Cumulative token count across all documents (used to compute `avg_dl`).
+    total_tokens: u64,
+}
+
+// ── FtsIndex ─────────────────────��────────────────────────────────────────────
+
+/// BM25 inverted index for a single `(label, property)` pair.
+#[derive(Debug)]
+pub struct FtsIndex {
+    /// Path on disk.
+    file_path: PathBuf,
+    /// In-memory state.
+    data: FtsIndexData,
+    /// Whether in-memory state differs from disk.
+    dirty: bool,
+    /// BM25 k1 parameter (term saturation). Default 1.2.
+    k1: f32,
+    /// BM25 b parameter (length normalisation). Default 0.75.
+    b: f32,
+}
+
+impl FtsIndex {
+    // ── Constructors ─────────────────────────────────────────────────────────
+
+    /// Open (or create) an FTS index stored under `{db_root}/fts/`.
+    ///
+    /// `label` and `property` must be valid identifier strings; they become
+    /// part of the file name so they must not contain path separators.
+    pub fn open(db_root: &Path, label: &str, property: &str) -> Result<Self> {
+        validate_component(label, "label")?;
+        validate_component(property, "property")?;
+        let file_path = index_path(db_root, label, property);
+        let data = if file_path.exists() {
+            load(&file_path)?
+        } else {
+            FtsIndexData::default()
+        };
+        Ok(Self {
+            file_path,
+            data,
+            dirty: false,
+            k1: 1.2,
+            b: 0.75,
+        })
+    }
+
+    /// Create (overwrite) a fresh FTS index, discarding any existing data.
+    pub fn create(db_root: &Path, label: &str, property: &str) -> Result<Self> {
+        let mut idx = Self::open(db_root, label, property)?;
+        idx.data = FtsIndexData::default();
+        idx.dirty = true;
+        idx.save()?;
+        Ok(idx)
+    }
+
+    // ── Write ──────────────────────────────────────────────────────────────��──
+
+    /// Index `text` for `node_id`, adding/updating its posting-list entries.
+    ///
+    /// Calling this again with the same `node_id` replaces (not duplicates)
+    /// the existing entry: the old document length and term frequencies are
+    /// removed before re-indexing.
+    pub fn insert(&mut self, node_id: u64, text: &str) {
+        // Remove stale entry for this node (idempotent re-index).
+        self.remove_internal(node_id);
+
+        let tokens = tokenize(text);
+        if tokens.is_empty() {
+            return;
+        }
+
+        // Count per-term frequencies.
+        let mut term_freq: HashMap<&str, u32> = HashMap::new();
+        for t in &tokens {
+            *term_freq.entry(t.as_str()).or_insert(0) += 1;
+        }
+
+        let doc_len = tokens.len() as u32;
+
+        // Update posting lists.
+        for (term, freq) in term_freq {
+            self.data
+                .postings
+                .entry(term.to_owned())
+                .or_default()
+                .push((node_id, freq));
+        }
+
+        self.data.doc_lengths.insert(node_id, doc_len);
+        self.data.doc_count += 1;
+        self.data.total_tokens += doc_len as u64;
+        self.dirty = true;
+    }
+
+    /// Remove a document from the index.
+    pub fn delete(&mut self, node_id: u64) {
+        self.remove_internal(node_id);
+        self.dirty = true;
+    }
+
+    // ── Read ────────────────────────────────��─────────────────────────────────
+
+    /// Search `query` returning `(node_id, bm25_score)` pairs sorted by
+    /// descending score (highest first).  At most `k` results are returned;
+    /// pass `usize::MAX` for all results.
+    pub fn search(&self, query: &str, k: usize) -> Vec<(u64, f32)> {
+        let terms = tokenize(query);
+        if terms.is_empty() || self.data.doc_count == 0 {
+            return vec![];
+        }
+
+        let avg_dl = if self.data.doc_count > 0 {
+            self.data.total_tokens as f64 / self.data.doc_count as f64
+        } else {
+            1.0
+        };
+        let n = self.data.doc_count as f64;
+        let k1 = self.k1 as f64;
+        let b = self.b as f64;
+
+        let mut scores: HashMap<u64, f64> = HashMap::new();
+
+        for term in &terms {
+            let Some(postings) = self.data.postings.get(term.as_str()) else {
+                continue;
+            };
+            let df = postings.len() as f64;
+            // Okapi IDF (Robertson et al., always positive).
+            let idf = ((n - df + 0.5) / (df + 0.5) + 1.0).ln();
+            for &(node_id, tf) in postings {
+                let dl = *self.data.doc_lengths.get(&node_id).unwrap_or(&1) as f64;
+                let tf_f = tf as f64;
+                let score = idf * (tf_f * (k1 + 1.0)) / (tf_f + k1 * (1.0 - b + b * dl / avg_dl));
+                *scores.entry(node_id).or_insert(0.0) += score;
+            }
+        }
+
+        let mut result: Vec<(u64, f32)> =
+            scores.into_iter().map(|(id, s)| (id, s as f32)).collect();
+
+        // Sort: descending score, then ascending node_id for determinism.
+        result.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+        });
+        result.truncate(k);
+        result
+    }
+
+    /// Compute the BM25 score for a single document identified by `node_id`
+    /// against `query`.  Returns `0.0` if the node is not in the index.
+    pub fn score(&self, node_id: u64, query: &str) -> f32 {
+        self.search(query, usize::MAX)
+            .into_iter()
+            .find(|(id, _)| *id == node_id)
+            .map(|(_, s)| s)
+            .unwrap_or(0.0)
+    }
+
+    /// Returns `true` if `node_id` contains **all** of the given `terms` in
+    /// its posting lists.  Used to accelerate CONTAINS pre-filtering.
+    pub fn contains_all(&self, node_id: u64, terms: &[&str]) -> bool {
+        terms.iter().all(|t| {
+            let tl = t.to_lowercase();
+            self.data
+                .postings
+                .get(tl.as_str())
+                .map(|pl| pl.iter().any(|(id, _)| *id == node_id))
+                .unwrap_or(false)
+        })
+    }
+
+    /// Returns all node IDs that match any of the given `terms` (OR semantics).
+    ///
+    /// This is a posting-list bitmap pre-filter suitable for accelerating a
+    /// subsequent CONTAINS or STARTS WITH check.
+    pub fn candidates_for_terms(&self, terms: &[&str]) -> Vec<u64> {
+        let mut seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        for t in terms {
+            let tl = t.to_lowercase();
+            if let Some(pl) = self.data.postings.get(tl.as_str()) {
+                for &(id, _) in pl {
+                    seen.insert(id);
+                }
+            }
+        }
+        seen.into_iter().collect()
+    }
+
+    // ── Persistence ───────────────────────────────────────────────────────────
+
+    /// Persist the index to disk (atomic write-rename).
+    pub fn save(&mut self) -> Result<()> {
+        if !self.dirty {
+            return Ok(());
+        }
+        if let Some(parent) = self.file_path.parent() {
+            std::fs::create_dir_all(parent).map_err(Error::Io)?;
+        }
+        let tmp = self.file_path.with_extension("fts.tmp");
+        let bytes = encode(&self.data)?;
+        std::fs::write(&tmp, &bytes).map_err(Error::Io)?;
+        std::fs::rename(&tmp, &self.file_path).map_err(Error::Io)?;
+        self.dirty = false;
+        Ok(())
+    }
+
+    /// Load an existing FTS index from disk.
+    pub fn load(db_root: &Path, label: &str, property: &str) -> Result<Self> {
+        Self::open(db_root, label, property)
+    }
+
+    /// Return `true` if an on-disk index file exists for this `(label, property)`.
+    pub fn exists(db_root: &Path, label: &str, property: &str) -> bool {
+        index_path(db_root, label, property).exists()
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────��──
+
+    fn remove_internal(&mut self, node_id: u64) {
+        if let Some(&old_len) = self.data.doc_lengths.get(&node_id) {
+            // Remove from every posting list.
+            for pl in self.data.postings.values_mut() {
+                pl.retain(|(id, _)| *id != node_id);
+            }
+            // Clean up empty posting lists.
+            self.data.postings.retain(|_, pl| !pl.is_empty());
+            self.data.doc_lengths.remove(&node_id);
+            self.data.doc_count = self.data.doc_count.saturating_sub(1);
+            self.data.total_tokens = self.data.total_tokens.saturating_sub(old_len as u64);
+        }
+    }
+}
+
+// ── Registry ──────────────────────────────────────────────────────────────────
+
+/// Persistent registry that tracks which `(label, property)` pairs have a
+/// BM25 full-text index.
+///
+/// Stored at `{db_root}/fts/registry.json` as a simple JSON array.
+#[derive(Debug, Default, Clone)]
+pub struct FtsRegistry {
+    /// List of `(label, property)` pairs with active indexes.
+    pub entries: Vec<(String, String)>,
+}
+
+impl FtsRegistry {
+    /// Path of the registry file.
+    pub fn registry_path(db_root: &Path) -> PathBuf {
+        db_root.join("fts").join("registry.json")
+    }
+
+    /// Load the registry from disk (returns empty registry if not found).
+    pub fn load(db_root: &Path) -> Self {
+        let path = Self::registry_path(db_root);
+        if !path.exists() {
+            return Self::default();
+        }
+        let bytes = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(_) => return Self::default(),
+        };
+        // Simple JSON decode: `[["Label","prop"],...]`
+        let s = String::from_utf8_lossy(&bytes);
+        let entries = parse_registry_json(&s);
+        Self { entries }
+    }
+
+    /// Register `(label, property)` and persist.
+    pub fn register(&mut self, db_root: &Path, label: &str, property: &str) -> Result<()> {
+        let pair = (label.to_owned(), property.to_owned());
+        if !self.entries.contains(&pair) {
+            self.entries.push(pair);
+        }
+        self.save(db_root)
+    }
+
+    /// Returns `true` if `(label, property)` is registered.
+    pub fn contains(&self, label: &str, property: &str) -> bool {
+        self.entries
+            .iter()
+            .any(|(l, p)| l == label && p == property)
+    }
+
+    fn save(&self, db_root: &Path) -> Result<()> {
+        let dir = db_root.join("fts");
+        std::fs::create_dir_all(&dir).map_err(Error::Io)?;
+        let path = Self::registry_path(db_root);
+        let json = format_registry_json(&self.entries);
+        std::fs::write(&path, json.as_bytes()).map_err(Error::Io)?;
+        Ok(())
+    }
+}
+
+// ── Tokeniser ──────────────────────────────────────────────────────��──────────
+
+/// Tokenise `text` into lowercase alphanumeric tokens, discarding tokens
+/// shorter than 2 characters.
+pub fn tokenize(text: &str) -> Vec<String> {
+    text.to_lowercase()
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|s| s.len() >= 2)
+        .map(String::from)
+        .collect()
+}
+
+// ── Helpers ─────────────────────────────────��─────────────────────────────────
+
+fn index_path(db_root: &Path, label: &str, property: &str) -> PathBuf {
+    // Use double-underscore separator between label and property.
+    db_root.join("fts").join(format!("{label}__{property}.bin"))
+}
+
+fn validate_component(s: &str, kind: &str) -> Result<()> {
+    if s.is_empty() || s.contains('/') || s.contains('\\') || s.contains("..") {
+        return Err(Error::InvalidArgument(format!(
+            "invalid FTS index {kind}: {s:?} — must not be empty or contain path separators"
+        )));
+    }
+    Ok(())
+}
+
+// ── Minimal binary codec (no external deps) ───────────────────────────────────
+//
+// Layout:
+//   u64 doc_count
+//   u64 total_tokens
+//   u64 num_dl_entries
+//   per entry: u64 node_id, u32 doc_len
+//   u64 num_terms
+//   per term:
+//     u32 term_len
+//     [u8] term bytes
+//     u64 num_postings
+//     per posting: u64 node_id, u32 term_freq
+
+fn encode(data: &FtsIndexData) -> Result<Vec<u8>> {
+    let mut buf: Vec<u8> = Vec::new();
+
+    write_u64(&mut buf, data.doc_count);
+    write_u64(&mut buf, data.total_tokens);
+
+    // doc_lengths
+    write_u64(&mut buf, data.doc_lengths.len() as u64);
+    for (&node_id, &len) in &data.doc_lengths {
+        write_u64(&mut buf, node_id);
+        write_u32(&mut buf, len);
+    }
+
+    // postings
+    write_u64(&mut buf, data.postings.len() as u64);
+    for (term, postings) in &data.postings {
+        let tb = term.as_bytes();
+        write_u32(&mut buf, tb.len() as u32);
+        buf.extend_from_slice(tb);
+        write_u64(&mut buf, postings.len() as u64);
+        for &(node_id, freq) in postings {
+            write_u64(&mut buf, node_id);
+            write_u32(&mut buf, freq);
+        }
+    }
+
+    Ok(buf)
+}
+
+fn load(path: &Path) -> Result<FtsIndexData> {
+    let bytes = std::fs::read(path).map_err(Error::Io)?;
+    let mut cur = 0usize;
+
+    let doc_count = read_u64(&bytes, &mut cur)?;
+    let total_tokens = read_u64(&bytes, &mut cur)?;
+
+    let num_dl = read_u64(&bytes, &mut cur)? as usize;
+    let mut doc_lengths = HashMap::with_capacity(num_dl);
+    for _ in 0..num_dl {
+        let node_id = read_u64(&bytes, &mut cur)?;
+        let len = read_u32(&bytes, &mut cur)?;
+        doc_lengths.insert(node_id, len);
+    }
+
+    let num_terms = read_u64(&bytes, &mut cur)? as usize;
+    let mut postings = HashMap::with_capacity(num_terms);
+    for _ in 0..num_terms {
+        let term_len = read_u32(&bytes, &mut cur)? as usize;
+        if cur + term_len > bytes.len() {
+            return Err(Error::Corruption(
+                "FTS index: term length out of bounds".into(),
+            ));
+        }
+        let term = String::from_utf8(bytes[cur..cur + term_len].to_vec())
+            .map_err(|e| Error::Corruption(format!("FTS index: invalid UTF-8 term: {e}")))?;
+        cur += term_len;
+
+        let num_postings = read_u64(&bytes, &mut cur)? as usize;
+        let mut pl = Vec::with_capacity(num_postings);
+        for _ in 0..num_postings {
+            let node_id = read_u64(&bytes, &mut cur)?;
+            let freq = read_u32(&bytes, &mut cur)?;
+            pl.push((node_id, freq));
+        }
+        postings.insert(term, pl);
+    }
+
+    Ok(FtsIndexData {
+        postings,
+        doc_lengths,
+        doc_count,
+        total_tokens,
+    })
+}
+
+#[inline]
+fn write_u64(buf: &mut Vec<u8>, v: u64) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+#[inline]
+fn write_u32(buf: &mut Vec<u8>, v: u32) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+#[inline]
+fn read_u64(buf: &[u8], cur: &mut usize) -> Result<u64> {
+    let end = *cur + 8;
+    if end > buf.len() {
+        return Err(Error::Corruption(
+            "FTS index: unexpected end of data".into(),
+        ));
+    }
+    let v = u64::from_le_bytes(buf[*cur..end].try_into().unwrap());
+    *cur = end;
+    Ok(v)
+}
+#[inline]
+fn read_u32(buf: &[u8], cur: &mut usize) -> Result<u32> {
+    let end = *cur + 4;
+    if end > buf.len() {
+        return Err(Error::Corruption(
+            "FTS index: unexpected end of data".into(),
+        ));
+    }
+    let v = u32::from_le_bytes(buf[*cur..end].try_into().unwrap());
+    *cur = end;
+    Ok(v)
+}
+
+// ── Minimal JSON helpers for registry ────────────────────────────────��───────
+
+fn format_registry_json(entries: &[(String, String)]) -> String {
+    let inner: Vec<String> = entries
+        .iter()
+        .map(|(l, p)| format!("[\"{}\",\"{}\"]", escape_json(l), escape_json(p)))
+        .collect();
+    format!("[{}]", inner.join(","))
+}
+
+fn escape_json(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn parse_registry_json(s: &str) -> Vec<(String, String)> {
+    // Very simple parser for `[["A","b"],["C","d"]]` without external deps.
+    let mut out = Vec::new();
+    let s = s.trim();
+    let s = s
+        .strip_prefix('[')
+        .unwrap_or(s)
+        .strip_suffix(']')
+        .unwrap_or(s)
+        .trim();
+    if s.is_empty() {
+        return out;
+    }
+    // Split on `],[` to get individual pair strings.
+    for chunk in s.split("],[") {
+        let chunk = chunk.trim().trim_start_matches('[').trim_end_matches(']');
+        let parts: Vec<&str> = chunk.splitn(2, ',').collect();
+        if parts.len() == 2 {
+            let label = unquote_json(parts[0].trim());
+            let prop = unquote_json(parts[1].trim());
+            if !label.is_empty() && !prop.is_empty() {
+                out.push((label, prop));
+            }
+        }
+    }
+    out
+}
+
+fn unquote_json(s: &str) -> String {
+    let s = s.trim().strip_prefix('"').unwrap_or(s);
+    let s = s.strip_suffix('"').unwrap_or(s);
+    s.replace("\\\"", "\"").replace("\\\\", "\\")
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokenize_basic() {
+        let tokens = tokenize("Hello, World! This is a test.");
+        // "a" and "is" are < 2 chars? No — both are 2 chars.
+        // "a" is 1 char — filtered.
+        assert!(tokens.contains(&"hello".to_owned()));
+        assert!(tokens.contains(&"world".to_owned()));
+        assert!(tokens.contains(&"test".to_owned()));
+        assert!(!tokens.contains(&"a".to_owned())); // too short
+    }
+
+    #[test]
+    fn insert_and_search() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut idx = FtsIndex::open(dir.path(), "Memory", "content").unwrap();
+
+        idx.insert(1, "transformer attention mechanism");
+        idx.insert(2, "neural network backpropagation");
+        idx.insert(3, "transformer architecture layers");
+
+        let results = idx.search("transformer attention", 10);
+        assert!(results.len() >= 2);
+        // Node 1 and 3 both have "transformer"; node 1 also has "attention".
+        let ids: Vec<u64> = results.iter().map(|(id, _)| *id).collect();
+        assert!(
+            ids.contains(&1),
+            "node 1 should match transformer+attention"
+        );
+        assert!(ids.contains(&3), "node 3 should match transformer");
+
+        // Node 1 should rank higher than 3 because it also has "attention".
+        let score_1 = results
+            .iter()
+            .find(|(id, _)| *id == 1)
+            .map(|(_, s)| *s)
+            .unwrap_or(0.0);
+        let score_3 = results
+            .iter()
+            .find(|(id, _)| *id == 3)
+            .map(|(_, s)| *s)
+            .unwrap_or(0.0);
+        assert!(
+            score_1 >= score_3,
+            "node 1 (has both terms) should rank >= node 3 (has one term)"
+        );
+    }
+
+    #[test]
+    fn bm25_scores_rank_relevant_higher() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut idx = FtsIndex::open(dir.path(), "Doc", "text").unwrap();
+
+        // Node 1: highly relevant — "rust" appears 3 times.
+        idx.insert(1, "rust rust rust programming language");
+        // Node 2: somewhat relevant — "rust" appears once.
+        idx.insert(2, "rust is a systems language");
+        // Node 3: not relevant.
+        idx.insert(3, "python data science pandas");
+
+        let results = idx.search("rust", 10);
+        let ids: Vec<u64> = results.iter().map(|(id, _)| *id).collect();
+        assert!(ids.contains(&1));
+        assert!(ids.contains(&2));
+        assert!(!ids.contains(&3));
+
+        // Node 1 should have a higher score (3 occurrences of "rust").
+        let s1 = results.iter().find(|(id, _)| *id == 1).unwrap().1;
+        let s2 = results.iter().find(|(id, _)| *id == 2).unwrap().1;
+        assert!(
+            s1 > s2,
+            "node 1 (tf=3) should score higher than node 2 (tf=1)"
+        );
+    }
+
+    #[test]
+    fn persistence_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+
+        {
+            let mut idx = FtsIndex::open(dir.path(), "Memory", "content").unwrap();
+            idx.insert(10, "graph database knowledge");
+            idx.insert(20, "relational database sql");
+            idx.save().unwrap();
+        }
+
+        let idx2 = FtsIndex::open(dir.path(), "Memory", "content").unwrap();
+        let results = idx2.search("database", 10);
+        let ids: Vec<u64> = results.iter().map(|(id, _)| *id).collect();
+        assert!(ids.contains(&10), "node 10 should survive restart");
+        assert!(ids.contains(&20), "node 20 should survive restart");
+    }
+
+    #[test]
+    fn delete_removes_document() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut idx = FtsIndex::open(dir.path(), "Doc", "text").unwrap();
+
+        idx.insert(1, "machine learning fundamentals");
+        idx.insert(2, "deep learning neural networks");
+        idx.delete(1);
+
+        let results = idx.search("learning", 10);
+        let ids: Vec<u64> = results.iter().map(|(id, _)| *id).collect();
+        assert!(!ids.contains(&1), "deleted node should not appear");
+        assert!(ids.contains(&2), "non-deleted node should appear");
+    }
+
+    #[test]
+    fn contains_all_acceleration() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut idx = FtsIndex::open(dir.path(), "X", "y").unwrap();
+        idx.insert(1, "alpha beta gamma");
+        idx.insert(2, "alpha delta epsilon");
+
+        assert!(idx.contains_all(1, &["alpha", "beta"]));
+        assert!(!idx.contains_all(1, &["alpha", "delta"]));
+        assert!(idx.contains_all(2, &["alpha", "delta"]));
+    }
+
+    #[test]
+    fn registry_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut reg = FtsRegistry::default();
+        reg.register(dir.path(), "Memory", "content").unwrap();
+        reg.register(dir.path(), "Doc", "body").unwrap();
+
+        let loaded = FtsRegistry::load(dir.path());
+        assert!(loaded.contains("Memory", "content"));
+        assert!(loaded.contains("Doc", "body"));
+        assert!(!loaded.contains("Other", "prop"));
+    }
+}

--- a/crates/sparrowdb-storage/src/fts_index.rs
+++ b/crates/sparrowdb-storage/src/fts_index.rs
@@ -196,12 +196,38 @@ impl FtsIndex {
 
     /// Compute the BM25 score for a single document identified by `node_id`
     /// against `query`.  Returns `0.0` if the node is not in the index.
+    ///
+    /// This runs in O(|query terms| * avg_postings_per_term) time and does
+    /// not sort all matching documents — unlike calling `search()` and
+    /// filtering, which would be O(M log M) for M matching nodes.
     pub fn score(&self, node_id: u64, query: &str) -> f32 {
-        self.search(query, usize::MAX)
-            .into_iter()
-            .find(|(id, _)| *id == node_id)
-            .map(|(_, s)| s)
-            .unwrap_or(0.0)
+        let terms = tokenize(query);
+        if terms.is_empty() || self.data.doc_count == 0 {
+            return 0.0;
+        }
+        let Some(&doc_len) = self.data.doc_lengths.get(&node_id) else {
+            return 0.0;
+        };
+
+        let avg_dl = self.data.total_tokens as f64 / self.data.doc_count as f64;
+        let n = self.data.doc_count as f64;
+        let k1 = self.k1 as f64;
+        let b = self.b as f64;
+        let dl = doc_len as f64;
+
+        let mut total: f64 = 0.0;
+        for term in &terms {
+            let Some(postings) = self.data.postings.get(term.as_str()) else {
+                continue;
+            };
+            let df = postings.len() as f64;
+            let idf = ((n - df + 0.5) / (df + 0.5) + 1.0).ln();
+            if let Some(&(_, tf)) = postings.iter().find(|(id, _)| *id == node_id) {
+                let tf_f = tf as f64;
+                total += idf * (tf_f * (k1 + 1.0)) / (tf_f + k1 * (1.0 - b + b * dl / avg_dl));
+            }
+        }
+        total as f32
     }
 
     /// Returns `true` if `node_id` contains **all** of the given `terms` in

--- a/crates/sparrowdb-storage/src/fts_index.rs
+++ b/crates/sparrowdb-storage/src/fts_index.rs
@@ -230,6 +230,24 @@ impl FtsIndex {
         total as f32
     }
 
+    /// Returns `true` if `node_id` appears in the posting lists for **any**
+    /// token in `query`.  This is a boolean membership test
+    /// (O(|query terms| * avg_postings)) and does not compute BM25 scores or
+    /// sort results.  Used by `full_text_search()` to avoid calling `search()`.
+    pub fn matches_query(&self, node_id: u64, query: &str) -> bool {
+        let terms = tokenize(query);
+        if terms.is_empty() || self.data.doc_count == 0 {
+            return false;
+        }
+        terms.iter().any(|term| {
+            self.data
+                .postings
+                .get(term.as_str())
+                .map(|pl| pl.iter().any(|(id, _)| *id == node_id))
+                .unwrap_or(false)
+        })
+    }
+
     /// Returns `true` if `node_id` contains **all** of the given `terms` in
     /// its posting lists.  Used to accelerate CONTAINS pre-filtering.
     pub fn contains_all(&self, node_id: u64, terms: &[&str]) -> bool {
@@ -369,9 +387,12 @@ impl FtsRegistry {
 
 /// Tokenise `text` into lowercase alphanumeric tokens, discarding tokens
 /// shorter than 2 characters.
+///
+/// Uses `char::is_alphanumeric` (Unicode-aware) so accented and non-Latin
+/// characters are treated as word constituents rather than delimiters.
 pub fn tokenize(text: &str) -> Vec<String> {
     text.to_lowercase()
-        .split(|c: char| !c.is_ascii_alphanumeric())
+        .split(|c: char| !c.is_alphanumeric())
         .filter(|s| s.len() >= 2)
         .map(String::from)
         .collect()
@@ -380,8 +401,18 @@ pub fn tokenize(text: &str) -> Vec<String> {
 // ── Helpers ─────────────────────────────────��─────────────────────────────────
 
 fn index_path(db_root: &Path, label: &str, property: &str) -> PathBuf {
-    // Use double-underscore separator between label and property.
-    db_root.join("fts").join(format!("{label}__{property}.bin"))
+    // Encode each component so that labels/properties containing `__`
+    // cannot produce colliding filenames.  Any `_` in the component is
+    // encoded as `_0` and the two-underscore separator is kept as `__`.
+    //
+    // Examples:
+    //   ("Foo", "bar")     →  Foo__bar.bin
+    //   ("Foo__Bar", "baz") → Foo_0_0Bar__baz.bin   (no collision with above)
+    let enc_label = label.replace('_', "_0");
+    let enc_prop = property.replace('_', "_0");
+    db_root
+        .join("fts")
+        .join(format!("{enc_label}__{enc_prop}.bin"))
 }
 
 fn validate_component(s: &str, kind: &str) -> Result<()> {
@@ -530,37 +561,114 @@ fn escape_json(s: &str) -> String {
 }
 
 fn parse_registry_json(s: &str) -> Vec<(String, String)> {
-    // Very simple parser for `[["A","b"],["C","d"]]` without external deps.
+    // Minimal recursive-descent parser for `[["A","b"],["C","d"]]`.
+    // Handles whitespace between tokens and escaped characters in strings.
+    // Does NOT split on `],[` (which breaks when spaces are present or when
+    // label/property names contain `],[`).
+    let bytes = s.trim().as_bytes();
+    let mut pos = 0;
+
+    /// Skip ASCII whitespace.
+    fn skip_ws(b: &[u8], p: &mut usize) {
+        while *p < b.len() && b[*p].is_ascii_whitespace() {
+            *p += 1;
+        }
+    }
+
+    /// Expect a specific byte, advancing pos past it.
+    fn expect_byte(b: &[u8], p: &mut usize, ch: u8) -> bool {
+        skip_ws(b, p);
+        if *p < b.len() && b[*p] == ch {
+            *p += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Parse a JSON string (including surrounding quotes), returning the
+    /// unescaped contents.  Returns `None` on parse error.
+    fn parse_string(b: &[u8], p: &mut usize) -> Option<String> {
+        skip_ws(b, p);
+        if *p >= b.len() || b[*p] != b'"' {
+            return None;
+        }
+        *p += 1; // consume opening quote
+        let mut out = String::new();
+        while *p < b.len() {
+            match b[*p] {
+                b'"' => {
+                    *p += 1; // consume closing quote
+                    return Some(out);
+                }
+                b'\\' => {
+                    *p += 1;
+                    if *p >= b.len() {
+                        return None;
+                    }
+                    match b[*p] {
+                        b'"' => out.push('"'),
+                        b'\\' => out.push('\\'),
+                        b'n' => out.push('\n'),
+                        b'r' => out.push('\r'),
+                        b't' => out.push('\t'),
+                        other => {
+                            out.push('\\');
+                            out.push(other as char);
+                        }
+                    }
+                    *p += 1;
+                }
+                c => {
+                    out.push(c as char);
+                    *p += 1;
+                }
+            }
+        }
+        None // unterminated string
+    }
+
     let mut out = Vec::new();
-    let s = s.trim();
-    let s = s
-        .strip_prefix('[')
-        .unwrap_or(s)
-        .strip_suffix(']')
-        .unwrap_or(s)
-        .trim();
-    if s.is_empty() {
+    if !expect_byte(bytes, &mut pos, b'[') {
+        return out; // not an array
+    }
+    skip_ws(bytes, &mut pos);
+    // Empty outer array.
+    if pos < bytes.len() && bytes[pos] == b']' {
         return out;
     }
-    // Split on `],[` to get individual pair strings.
-    for chunk in s.split("],[") {
-        let chunk = chunk.trim().trim_start_matches('[').trim_end_matches(']');
-        let parts: Vec<&str> = chunk.splitn(2, ',').collect();
-        if parts.len() == 2 {
-            let label = unquote_json(parts[0].trim());
-            let prop = unquote_json(parts[1].trim());
-            if !label.is_empty() && !prop.is_empty() {
-                out.push((label, prop));
-            }
+    loop {
+        // Expect inner array `["label","property"]`.
+        if !expect_byte(bytes, &mut pos, b'[') {
+            break;
+        }
+        let label = match parse_string(bytes, &mut pos) {
+            Some(s) if !s.is_empty() => s,
+            _ => break,
+        };
+        if !expect_byte(bytes, &mut pos, b',') {
+            break;
+        }
+        let prop = match parse_string(bytes, &mut pos) {
+            Some(s) if !s.is_empty() => s,
+            _ => break,
+        };
+        if !expect_byte(bytes, &mut pos, b']') {
+            break;
+        }
+        out.push((label, prop));
+        skip_ws(bytes, &mut pos);
+        // Either a comma (more entries) or `]` (end of outer array).
+        if pos >= bytes.len() || bytes[pos] == b']' {
+            break;
+        }
+        if bytes[pos] == b',' {
+            pos += 1; // consume comma between pairs
+        } else {
+            break; // unexpected byte
         }
     }
     out
-}
-
-fn unquote_json(s: &str) -> String {
-    let s = s.trim().strip_prefix('"').unwrap_or(s);
-    let s = s.strip_suffix('"').unwrap_or(s);
-    s.replace("\\\"", "\"").replace("\\\\", "\\")
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -699,5 +807,65 @@ mod tests {
         assert!(loaded.contains("Memory", "content"));
         assert!(loaded.contains("Doc", "body"));
         assert!(!loaded.contains("Other", "prop"));
+    }
+
+    #[test]
+    fn registry_roundtrip_with_special_chars() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut reg = FtsRegistry::default();
+        // Labels/properties containing underscores should not collide.
+        reg.register(dir.path(), "A__B", "c").unwrap();
+        reg.register(dir.path(), "A", "B__c").unwrap();
+
+        let loaded = FtsRegistry::load(dir.path());
+        assert!(loaded.contains("A__B", "c"));
+        assert!(loaded.contains("A", "B__c"));
+    }
+
+    #[test]
+    fn registry_json_handles_whitespace() {
+        // The parser must tolerate spaces between tokens.
+        let json = r#"[ [ "Label" , "prop" ] , [ "Doc" , "body" ] ]"#;
+        let entries = parse_registry_json(json);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0], ("Label".into(), "prop".into()));
+        assert_eq!(entries[1], ("Doc".into(), "body".into()));
+    }
+
+    #[test]
+    fn registry_json_handles_escaped_strings() {
+        let json = r#"[["Label\"X","prop\\y"]]"#;
+        let entries = parse_registry_json(json);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0], ("Label\"X".into(), "prop\\y".into()));
+    }
+
+    #[test]
+    fn matches_query_is_union_membership() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut idx = FtsIndex::open(dir.path(), "X", "y").unwrap();
+        idx.insert(1, "alpha beta gamma");
+        idx.insert(2, "delta epsilon");
+
+        // Node 1 matches "alpha" (any term in query matches).
+        assert!(idx.matches_query(1, "alpha zeta"));
+        // Node 1 does NOT match "delta" (not in node 1's posting lists).
+        assert!(!idx.matches_query(1, "delta"));
+        // Node 2 matches "epsilon".
+        assert!(idx.matches_query(2, "epsilon"));
+        // Unknown node never matches.
+        assert!(!idx.matches_query(99, "alpha"));
+    }
+
+    #[test]
+    fn tokenize_unicode() {
+        // Accented characters should be kept as part of tokens.
+        let tokens = tokenize("Héllo wörld");
+        assert!(
+            tokens.contains(&"héllo".to_owned()),
+            "accented token 'héllo' should survive tokenization: {:?}",
+            tokens
+        );
+        assert!(tokens.contains(&"wörld".to_owned()));
     }
 }

--- a/crates/sparrowdb-storage/src/lib.rs
+++ b/crates/sparrowdb-storage/src/lib.rs
@@ -3,6 +3,9 @@ pub mod metapage;
 /// Simple inverted full-text index for CALL db.index.fulltext.queryNodes.
 pub mod fulltext_index;
 
+/// BM25 inverted full-text index (issue #395).
+pub mod fts_index;
+
 /// At-rest page encryption using XChaCha20-Poly1305.
 pub mod encryption;
 

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -778,6 +778,14 @@ impl GraphDb {
 
         let mut tx = self.begin_write()?;
 
+        // Load the FTS registry once for the entire CREATE statement.  Loading
+        // inside the per-node loop would cause redundant disk reads for every
+        // node in a bulk `CREATE` statement.
+        let fts_registry = {
+            use sparrowdb_storage::fts_index::FtsRegistry;
+            FtsRegistry::load(&self.inner.path)
+        };
+
         // Map variable name → NodeId for all newly created nodes.
         let mut var_to_node: HashMap<String, NodeId> = HashMap::new();
         // Map variable name → named props written (for RETURN projection).
@@ -877,11 +885,10 @@ impl GraphDb {
             // FTS auto-indexing: if a fulltext index is registered for this
             // (label, property) pair, insert the string value into the BM25 index.
             {
-                use sparrowdb_storage::fts_index::{FtsIndex, FtsRegistry};
+                use sparrowdb_storage::fts_index::FtsIndex;
                 use sparrowdb_storage::node_store::Value as StorageValue;
-                let registry = FtsRegistry::load(&self.inner.path);
                 for (prop_name, val) in &named_props {
-                    if registry.contains(&label, prop_name) {
+                    if fts_registry.contains(&label, prop_name) {
                         if let StorageValue::Bytes(ref bytes) = val {
                             // Decode the string from the stored bytes.
                             if let Ok(text) = std::str::from_utf8(bytes) {

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -874,6 +874,29 @@ impl GraphDb {
 
             let node_id = tx.create_node_named(label_id, &named_props)?;
 
+            // FTS auto-indexing: if a fulltext index is registered for this
+            // (label, property) pair, insert the string value into the BM25 index.
+            {
+                use sparrowdb_storage::fts_index::{FtsIndex, FtsRegistry};
+                use sparrowdb_storage::node_store::Value as StorageValue;
+                let registry = FtsRegistry::load(&self.inner.path);
+                for (prop_name, val) in &named_props {
+                    if registry.contains(&label, prop_name) {
+                        if let StorageValue::Bytes(ref bytes) = val {
+                            // Decode the string from the stored bytes.
+                            if let Ok(text) = std::str::from_utf8(bytes) {
+                                if let Ok(mut idx) =
+                                    FtsIndex::open(&self.inner.path, &label, prop_name)
+                                {
+                                    idx.insert(node_id.0, text);
+                                    let _ = idx.save();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             // SPA-289: record secondary labels (labels[1..]) in the catalog
             // side table so that MATCH on secondary labels and labels(n)
             // return the full label set.

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -29,7 +29,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
-use tracing::info_span;
+use tracing::{info_span, warn};
 
 // ── DbStats ───────────────────────────────────────────────────────────────────
 
@@ -889,7 +889,11 @@ impl GraphDb {
                                     FtsIndex::open(&self.inner.path, &label, prop_name)
                                 {
                                     idx.insert(node_id.0, text);
-                                    let _ = idx.save();
+                                    if let Err(e) = idx.save() {
+                                        warn!(
+                                            "FTS index save failed for ({label}, {prop_name}): {e}"
+                                        );
+                                    }
                                 }
                             }
                         }

--- a/crates/sparrowdb/tests/fts_index.rs
+++ b/crates/sparrowdb/tests/fts_index.rs
@@ -1,0 +1,356 @@
+//! Integration tests for BM25 full-text index (issue #395).
+//!
+//! Tests cover:
+//!  1. `CREATE FULLTEXT INDEX` DDL
+//!  2. Auto-indexing on `CREATE` for nodes whose label/property is registered
+//!  3. `full_text_search(label, property, query)` WHERE predicate
+//!  4. `bm25_score(n.prop, query)` AS score expression + ORDER BY
+//!  5. Multi-word queries (union of term scores)
+//!  6. Restart survival (index is persisted to disk)
+//!  7. Score ordering (nodes with more matching terms rank higher)
+
+use sparrowdb::GraphDb;
+use sparrowdb_execution::types::Value;
+
+fn open_db(dir: &std::path::Path) -> GraphDb {
+    GraphDb::open(dir).expect("open db")
+}
+
+// ── Helper: run a Cypher statement, panic on error ────────────────────────────
+
+fn exec(db: &GraphDb, cypher: &str) {
+    db.execute(cypher)
+        .unwrap_or_else(|e| panic!("exec failed for `{cypher}`: {e}"));
+}
+
+// ── 1. CREATE FULLTEXT INDEX DDL ──────────────────────────────────────────────
+
+#[test]
+fn test_create_fulltext_index_ddl() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+    exec(
+        &db,
+        "CREATE FULLTEXT INDEX memory_content FOR (n:Memory) ON (n.content)",
+    );
+    // A second call should be idempotent (no error).
+    exec(
+        &db,
+        "CREATE FULLTEXT INDEX memory_content FOR (n:Memory) ON (n.content)",
+    );
+}
+
+// ── 2. Auto-indexing on CREATE ────────────────────────────────────────────────
+
+#[test]
+fn test_auto_index_on_create() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    exec(&db, "CREATE FULLTEXT INDEX FOR (n:Memory) ON (n.content)");
+    exec(
+        &db,
+        "CREATE (m:Memory {content: 'transformer attention mechanism'})",
+    );
+
+    // Should be findable via full_text_search.
+    let result = db
+        .execute(
+            "MATCH (n:Memory) WHERE full_text_search('Memory', 'content', 'transformer') RETURN n.content",
+        )
+        .expect("query failed");
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "expected 1 row, got {}: {:?}",
+        result.rows.len(),
+        result.rows
+    );
+    assert_eq!(
+        result.rows[0][0],
+        Value::String("transformer attention mechanism".into())
+    );
+}
+
+// ── 3. full_text_search predicate ─────────────────────────────────────────────
+
+#[test]
+fn test_full_text_search_predicate() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    exec(&db, "CREATE FULLTEXT INDEX FOR (n:Article) ON (n.body)");
+    exec(
+        &db,
+        "CREATE (a:Article {body: 'rust programming language safety'})",
+    );
+    exec(
+        &db,
+        "CREATE (a:Article {body: 'python machine learning frameworks'})",
+    );
+    exec(&db, "CREATE (a:Article {body: 'rust async tokio runtime'})");
+    exec(
+        &db,
+        "CREATE (a:Article {body: 'java spring boot microservices'})",
+    );
+
+    // Query for 'rust' — should match 2 articles.
+    let result = db
+        .execute(
+            "MATCH (a:Article) WHERE full_text_search('Article', 'body', 'rust') RETURN a.body",
+        )
+        .expect("query failed");
+
+    assert_eq!(
+        result.rows.len(),
+        2,
+        "expected 2 rows for 'rust', got {}: {:?}",
+        result.rows.len(),
+        result.rows
+    );
+
+    // Query for 'python' — should match 1.
+    let result2 = db
+        .execute(
+            "MATCH (a:Article) WHERE full_text_search('Article', 'body', 'python') RETURN a.body",
+        )
+        .expect("query failed");
+
+    assert_eq!(result2.rows.len(), 1);
+
+    // Query for 'nonexistent' — should return 0.
+    let result3 = db
+        .execute(
+            "MATCH (a:Article) WHERE full_text_search('Article', 'body', 'nonexistent') RETURN a.body",
+        )
+        .expect("query failed");
+
+    assert_eq!(result3.rows.len(), 0);
+}
+
+// ── 4. bm25_score expression + ORDER BY ───────────────────────────────────────
+
+#[test]
+fn test_bm25_score_order_by() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    exec(&db, "CREATE FULLTEXT INDEX FOR (n:Memory) ON (n.content)");
+
+    // Insert nodes with different relevance to 'attention transformer'.
+    exec(
+        &db,
+        "CREATE (m:Memory {content: 'attention is all you need transformer model'})",
+    );
+    exec(
+        &db,
+        "CREATE (m:Memory {content: 'convolutional neural network image classification'})",
+    );
+    exec(
+        &db,
+        "CREATE (m:Memory {content: 'transformer encoder decoder attention mechanism attention'})",
+    );
+    exec(
+        &db,
+        "CREATE (m:Memory {content: 'recurrent neural network language model'})",
+    );
+
+    let result = db
+        .execute(
+            "MATCH (n:Memory) \
+             WHERE full_text_search('Memory', 'content', 'transformer attention') \
+             RETURN n.content, bm25_score(n.content, 'transformer attention') AS score \
+             ORDER BY score DESC LIMIT 20",
+        )
+        .expect("query failed");
+
+    // We should get the two documents that mention 'transformer' or 'attention'.
+    assert!(
+        result.rows.len() >= 2,
+        "expected at least 2 rows, got {}",
+        result.rows.len()
+    );
+
+    // Scores should be in descending order.
+    let scores: Vec<f64> = result
+        .rows
+        .iter()
+        .map(|row| match &row[1] {
+            Value::Float64(f) => *f,
+            _ => 0.0,
+        })
+        .collect();
+
+    for window in scores.windows(2) {
+        assert!(
+            window[0] >= window[1],
+            "rows should be ordered by descending score: {} < {}",
+            window[0],
+            window[1]
+        );
+    }
+}
+
+// ── 5. Multi-word query (union of term scores) ────────────────────────────────
+
+#[test]
+fn test_multiword_query_union_scoring() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    exec(&db, "CREATE FULLTEXT INDEX FOR (n:Doc) ON (n.text)");
+    exec(&db, "CREATE (d:Doc {text: 'alpha beta gamma'})");
+    exec(&db, "CREATE (d:Doc {text: 'delta epsilon'})");
+    exec(&db, "CREATE (d:Doc {text: 'alpha delta zeta'})");
+
+    // Query for 'alpha beta' — doc 1 matches both, doc 3 matches 'alpha' only.
+    let result = db
+        .execute("MATCH (d:Doc) WHERE full_text_search('Doc', 'text', 'alpha beta') RETURN d.text")
+        .expect("query failed");
+
+    // Documents 1 and 3 contain 'alpha'; document 1 also contains 'beta'.
+    assert!(
+        result.rows.len() >= 2,
+        "expected at least 2 results for 'alpha beta', got {}",
+        result.rows.len()
+    );
+}
+
+// ── 6. Restart survival (index persisted to disk) ────────────────────────────
+
+#[test]
+fn test_fts_index_survives_restart() {
+    let dir = tempfile::tempdir().unwrap();
+
+    {
+        let db = open_db(dir.path());
+        exec(&db, "CREATE FULLTEXT INDEX FOR (n:Note) ON (n.text)");
+        exec(
+            &db,
+            "CREATE (n:Note {text: 'persistent full text indexing rocks'})",
+        );
+        exec(
+            &db,
+            "CREATE (n:Note {text: 'unrelated content about databases'})",
+        );
+        // db drops here, flushing to disk
+    }
+
+    // Reopen without re-creating the index.
+    let db2 = open_db(dir.path());
+
+    let result = db2
+        .execute(
+            "MATCH (n:Note) WHERE full_text_search('Note', 'text', 'persistent') RETURN n.text",
+        )
+        .expect("query after restart failed");
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "expected 1 row after restart, got {}",
+        result.rows.len()
+    );
+    assert_eq!(
+        result.rows[0][0],
+        Value::String("persistent full text indexing rocks".into())
+    );
+}
+
+// ── 7. BM25 ranking with 50 nodes ────────────────────────────────────────────
+
+#[test]
+fn test_bm25_ranking_50_nodes() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    exec(&db, "CREATE FULLTEXT INDEX FOR (n:Knowledge) ON (n.fact)");
+
+    // Create 50 nodes. Every 5th mentions 'quantum', every 10th also 'entanglement'.
+    for i in 0..50u32 {
+        let text = if i % 10 == 0 {
+            format!("quantum entanglement physics phenomenon node{i}")
+        } else if i % 5 == 0 {
+            format!("quantum computing superposition node{i}")
+        } else {
+            format!("classical physics determinism node{i}")
+        };
+        db.execute(&format!("CREATE (k:Knowledge {{fact: '{text}'}})"))
+            .expect("create node failed");
+    }
+
+    // Query for 'quantum entanglement'.
+    let result = db
+        .execute(
+            "MATCH (k:Knowledge) \
+             WHERE full_text_search('Knowledge', 'fact', 'quantum entanglement') \
+             RETURN k.fact, bm25_score(k.fact, 'quantum entanglement') AS score \
+             ORDER BY score DESC LIMIT 10",
+        )
+        .expect("query failed");
+
+    assert!(
+        !result.rows.is_empty(),
+        "expected at least one result for 'quantum entanglement'"
+    );
+
+    // Verify descending score order.
+    let scores: Vec<f64> = result
+        .rows
+        .iter()
+        .map(|row| match &row[1] {
+            Value::Float64(f) => *f,
+            _ => 0.0,
+        })
+        .collect();
+
+    for window in scores.windows(2) {
+        assert!(
+            window[0] >= window[1],
+            "scores not in descending order: {} < {}",
+            window[0],
+            window[1]
+        );
+    }
+
+    // Top result should contain both 'quantum' and 'entanglement'.
+    let top_fact = match &result.rows[0][0] {
+        Value::String(s) => s.clone(),
+        other => panic!("expected string for fact, got: {other:?}"),
+    };
+    assert!(
+        top_fact.contains("quantum") && top_fact.contains("entanglement"),
+        "top result should mention both terms: {top_fact}"
+    );
+}
+
+// ── 8. Direct index file access ───────────────────────────────────────────────
+#[test]
+fn test_fts_index_file_exists_and_is_searchable() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    exec(&db, "CREATE FULLTEXT INDEX FOR (n:Memory) ON (n.content)");
+    exec(
+        &db,
+        "CREATE (m:Memory {content: 'transformer attention mechanism'})",
+    );
+
+    // Check index file exists
+    let idx_path = dir.path().join("fts").join("Memory__content.bin");
+    assert!(
+        idx_path.exists(),
+        "index file should exist at {:?}",
+        idx_path
+    );
+
+    // Load the index and verify it has the document
+    let idx = sparrowdb_storage::fts_index::FtsIndex::open(dir.path(), "Memory", "content")
+        .expect("open index");
+    let results = idx.search("transformer", usize::MAX);
+    assert!(
+        !results.is_empty(),
+        "FTS index should contain 'transformer'; search returned empty"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds a pure-Rust BM25 inverted index stored at `{db_root}/fts/{label}__{property}.bin` — no external search crates, no C deps
- Implements `CREATE FULLTEXT INDEX [name] FOR (n:Label) ON (n.prop)` DDL
- Auto-indexes string properties on `CREATE` when an FTS index is registered for the `(label, property)` pair
- Implements `full_text_search(label, prop, query)` as a graph-aware WHERE predicate
- Implements `bm25_score(n.prop, query)` as a scalar function usable in `RETURN ... ORDER BY`

The target Cypher from the issue now works end-to-end:
```cypher
CREATE FULLTEXT INDEX FOR (n:Memory) ON (n.content)
MATCH (n:Memory) WHERE full_text_search('Memory', 'content', 'transformer attention') RETURN n, bm25_score(n.content, 'transformer attention') AS score ORDER BY score DESC LIMIT 20
```

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy -p sparrowdb -p sparrowdb-execution -p sparrowdb-storage -p sparrowdb-cypher -- -D warnings` — clean
- [x] `cargo test -p sparrowdb --test fts_index` — 8/8 pass
  - DDL idempotency
  - Auto-indexing on CREATE
  - `full_text_search` predicate (2 matches for 'rust', 1 for 'python', 0 for unknown)
  - `bm25_score` ORDER BY DESC
  - Multi-word query union scoring
  - Restart survival (index persists to disk, searchable after reopen)
  - 50-node BM25 ranking correctness (top result contains both query terms)
  - Direct index file access

🤖 Generated with [Claude Code](https://claude.com/claude-code)