### PR TITLE
feat(node): wire hybridSearch + bump 0.1.21 → 0.1.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 license = "MIT"
 authors = ["Rich Yaker"]
@@ -27,13 +27,13 @@ documentation = "https://docs.rs/sparrowdb"
 readme = "README.md"
 
 [workspace.dependencies]
-sparrowdb-common = { path = "crates/sparrowdb-common", version = "0.1.21" }
-sparrowdb-storage = { path = "crates/sparrowdb-storage", version = "0.1.21" }
-sparrowdb-catalog = { path = "crates/sparrowdb-catalog", version = "0.1.21" }
-sparrowdb-cypher  = { path = "crates/sparrowdb-cypher", version = "0.1.21" }
-sparrowdb-execution = { path = "crates/sparrowdb-execution", version = "0.1.21" }
-sparrowdb = { path = "crates/sparrowdb", version = "0.1.21" }
-sparrowdb-metrics = { path = "crates/sparrowdb-metrics", version = "0.1.21" }
+sparrowdb-common = { path = "crates/sparrowdb-common", version = "0.1.22" }
+sparrowdb-storage = { path = "crates/sparrowdb-storage", version = "0.1.22" }
+sparrowdb-catalog = { path = "crates/sparrowdb-catalog", version = "0.1.22" }
+sparrowdb-cypher  = { path = "crates/sparrowdb-cypher", version = "0.1.22" }
+sparrowdb-execution = { path = "crates/sparrowdb-execution", version = "0.1.22" }
+sparrowdb = { path = "crates/sparrowdb", version = "0.1.22" }
+sparrowdb-metrics = { path = "crates/sparrowdb-metrics", version = "0.1.22" }
 tiny_http         = "0.12"
 tempfile          = "3"
 crc32fast         = "1"

--- a/crates/sparrowdb-bench/src/ic_queries.rs
+++ b/crates/sparrowdb-bench/src/ic_queries.rs
@@ -467,7 +467,7 @@ pub fn ic12_expert_search(
     }
 
     let mut results: Vec<(PersonName, i64)> = person_counts.into_iter().collect();
-    results.sort_by(|a, b| b.1.cmp(&a.1));
+    results.sort_by_key(|b| std::cmp::Reverse(b.1));
     results.truncate(20);
     Ok(results)
 }

--- a/crates/sparrowdb-execution/src/engine/hop.rs
+++ b/crates/sparrowdb-execution/src/engine/hop.rs
@@ -249,7 +249,7 @@ impl Engine {
                 let all_neighbors: Vec<u64> = csr_neighbors
                     .iter()
                     .copied()
-                    .chain(delta_neighbors.into_iter())
+                    .chain(delta_neighbors)
                     .collect();
 
                 // ── SPA-200: batch-read dst properties — O(cols) fs::read() calls
@@ -620,7 +620,7 @@ impl Engine {
                     let all_predecessors: Vec<u64> = csr_predecessors
                         .iter()
                         .copied()
-                        .chain(delta_predecessors.into_iter())
+                        .chain(delta_predecessors)
                         .collect();
 
                     let mut seen_preds: HashSet<u64> = HashSet::new();

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -1235,14 +1235,13 @@ fn extract_return_column_names(items: &[ReturnItem]) -> Vec<String> {
 /// accidentally fetching unrelated properties from the wrong node.
 fn collect_col_ids_from_expr_for_var(expr: &Expr, target_var: &str, out: &mut Vec<u32>) {
     match expr {
-        Expr::PropAccess { var, prop } => {
-            if var == target_var {
-                let col_id = prop_name_to_col_id(prop);
-                if !out.contains(&col_id) {
-                    out.push(col_id);
-                }
+        Expr::PropAccess { var, prop } if var == target_var => {
+            let col_id = prop_name_to_col_id(prop);
+            if !out.contains(&col_id) {
+                out.push(col_id);
             }
         }
+        Expr::PropAccess { .. } => {}
         Expr::BinOp { left, right, .. } => {
             collect_col_ids_from_expr_for_var(left, target_var, out);
             collect_col_ids_from_expr_for_var(right, target_var, out);

--- a/crates/sparrowdb-execution/src/engine/scan.rs
+++ b/crates/sparrowdb-execution/src/engine/scan.rs
@@ -1125,13 +1125,12 @@ impl Engine {
                             return Ok(None);
                         }
                     }
-                    Expr::PropAccess { var, prop } => {
+                    Expr::PropAccess { var, prop } if var == src_var => {
                         // n.prop — must reference the source variable.
-                        if var == src_var {
-                            prop_col = Some(prop.clone());
-                        } else {
-                            return Ok(None);
-                        }
+                        prop_col = Some(prop.clone());
+                    }
+                    Expr::PropAccess { .. } => {
+                        return Ok(None);
                     }
                     _ => return Ok(None),
                 }

--- a/crates/sparrowdb-node/src/lib.rs
+++ b/crates/sparrowdb-node/src/lib.rs
@@ -369,32 +369,118 @@ impl SparrowDB {
             .collect())
     }
 
-    // ── Hybrid search (stub) ──────────────────────────────────────────────────
+    // ── Hybrid search ────────────────────────────────────────────────────────
 
     /// Hybrid vector + full-text search using Reciprocal Rank Fusion (RRF).
     ///
-    /// **Not yet available** — requires issue #396 (RRF hybrid fusion) to land.
+    /// Runs HNSW vector search and BM25 full-text search independently, then
+    /// fuses the ranked lists.  Missing indexes are treated as empty — so if
+    /// only a vector index exists the call degrades gracefully to vector-only.
     ///
-    /// Throws always until #396 is merged.
+    /// `label`           — node label (e.g. `"Memory"`)
+    /// `text_property`   — property holding the text content (for BM25)
+    /// `vector_property` — property holding the embedding (for HNSW)
+    /// `query_vector`    — Float32Array query embedding
+    /// `text_query`      — query string for full-text search
+    /// `k`               — max results to return (default 10)
+    /// `alpha`           — optional; when supplied uses weighted fusion:
+    ///                     `alpha * norm_vec + (1-alpha) * norm_bm25`.
+    ///                     When omitted, uses RRF with k=60.
     ///
     /// ```typescript
-    /// // Will throw: "hybrid search requires #396 (RRF fusion) to be merged"
-    /// db.hybridSearch('Memory', 'content', 'embedding', queryVec, 'neural networks', 10)
+    /// const hits = db.hybridSearch('Memory', 'content', 'embedding', queryVec, 'neural networks', 10)
+    /// // hits: Array<{ id: string, score: number }>
+    ///
+    /// // Weighted fusion (vector-heavy):
+    /// const hits2 = db.hybridSearch('Memory', 'content', 'embedding', queryVec, 'query', 10, 0.7)
     /// ```
+    #[allow(clippy::too_many_arguments)]
     #[napi]
     pub fn hybrid_search(
         &self,
-        _label: String,
-        _text_property: String,
-        _vector_property: String,
-        _query_vector: Float32Array,
-        _text_query: String,
-        _k: Option<u32>,
+        label: String,
+        text_property: String,
+        vector_property: String,
+        query_vector: Float32Array,
+        text_query: String,
+        k: Option<u32>,
+        alpha: Option<f64>,
     ) -> napi::Result<Vec<NodeResult>> {
-        Err(napi::Error::from_reason(
-            "hybrid search requires #396 (RRF fusion) to be merged; \
-             use vectorSearch() and fulltextSearch() separately until then",
-        ))
+        use sparrowdb_storage::fts_index::FtsIndex;
+        use std::collections::HashMap;
+
+        let k_usize = k.unwrap_or(10) as usize;
+        // Fetch k*2 candidates from each index for better fusion quality.
+        let fetch_k = (k_usize * 2).max(20);
+
+        // ── 1. Vector search ─────────────────────────────────────────────────
+        let vec_results: Vec<(u64, f32)> =
+            match self.inner.get_vector_index(&label, &vector_property) {
+                Some(arc) => {
+                    let idx = arc
+                        .read()
+                        .map_err(|e| to_napi(format!("lock poisoned: {e}")))?;
+                    let ef = (fetch_k * 4).max(50);
+                    idx.search(query_vector.as_ref(), fetch_k, ef)
+                }
+                None => vec![],
+            };
+
+        // ── 2. Full-text (BM25) search ───────────────────────────────────────
+        let db_path = self.inner.path();
+        let fts_results: Vec<(u64, f32)> = match FtsIndex::open(db_path, &label, &text_property) {
+            Ok(idx) => idx.search(&text_query, fetch_k),
+            Err(_) => vec![],
+        };
+
+        // ── 3. Fuse ──────────────────────────────────────────────────────────
+        let mut scores: HashMap<u64, f64> = HashMap::new();
+
+        if let Some(a) = alpha {
+            // Weighted fusion: normalise each list to [0,1] then blend.
+            let a = a.clamp(0.0, 1.0);
+            let max_vec = vec_results.first().map(|(_, s)| *s as f64).unwrap_or(1.0);
+            let max_fts = fts_results.first().map(|(_, s)| *s as f64).unwrap_or(1.0);
+
+            for (node_id, score) in &vec_results {
+                let norm = if max_vec > 0.0 {
+                    *score as f64 / max_vec
+                } else {
+                    0.0
+                };
+                *scores.entry(*node_id).or_insert(0.0) += a * norm;
+            }
+            for (node_id, score) in &fts_results {
+                let norm = if max_fts > 0.0 {
+                    *score as f64 / max_fts
+                } else {
+                    0.0
+                };
+                *scores.entry(*node_id).or_insert(0.0) += (1.0 - a) * norm;
+            }
+        } else {
+            // RRF: score += 1 / (60 + rank).
+            const RRF_K: f64 = 60.0;
+            for (rank, (node_id, _)) in vec_results.iter().enumerate() {
+                *scores.entry(*node_id).or_insert(0.0) += 1.0 / (RRF_K + rank as f64 + 1.0);
+            }
+            for (rank, (node_id, _)) in fts_results.iter().enumerate() {
+                *scores.entry(*node_id).or_insert(0.0) += 1.0 / (RRF_K + rank as f64 + 1.0);
+            }
+        }
+
+        // ── 4. Sort descending by fused score, truncate to k ─────────────────
+        let mut ranked: Vec<(u64, f64)> = scores.into_iter().collect();
+        ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        ranked.truncate(k_usize);
+
+        Ok(ranked
+            .into_iter()
+            .map(|(node_id, score)| NodeResult {
+                id: node_id.to_string(),
+                score,
+            })
+            .collect())
     }
 }
 

--- a/crates/sparrowdb-storage/src/wal/replay.rs
+++ b/crates/sparrowdb-storage/src/wal/replay.rs
@@ -329,10 +329,8 @@ impl WalReplayer {
                 WalRecordKind::Begin => {
                     begun.insert(rec.txn_id.0);
                 }
-                WalRecordKind::Commit => {
-                    if begun.contains(&rec.txn_id.0) {
-                        committed.insert(rec.txn_id.0);
-                    }
+                WalRecordKind::Commit if begun.contains(&rec.txn_id.0) => {
+                    committed.insert(rec.txn_id.0);
                 }
                 WalRecordKind::Abort => {
                     begun.remove(&rec.txn_id.0);
@@ -462,10 +460,8 @@ impl WalReplayer {
                 WalRecordKind::Begin => {
                     begun.insert(rec.txn_id.0);
                 }
-                WalRecordKind::Commit => {
-                    if begun.contains(&rec.txn_id.0) {
-                        committed.insert(rec.txn_id.0);
-                    }
+                WalRecordKind::Commit if begun.contains(&rec.txn_id.0) => {
+                    committed.insert(rec.txn_id.0);
                 }
                 WalRecordKind::Abort => {
                     begun.remove(&rec.txn_id.0);
@@ -501,17 +497,15 @@ impl WalReplayer {
                         entry.insert(name.clone());
                     }
                 }
-                WalPayload::NodeUpdate { node_id, key, .. } => {
-                    // Only include non-empty keys (guard against low-level
-                    // col_id-only paths that may not record a human-readable name).
-                    if !key.is_empty() {
-                        if let Some(&label_id) = node_label.get(node_id) {
-                            schema
-                                .node_props
-                                .entry(label_id)
-                                .or_default()
-                                .insert(key.clone());
-                        }
+                // Only include non-empty keys (guard against low-level
+                // col_id-only paths that may not record a human-readable name).
+                WalPayload::NodeUpdate { node_id, key, .. } if !key.is_empty() => {
+                    if let Some(&label_id) = node_label.get(node_id) {
+                        schema
+                            .node_props
+                            .entry(label_id)
+                            .or_default()
+                            .insert(key.clone());
                     }
                 }
                 WalPayload::EdgeCreate {

--- a/crates/sparrowdb-storage/src/wal/replay.rs
+++ b/crates/sparrowdb-storage/src/wal/replay.rs
@@ -157,10 +157,8 @@ impl WalReplayer {
                 WalRecordKind::Begin => {
                     begun.insert(rec.txn_id.0, true);
                 }
-                WalRecordKind::Commit => {
-                    if begun.contains_key(&rec.txn_id.0) {
-                        committed.insert(rec.txn_id.0);
-                    }
+                WalRecordKind::Commit if begun.contains_key(&rec.txn_id.0) => {
+                    committed.insert(rec.txn_id.0);
                 }
                 WalRecordKind::Abort => {
                     begun.remove(&rec.txn_id.0);


### PR DESCRIPTION
## Summary

- **Wires up `hybridSearch`** in the Node NAPI bindings — replaces the placeholder stub (which threw an error) with a full implementation now that PR #403 (RRF hybrid fusion) is on `main`
- **Bumps workspace version** `0.1.21 → 0.1.22` — all four KMS-enabling features have now landed (#398 HNSW, #399 BM25, #403 RRF, #402 Node NAPI)

## Implementation

The Node binding mirrors `eval_hybrid_search` in the execution engine, calling storage indexes directly (same pattern as `vectorSearch` / `fulltextSearch`):

1. **Vector search** via `get_vector_index()` (HNSW) — gracefully returns empty if no vector index exists
2. **Full-text search** via `FtsIndex::open()` (BM25) — gracefully returns empty if no FTS index exists
3. **RRF fusion** (k=60) by default; optional `alpha` parameter enables weighted fusion: `alpha * norm_vec + (1-alpha) * norm_bm25`
4. Returns top-k results sorted by descending fused score

```typescript
// RRF (default)
const hits = db.hybridSearch('Memory', 'content', 'embedding', queryVec, 'neural networks', 10)

// Weighted fusion (vector-heavy)
const hits2 = db.hybridSearch('Memory', 'content', 'embedding', queryVec, 'query', 10, 0.7)
// hits: Array<{ id: string, score: number }>
```

## Test plan

- [ ] CI: `cargo check` / `cargo clippy -D warnings` / `cargo fmt --check` pass on all crates
- [ ] CI: existing hybrid_search integration tests in `crates/sparrowdb/tests/hybrid_search.rs` pass (those test the execution-engine path; the Node binding uses the same storage primitives)
- [ ] Manual: `db.hybridSearch(...)` no longer throws "requires #396 to be merged"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hybrid search is now functional: combined vector + text results, optional alpha to control weighted fusion (or use reciprocal-rank fusion when omitted), improved ranking and default result limit (k defaults to 10).

* **Chores**
  * Project version bumped to 0.1.22.

* **Refactor**
  * Internal storage/wal logic simplified for more streamlined replay and schema handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->