### PR TITLE
feat(server): HTTP transport (Phase A) — sparrowdb-server crate (closes #291 phase A)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/sparrowdb-bench",
     "crates/sparrowdb-ruby",
     "crates/sparrowdb-bolt",
+    "crates/sparrowdb-server",
 ]
 
 [workspace.package]

--- a/crates/sparrowdb-server/Cargo.toml
+++ b/crates/sparrowdb-server/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "sparrowdb-server"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "HTTP REST server for SparrowDB (Phase A: synchronous JSON)"
+publish = false
+
+[lib]
+name = "sparrowdb_server"
+path = "src/lib.rs"
+
+[[bin]]
+name = "sparrowdb-server"
+path = "src/main.rs"
+
+[dependencies]
+sparrowdb = { workspace = true }
+sparrowdb-execution = { workspace = true }
+tiny_http = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+clap = { version = "4", features = ["derive", "env"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+ureq = { version = "2", features = ["json"] }

--- a/crates/sparrowdb-server/Cargo.toml
+++ b/crates/sparrowdb-server/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = { workspace = true }
 clap = { version = "4", features = ["derive", "env"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+constant_time_eq = "0.3"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/sparrowdb-server/src/auth.rs
+++ b/crates/sparrowdb-server/src/auth.rs
@@ -1,0 +1,131 @@
+//! Authentication for the HTTP server.
+//!
+//! Phase A supports a single bearer token (or no auth, gated to loopback).
+
+use std::net::{IpAddr, SocketAddr};
+
+/// How the server authenticates incoming requests.
+#[derive(Debug, Clone)]
+pub enum AuthConfig {
+    /// Require `Authorization: Bearer <token>` on every authenticated route.
+    BearerToken(String),
+    /// Disable authentication entirely.  Only valid when bound to loopback —
+    /// see [`AuthConfig::validate_against_bind`].
+    None,
+}
+
+impl AuthConfig {
+    /// Reject a [`AuthConfig::None`] policy bound to a non-loopback address.
+    ///
+    /// The HTTP server must never accept unauthenticated requests on an
+    /// externally reachable interface — that would expose the database to the
+    /// open internet.  This check is enforced at construction time.
+    pub fn validate_against_bind(&self, bind: SocketAddr) -> Result<(), String> {
+        match self {
+            AuthConfig::BearerToken(_) => Ok(()),
+            AuthConfig::None => {
+                if is_loopback_addr(bind.ip()) {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "refusing --no-auth on non-loopback address {bind}: \
+                         bearer-token auth is required when binding to a non-loopback interface"
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Check whether the supplied `Authorization` header value is acceptable.
+    ///
+    /// Returns `true` if auth is disabled, or the header carries a matching
+    /// `Bearer <token>` value.  Comparison is constant-time-ish: it walks
+    /// every byte of the expected token rather than short-circuiting on
+    /// mismatch, to make timing-attack reasoning slightly easier.
+    pub fn check_header(&self, header: Option<&str>) -> bool {
+        match self {
+            AuthConfig::None => true,
+            AuthConfig::BearerToken(expected) => {
+                let Some(value) = header else {
+                    return false;
+                };
+                let Some(presented) = value.strip_prefix("Bearer ") else {
+                    return false;
+                };
+                let presented = presented.trim();
+                constant_time_eq(presented.as_bytes(), expected.as_bytes())
+            }
+        }
+    }
+}
+
+/// Return `true` if `addr` is a loopback IP (127.0.0.0/8 or ::1).
+pub fn is_loopback_addr(addr: IpAddr) -> bool {
+    addr.is_loopback()
+}
+
+/// Constant-ish-time byte comparison.
+///
+/// Walks the longer of the two slices to avoid leaking the length of `expected`.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::SocketAddr;
+
+    #[test]
+    fn loopback_v4_accepts_no_auth() {
+        let cfg = AuthConfig::None;
+        let addr: SocketAddr = "127.0.0.1:7480".parse().unwrap();
+        assert!(cfg.validate_against_bind(addr).is_ok());
+    }
+
+    #[test]
+    fn loopback_v6_accepts_no_auth() {
+        let cfg = AuthConfig::None;
+        let addr: SocketAddr = "[::1]:7480".parse().unwrap();
+        assert!(cfg.validate_against_bind(addr).is_ok());
+    }
+
+    #[test]
+    fn non_loopback_rejects_no_auth() {
+        let cfg = AuthConfig::None;
+        let addr: SocketAddr = "0.0.0.0:7480".parse().unwrap();
+        assert!(cfg.validate_against_bind(addr).is_err());
+        let addr: SocketAddr = "192.168.1.10:7480".parse().unwrap();
+        assert!(cfg.validate_against_bind(addr).is_err());
+    }
+
+    #[test]
+    fn non_loopback_accepts_token() {
+        let cfg = AuthConfig::BearerToken("secret".into());
+        let addr: SocketAddr = "0.0.0.0:7480".parse().unwrap();
+        assert!(cfg.validate_against_bind(addr).is_ok());
+    }
+
+    #[test]
+    fn token_check_matches() {
+        let cfg = AuthConfig::BearerToken("secret".into());
+        assert!(cfg.check_header(Some("Bearer secret")));
+        assert!(!cfg.check_header(Some("Bearer wrong")));
+        assert!(!cfg.check_header(Some("secret"))); // missing prefix
+        assert!(!cfg.check_header(None));
+    }
+
+    #[test]
+    fn no_auth_always_passes() {
+        let cfg = AuthConfig::None;
+        assert!(cfg.check_header(None));
+        assert!(cfg.check_header(Some("Bearer anything")));
+    }
+}

--- a/crates/sparrowdb-server/src/auth.rs
+++ b/crates/sparrowdb-server/src/auth.rs
@@ -2,6 +2,7 @@
 //!
 //! Phase A supports a single bearer token (or no auth, gated to loopback).
 
+use constant_time_eq::constant_time_eq;
 use std::net::{IpAddr, SocketAddr};
 
 /// How the server authenticates incoming requests.
@@ -39,9 +40,9 @@ impl AuthConfig {
     /// Check whether the supplied `Authorization` header value is acceptable.
     ///
     /// Returns `true` if auth is disabled, or the header carries a matching
-    /// `Bearer <token>` value.  Comparison is constant-time-ish: it walks
-    /// every byte of the expected token rather than short-circuiting on
-    /// mismatch, to make timing-attack reasoning slightly easier.
+    /// `Bearer <token>` value.  Comparison is constant-time via the
+    /// `constant_time_eq` crate, which handles both differing lengths and
+    /// differing contents without short-circuiting.
     pub fn check_header(&self, header: Option<&str>) -> bool {
         match self {
             AuthConfig::None => true,
@@ -62,20 +63,6 @@ impl AuthConfig {
 /// Return `true` if `addr` is a loopback IP (127.0.0.0/8 or ::1).
 pub fn is_loopback_addr(addr: IpAddr) -> bool {
     addr.is_loopback()
-}
-
-/// Constant-ish-time byte comparison.
-///
-/// Walks the longer of the two slices to avoid leaking the length of `expected`.
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut diff: u8 = 0;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
 }
 
 #[cfg(test)]

--- a/crates/sparrowdb-server/src/handlers.rs
+++ b/crates/sparrowdb-server/src/handlers.rs
@@ -20,12 +20,11 @@ const MAX_BODY_BYTES: usize = 1024 * 1024;
 pub fn dispatch(mut req: Request, db: &GraphDb, auth: &AuthConfig) {
     let method = req.method().clone();
     // Strip query string — Phase A has no query parameters.
-    let raw_url = req.url().to_owned();
-    let path = raw_url.split('?').next().unwrap_or("").to_owned();
+    let path = req.url().split('?').next().unwrap_or("");
 
     tracing::debug!(?method, %path, "incoming request");
 
-    let response = match (&method, path.as_str()) {
+    let response = match (&method, path) {
         // CORS preflight — answer any path.
         (Method::Options, _) => cors_preflight(),
 

--- a/crates/sparrowdb-server/src/handlers.rs
+++ b/crates/sparrowdb-server/src/handlers.rs
@@ -1,0 +1,344 @@
+//! HTTP route handlers.
+//!
+//! Each handler returns a [`tiny_http::Response`] with `Content-Type:
+//! application/json` and a permissive CORS header set.  Response bodies are
+//! always JSON (an object, never a bare value) so clients can rely on a
+//! consistent shape.
+
+use crate::auth::AuthConfig;
+use crate::VERSION;
+use sparrowdb::GraphDb;
+use sparrowdb_execution::{json::query_result_to_json, Value};
+use std::collections::HashMap;
+use std::io::Read;
+use tiny_http::{Header, Method, Request, Response};
+
+/// Maximum accepted request body length (1 MiB) — protects against runaway POSTs.
+const MAX_BODY_BYTES: usize = 1024 * 1024;
+
+/// Top-level dispatcher.  Routes by `(method, path)`.
+pub fn dispatch(mut req: Request, db: &GraphDb, auth: &AuthConfig) {
+    let method = req.method().clone();
+    // Strip query string — Phase A has no query parameters.
+    let raw_url = req.url().to_owned();
+    let path = raw_url.split('?').next().unwrap_or("").to_owned();
+
+    tracing::debug!(?method, %path, "incoming request");
+
+    let response = match (&method, path.as_str()) {
+        // CORS preflight — answer any path.
+        (Method::Options, _) => cors_preflight(),
+
+        // Public routes.
+        (Method::Get, "/health") | (Method::Get, "/health/") => handle_health(),
+
+        // Authenticated routes.
+        (Method::Get, "/info") | (Method::Get, "/info/") => {
+            if !check_auth(&req, auth) {
+                unauthorized()
+            } else {
+                handle_info(db)
+            }
+        }
+        (Method::Post, "/cypher") | (Method::Post, "/cypher/") => {
+            if !check_auth(&req, auth) {
+                unauthorized()
+            } else {
+                handle_cypher(&mut req, db)
+            }
+        }
+
+        // Anything else.
+        _ => not_found(),
+    };
+
+    if let Err(e) = req.respond(response) {
+        tracing::warn!("response write error: {e}");
+    }
+}
+
+// ── Auth helpers ────────────────────────────────────────────────────
+
+fn check_auth(req: &Request, auth: &AuthConfig) -> bool {
+    let header = req
+        .headers()
+        .iter()
+        .find(|h| h.field.equiv("Authorization"))
+        .map(|h| h.value.as_str());
+    auth.check_header(header)
+}
+
+// ── Route handlers ──────────────────────────────────────────────────
+
+fn handle_health() -> Response<std::io::Cursor<Vec<u8>>> {
+    let body = serde_json::json!({
+        "status": "ok",
+        "version": VERSION,
+    });
+    json_response(200, &body)
+}
+
+fn handle_info(db: &GraphDb) -> Response<std::io::Cursor<Vec<u8>>> {
+    let labels = match db.labels() {
+        Ok(v) => v,
+        Err(e) => return engine_error(&e.to_string()),
+    };
+    let rel_types = match db.relationship_types() {
+        Ok(v) => v,
+        Err(e) => return engine_error(&e.to_string()),
+    };
+    let (nodes, edges) = match db.db_counts() {
+        Ok(v) => v,
+        Err(e) => return engine_error(&e.to_string()),
+    };
+
+    let body = serde_json::json!({
+        "version": VERSION,
+        "labels": labels,
+        "relationship_types": rel_types,
+        "counts": {
+            "nodes": nodes,
+            "edges": edges,
+        },
+    });
+    json_response(200, &body)
+}
+
+fn handle_cypher(req: &mut Request, db: &GraphDb) -> Response<std::io::Cursor<Vec<u8>>> {
+    // Read body up to MAX_BODY_BYTES.
+    let body = match read_body(req) {
+        Ok(b) => b,
+        Err(e) => return bad_request(&format!("failed to read request body: {e}")),
+    };
+
+    // Parse the JSON envelope.
+    #[derive(serde::Deserialize)]
+    struct CypherRequest {
+        query: String,
+        #[serde(default)]
+        params: serde_json::Value, // optional; may be Null or {}
+    }
+
+    let parsed: CypherRequest = match serde_json::from_slice(&body) {
+        Ok(p) => p,
+        Err(e) => return bad_request(&format!("invalid JSON body: {e}")),
+    };
+
+    if parsed.query.trim().is_empty() {
+        return bad_request("query string is empty");
+    }
+
+    // Convert the optional `params` JSON object into Value map.
+    let params = match parsed.params {
+        serde_json::Value::Null => HashMap::new(),
+        serde_json::Value::Object(map) => {
+            let mut out = HashMap::with_capacity(map.len());
+            for (k, v) in map {
+                match json_to_value(v) {
+                    Ok(val) => {
+                        out.insert(k, val);
+                    }
+                    Err(e) => {
+                        return bad_request(&format!(
+                            "param `{k}` could not be coerced to a SparrowDB value: {e}"
+                        ));
+                    }
+                }
+            }
+            out
+        }
+        _ => return bad_request("`params` must be a JSON object or null"),
+    };
+
+    // Execute against the engine.
+    let result = if params.is_empty() {
+        db.execute(&parsed.query)
+    } else {
+        db.execute_with_params(&parsed.query, params)
+    };
+
+    match result {
+        Ok(r) => json_response(200, &query_result_to_json(&r)),
+        Err(e) => engine_error(&e.to_string()),
+    }
+}
+
+// ── Error responses ─────────────────────────────────────────────────
+
+fn unauthorized() -> Response<std::io::Cursor<Vec<u8>>> {
+    json_response(
+        401,
+        &serde_json::json!({
+            "error": "unauthorized: missing or invalid bearer token",
+        }),
+    )
+}
+
+fn bad_request(msg: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    json_response(400, &serde_json::json!({ "error": msg }))
+}
+
+fn engine_error(msg: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    json_response(500, &serde_json::json!({ "error": msg }))
+}
+
+fn not_found() -> Response<std::io::Cursor<Vec<u8>>> {
+    json_response(
+        404,
+        &serde_json::json!({
+            "error": "not found",
+        }),
+    )
+}
+
+fn cors_preflight() -> Response<std::io::Cursor<Vec<u8>>> {
+    // Empty 204 with CORS headers.
+    let mut response = Response::from_data(Vec::<u8>::new()).with_status_code(204);
+    for h in cors_headers() {
+        response.add_header(h);
+    }
+    response
+}
+
+// ── Response builder ────────────────────────────────────────────────
+
+fn json_response(status: u16, body: &serde_json::Value) -> Response<std::io::Cursor<Vec<u8>>> {
+    let bytes = serde_json::to_vec(body).unwrap_or_else(|_| b"{}".to_vec());
+    let mut response = Response::from_data(bytes).with_status_code(status);
+    response.add_header(
+        "Content-Type: application/json; charset=utf-8"
+            .parse::<Header>()
+            .expect("static header parses"),
+    );
+    for h in cors_headers() {
+        response.add_header(h);
+    }
+    response
+}
+
+/// Permissive Phase-1 CORS — `*` origin, POST + GET, common headers.
+fn cors_headers() -> Vec<Header> {
+    vec![
+        "Access-Control-Allow-Origin: *"
+            .parse()
+            .expect("static header parses"),
+        "Access-Control-Allow-Methods: POST, GET, OPTIONS"
+            .parse()
+            .expect("static header parses"),
+        "Access-Control-Allow-Headers: Authorization, Content-Type"
+            .parse()
+            .expect("static header parses"),
+    ]
+}
+
+// ── Body reading ────────────────────────────────────────────────────
+
+fn read_body(req: &mut Request) -> std::io::Result<Vec<u8>> {
+    // If a Content-Length header was supplied, refuse early on huge bodies.
+    if let Some(len) = req.body_length() {
+        if len > MAX_BODY_BYTES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("body too large: {len} > {MAX_BODY_BYTES}"),
+            ));
+        }
+    }
+    let mut buf = Vec::new();
+    let n = req
+        .as_reader()
+        .take((MAX_BODY_BYTES as u64) + 1)
+        .read_to_end(&mut buf)?;
+    if n > MAX_BODY_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("body too large: > {MAX_BODY_BYTES}"),
+        ));
+    }
+    Ok(buf)
+}
+
+// ── JSON ⇒ Value ────────────────────────────────────────────────────
+
+/// Best-effort conversion from a JSON value into a SparrowDB [`Value`].
+///
+/// Maps:
+/// - `null` → [`Value::Null`]
+/// - `true` / `false` → [`Value::Bool`]
+/// - numbers without a fractional part that fit in `i64` → [`Value::Int64`]
+/// - any other number → [`Value::Float64`]
+/// - strings → [`Value::String`]
+/// - arrays → [`Value::List`] (recursively)
+/// - objects → [`Value::Map`] with stable key ordering (recursively)
+///
+/// Returns `Err` if a number is not representable as `i64` *or* `f64`
+/// (effectively never — `serde_json::Number` only carries those — but the
+/// signature leaves room for stricter types later).
+fn json_to_value(v: serde_json::Value) -> Result<Value, String> {
+    match v {
+        serde_json::Value::Null => Ok(Value::Null),
+        serde_json::Value::Bool(b) => Ok(Value::Bool(b)),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(Value::Int64(i))
+            } else if let Some(f) = n.as_f64() {
+                Ok(Value::Float64(f))
+            } else {
+                Err(format!("number `{n}` not representable as i64 or f64"))
+            }
+        }
+        serde_json::Value::String(s) => Ok(Value::String(s)),
+        serde_json::Value::Array(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items {
+                out.push(json_to_value(item)?);
+            }
+            Ok(Value::List(out))
+        }
+        serde_json::Value::Object(map) => {
+            let mut out = Vec::with_capacity(map.len());
+            for (k, v) in map {
+                out.push((k, json_to_value(v)?));
+            }
+            Ok(Value::Map(out))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_int_to_value() {
+        assert_eq!(
+            json_to_value(serde_json::json!(42)).unwrap(),
+            Value::Int64(42)
+        );
+    }
+
+    #[test]
+    fn json_float_to_value() {
+        match json_to_value(serde_json::json!(2.5)).unwrap() {
+            Value::Float64(f) => assert!((f - 2.5).abs() < 1e-9),
+            other => panic!("expected Float64, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_array_to_list() {
+        let v = json_to_value(serde_json::json!([1, "two", true])).unwrap();
+        let Value::List(items) = v else {
+            panic!("expected list")
+        };
+        assert_eq!(items.len(), 3);
+    }
+
+    #[test]
+    fn json_object_to_map() {
+        let v = json_to_value(serde_json::json!({"a": 1, "b": "two"})).unwrap();
+        let Value::Map(entries) = v else {
+            panic!("expected map")
+        };
+        assert_eq!(entries.len(), 2);
+    }
+}

--- a/crates/sparrowdb-server/src/lib.rs
+++ b/crates/sparrowdb-server/src/lib.rs
@@ -1,0 +1,34 @@
+//! SparrowDB HTTP server library (Phase A).
+//!
+//! Provides a synchronous JSON HTTP API that routes Cypher queries to a
+//! [`sparrowdb::GraphDb`] instance.  Built on top of `tiny_http` to match the
+//! single-writer multi-reader (SWMR) engine model — every request runs on a
+//! worker thread with a cloned `GraphDb` handle.
+//!
+//! # Routes
+//!
+//! | Method | Path        | Auth | Description                                    |
+//! |--------|-------------|------|------------------------------------------------|
+//! | GET    | `/health`   | no   | Liveness probe; returns `{ "status": "ok", … }` |
+//! | GET    | `/info`     | yes  | DB metadata: labels, rel types, node/edge counts |
+//! | POST   | `/cypher`   | yes  | Execute a Cypher query, returns columns + rows |
+//!
+//! # Auth
+//!
+//! Requests must carry `Authorization: Bearer <token>` unless the server was
+//! constructed with [`AuthConfig::None`] **and** bound to a loopback address.
+//!
+//! # Streaming
+//!
+//! Phase A buffers the full result set into a JSON document.  SSE / chunked
+//! NDJSON streaming is Phase B.
+
+pub mod auth;
+pub mod handlers;
+pub mod server;
+
+pub use auth::{is_loopback_addr, AuthConfig};
+pub use server::{Server, ServerConfig};
+
+/// The crate version, used by `/health`.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/sparrowdb-server/src/main.rs
+++ b/crates/sparrowdb-server/src/main.rs
@@ -1,0 +1,109 @@
+//! `sparrowdb-server` — HTTP REST server for SparrowDB (Phase A).
+//!
+//! Boots a [`sparrowdb::GraphDb`] from a directory and serves the HTTP API
+//! defined in `sparrowdb_server`.
+//!
+//! ```text
+//! sparrowdb-server --db /path/to/db --port 7480 --token-file /etc/sparrow.token
+//! ```
+
+use clap::Parser;
+use sparrowdb::GraphDb;
+use sparrowdb_server::{AuthConfig, Server, ServerConfig};
+use std::net::{IpAddr, SocketAddr};
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "sparrowdb-server",
+    about = "HTTP REST server for SparrowDB (Phase A)"
+)]
+struct Args {
+    /// Path to the SparrowDB database directory.
+    #[arg(long, env = "SPARROWDB_PATH")]
+    db: PathBuf,
+
+    /// Bind address (IP).  Default: `127.0.0.1`.
+    #[arg(long, default_value = "127.0.0.1")]
+    bind: String,
+
+    /// Port to listen on.  Default: `7480`.
+    #[arg(long, default_value_t = 7480)]
+    port: u16,
+
+    /// File containing the bearer token (single line, trimmed).
+    /// Conflicts with `--no-auth`.  If omitted, falls back to
+    /// `$SPARROWDB_HTTP_TOKEN`.
+    #[arg(long)]
+    token_file: Option<PathBuf>,
+
+    /// Disable authentication entirely.
+    /// Refused on any non-loopback bind address.
+    #[arg(long, default_value_t = false)]
+    no_auth: bool,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "sparrowdb_server=info".into()),
+        )
+        .init();
+
+    let args = Args::parse();
+
+    let ip: IpAddr = args
+        .bind
+        .parse()
+        .map_err(|e| format!("invalid --bind `{}`: {e}", args.bind))?;
+    let addr = SocketAddr::new(ip, args.port);
+
+    let auth = resolve_auth(&args)?;
+    let cfg = ServerConfig {
+        auth,
+        ..Default::default()
+    };
+
+    let db = GraphDb::open(&args.db)?;
+    tracing::info!("opened database at {:?}", args.db);
+
+    let server = Server::new(addr, cfg)?;
+    tracing::info!("HTTP server bound to {}", server.local_addr());
+
+    server.serve(db);
+    Ok(())
+}
+
+/// Determine the authentication policy from CLI flags + env vars.
+fn resolve_auth(args: &Args) -> Result<AuthConfig, String> {
+    if args.no_auth {
+        if args.token_file.is_some() {
+            return Err("--no-auth conflicts with --token-file".into());
+        }
+        return Ok(AuthConfig::None);
+    }
+
+    if let Some(path) = &args.token_file {
+        let raw = std::fs::read_to_string(path)
+            .map_err(|e| format!("could not read --token-file {path:?}: {e}"))?;
+        let token = raw.trim().to_owned();
+        if token.is_empty() {
+            return Err(format!("token file {path:?} is empty"));
+        }
+        return Ok(AuthConfig::BearerToken(token));
+    }
+
+    if let Ok(token) = std::env::var("SPARROWDB_HTTP_TOKEN") {
+        let token = token.trim().to_owned();
+        if !token.is_empty() {
+            return Ok(AuthConfig::BearerToken(token));
+        }
+    }
+
+    Err(
+        "no authentication configured: pass --token-file <path>, set SPARROWDB_HTTP_TOKEN, \
+         or pass --no-auth (loopback bind only)"
+            .into(),
+    )
+}

--- a/crates/sparrowdb-server/src/server.rs
+++ b/crates/sparrowdb-server/src/server.rs
@@ -1,0 +1,109 @@
+//! HTTP server orchestrator.
+
+use crate::auth::AuthConfig;
+use crate::handlers;
+use sparrowdb::GraphDb;
+use std::net::SocketAddr;
+
+/// Server runtime configuration (auth + worker thread count).
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    /// Authentication policy.
+    pub auth: AuthConfig,
+    /// Number of worker threads handling requests.  Defaults to
+    /// `min(num_cpus, 8)`.
+    pub workers: usize,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        let workers = std::thread::available_parallelism()
+            .map(|n| n.get().min(8))
+            .unwrap_or(4);
+        Self {
+            auth: AuthConfig::None,
+            workers,
+        }
+    }
+}
+
+/// HTTP server that routes Cypher queries to a [`GraphDb`].
+///
+/// The server is single-threaded for `accept`, with a fixed pool of worker
+/// threads pulling requests off the shared `tiny_http::Server` queue.
+pub struct Server {
+    inner: tiny_http::Server,
+    addr: SocketAddr,
+    config: ServerConfig,
+}
+
+impl Server {
+    /// Bind a server to `addr` with the given config.
+    ///
+    /// Validates the auth policy against the bind address — refuses
+    /// `--no-auth` on any non-loopback interface.
+    pub fn new(addr: SocketAddr, config: ServerConfig) -> Result<Self, String> {
+        config
+            .auth
+            .validate_against_bind(addr)
+            .map_err(|e| e.to_string())?;
+
+        let inner = tiny_http::Server::http(addr).map_err(|e| e.to_string())?;
+        let bound = inner
+            .server_addr()
+            .to_ip()
+            .ok_or_else(|| "tiny_http did not return an IP socket".to_string())?;
+
+        Ok(Self {
+            inner,
+            addr: bound,
+            config,
+        })
+    }
+
+    /// Return the resolved local socket address (useful when port `0` was
+    /// supplied to bind to a random free port — common in tests).
+    pub fn local_addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// Serve requests forever, blocking the caller.
+    ///
+    /// Internally spawns `config.workers` OS threads; each pulls requests off
+    /// the shared queue and dispatches them to [`handlers::dispatch`].  The
+    /// underlying `GraphDb` is cloned for each worker so SWMR semantics are
+    /// preserved.
+    pub fn serve(self, db: GraphDb) {
+        tracing::info!(addr = %self.addr, workers = self.config.workers, "sparrowdb-server: HTTP listening");
+
+        let server = std::sync::Arc::new(self.inner);
+        let auth = std::sync::Arc::new(self.config.auth);
+
+        let mut handles = Vec::with_capacity(self.config.workers);
+        for i in 0..self.config.workers {
+            let server = std::sync::Arc::clone(&server);
+            let auth = std::sync::Arc::clone(&auth);
+            let db = db.clone();
+            handles.push(
+                std::thread::Builder::new()
+                    .name(format!("sparrowdb-http-{i}"))
+                    .spawn(move || loop {
+                        match server.recv() {
+                            Ok(req) => handlers::dispatch(req, &db, &auth),
+                            Err(e) => {
+                                tracing::error!("sparrowdb-server: recv error: {e}");
+                                break;
+                            }
+                        }
+                    })
+                    .expect("spawn worker thread"),
+            );
+        }
+
+        // Block on workers — `tiny_http::Server::recv` only returns an error
+        // when the server is dropped, so the workers exit together.
+        for h in handles {
+            let _ = h.join();
+        }
+    }
+}

--- a/crates/sparrowdb-server/tests/http_integration.rs
+++ b/crates/sparrowdb-server/tests/http_integration.rs
@@ -1,0 +1,234 @@
+//! Integration test: spin up an HTTP server, send real HTTP requests with
+//! `ureq`, verify the JSON envelope and status codes.
+//!
+//! Each test uses port `0` so the OS picks a free port — keeps tests
+//! parallel-safe.
+
+use sparrowdb::GraphDb;
+use sparrowdb_server::{AuthConfig, Server, ServerConfig};
+use std::net::SocketAddr;
+use std::time::Duration;
+
+const TOKEN: &str = "test-token-12345";
+
+/// Spin up a server on a random loopback port and return its `SocketAddr`.
+fn start_server(db: GraphDb, auth: AuthConfig) -> SocketAddr {
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let cfg = ServerConfig { auth, workers: 2 };
+    let server = Server::new(addr, cfg).expect("bind server");
+    let local = server.local_addr();
+
+    std::thread::spawn(move || server.serve(db));
+
+    // Give the worker threads a moment to start consuming.
+    std::thread::sleep(Duration::from_millis(50));
+    local
+}
+
+fn url(addr: SocketAddr, path: &str) -> String {
+    format!("http://{addr}{path}")
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+#[test]
+fn health_is_unauthenticated() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    let addr = start_server(db, AuthConfig::BearerToken(TOKEN.into()));
+
+    // No Authorization header — should still succeed.
+    let resp = ureq::get(&url(addr, "/health"))
+        .timeout(Duration::from_secs(5))
+        .call()
+        .expect("GET /health");
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.into_json().expect("parse json");
+    assert_eq!(body["status"], "ok");
+    assert!(body["version"].is_string());
+}
+
+#[test]
+fn cypher_with_valid_token_executes() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    let addr = start_server(db, AuthConfig::BearerToken(TOKEN.into()));
+
+    // Seed the DB with a CREATE.
+    let resp = ureq::post(&url(addr, "/cypher"))
+        .set("Authorization", &format!("Bearer {TOKEN}"))
+        .set("Content-Type", "application/json")
+        .timeout(Duration::from_secs(5))
+        .send_json(serde_json::json!({
+            "query": "CREATE (n:Test {name: 'alice'}) RETURN n.name",
+        }))
+        .expect("POST /cypher");
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.into_json().expect("parse json");
+    assert_eq!(body["columns"], serde_json::json!(["n.name"]));
+    let rows = body["rows"].as_array().expect("rows array");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["n.name"], "alice");
+
+    // Read it back.
+    let resp = ureq::post(&url(addr, "/cypher"))
+        .set("Authorization", &format!("Bearer {TOKEN}"))
+        .set("Content-Type", "application/json")
+        .timeout(Duration::from_secs(5))
+        .send_json(serde_json::json!({
+            "query": "MATCH (n:Test) RETURN n.name",
+        }))
+        .expect("POST /cypher (read)");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.into_json().unwrap();
+    let rows = body["rows"].as_array().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["n.name"], "alice");
+}
+
+#[test]
+fn cypher_without_auth_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    let addr = start_server(db, AuthConfig::BearerToken(TOKEN.into()));
+
+    // No Authorization header.
+    let resp_err = ureq::post(&url(addr, "/cypher"))
+        .set("Content-Type", "application/json")
+        .timeout(Duration::from_secs(5))
+        .send_json(serde_json::json!({ "query": "RETURN 1" }))
+        .expect_err("expected 401");
+
+    let resp = match resp_err {
+        ureq::Error::Status(_, r) => r,
+        ureq::Error::Transport(t) => panic!("transport error: {t}"),
+    };
+    assert_eq!(resp.status(), 401);
+    let body: serde_json::Value = resp.into_json().expect("parse json");
+    assert!(body["error"].as_str().unwrap().contains("unauthorized"));
+}
+
+#[test]
+fn cypher_with_malformed_json_returns_400() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    let addr = start_server(db, AuthConfig::BearerToken(TOKEN.into()));
+
+    let resp_err = ureq::post(&url(addr, "/cypher"))
+        .set("Authorization", &format!("Bearer {TOKEN}"))
+        .set("Content-Type", "application/json")
+        .timeout(Duration::from_secs(5))
+        .send_string("{ this is not valid json")
+        .expect_err("expected 400");
+
+    let resp = match resp_err {
+        ureq::Error::Status(_, r) => r,
+        ureq::Error::Transport(t) => panic!("transport error: {t}"),
+    };
+    assert_eq!(resp.status(), 400);
+    let body: serde_json::Value = resp.into_json().expect("parse json");
+    assert!(body["error"].as_str().unwrap().contains("invalid JSON"));
+}
+
+#[test]
+fn info_returns_structure() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    let addr = start_server(db, AuthConfig::BearerToken(TOKEN.into()));
+
+    // Create a node so we have a label registered.
+    ureq::post(&url(addr, "/cypher"))
+        .set("Authorization", &format!("Bearer {TOKEN}"))
+        .set("Content-Type", "application/json")
+        .timeout(Duration::from_secs(5))
+        .send_json(serde_json::json!({
+            "query": "CREATE (:Person {name: 'bob'})",
+        }))
+        .unwrap();
+
+    let resp = ureq::get(&url(addr, "/info"))
+        .set("Authorization", &format!("Bearer {TOKEN}"))
+        .timeout(Duration::from_secs(5))
+        .call()
+        .expect("GET /info");
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.into_json().expect("parse json");
+    assert!(body["version"].is_string());
+    assert!(body["labels"].is_array());
+    assert!(body["relationship_types"].is_array());
+    assert!(body["counts"]["nodes"].is_number());
+    assert!(body["counts"]["edges"].is_number());
+
+    let labels: Vec<String> = body["labels"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(labels.iter().any(|l| l == "Person"));
+}
+
+#[test]
+fn no_auth_rejected_on_non_loopback_bind() {
+    // We don't actually bind to 0.0.0.0 — Server::new validates the policy
+    // before opening the listener.
+    let addr: SocketAddr = "0.0.0.0:7481".parse().unwrap();
+    let cfg = ServerConfig {
+        auth: AuthConfig::None,
+        workers: 1,
+    };
+    let err = match Server::new(addr, cfg) {
+        Ok(_) => panic!("must reject --no-auth on 0.0.0.0"),
+        Err(e) => e,
+    };
+    assert!(
+        err.contains("non-loopback"),
+        "unexpected error message: {err}"
+    );
+}
+
+#[test]
+fn no_auth_allowed_on_loopback() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    let addr = start_server(db, AuthConfig::None);
+
+    let resp = ureq::post(&url(addr, "/cypher"))
+        .set("Content-Type", "application/json")
+        .timeout(Duration::from_secs(5))
+        .send_json(serde_json::json!({
+            "query": "RETURN 1 AS n",
+        }))
+        .expect("POST /cypher with no auth");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.into_json().unwrap();
+    let rows = body["rows"].as_array().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["n"], 1);
+}
+
+#[test]
+fn cypher_with_params() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    let addr = start_server(db, AuthConfig::BearerToken(TOKEN.into()));
+
+    let resp = ureq::post(&url(addr, "/cypher"))
+        .set("Authorization", &format!("Bearer {TOKEN}"))
+        .set("Content-Type", "application/json")
+        .timeout(Duration::from_secs(5))
+        .send_json(serde_json::json!({
+            "query": "UNWIND $names AS name RETURN name",
+            "params": { "names": ["alice", "bob", "carol"] },
+        }))
+        .expect("POST /cypher with params");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.into_json().unwrap();
+    let rows = body["rows"].as_array().unwrap();
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0]["name"], "alice");
+    assert_eq!(rows[2]["name"], "carol");
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -664,3 +664,140 @@ WalReplayer::replay(wal_dir, last_applied_lsn, |page_id, data, lsn| {
     Ok(())
 })?;
 ```
+
+---
+
+## HTTP API (`sparrowdb-server`, Phase A)
+
+The `sparrowdb-server` crate exposes a small JSON-over-HTTP surface so
+language-agnostic clients (browsers, `curl`, Go, Java, etc.) can run Cypher
+queries against an embedded SparrowDB instance without speaking Bolt.
+
+The server is synchronous (`tiny_http` worker pool) and routes every request
+to a cloned `GraphDb` handle, matching the SWMR engine model.  Phase A
+buffers full result sets into a JSON response.  Streaming (SSE / NDJSON) is
+Phase B.
+
+### Binary
+
+```bash
+sparrowdb-server \
+  --db /path/to/sparrowdb \
+  --bind 127.0.0.1 \
+  --port 7480 \
+  --token-file /etc/sparrowdb/http.token
+```
+
+| Flag           | Default       | Notes                                                          |
+|----------------|---------------|----------------------------------------------------------------|
+| `--db`         | (required)    | Database directory.  Also reads `SPARROWDB_PATH`.              |
+| `--bind`       | `127.0.0.1`   | IP to bind to.  Use `0.0.0.0` to expose the server externally. |
+| `--port`       | `7480`        | TCP port.                                                      |
+| `--token-file` | (none)        | File containing the bearer token (single line, trimmed).       |
+| `--no-auth`    | `false`       | Disable auth.  **Refused** on any non-loopback bind address.   |
+
+The bearer token may also be supplied via `SPARROWDB_HTTP_TOKEN`.
+
+### Authentication
+
+Authenticated routes require:
+
+```
+Authorization: Bearer <token>
+```
+
+`/health` is intentionally unauthenticated so liveness probes work without
+secrets.  `--no-auth` is only allowed on loopback (`127.0.0.0/8`, `::1`) —
+attempts to combine `--no-auth` with a non-loopback `--bind` are rejected
+at startup.
+
+### Routes
+
+#### `GET /health`
+
+No auth.  Liveness probe.
+
+```json
+{ "status": "ok", "version": "0.1.22" }
+```
+
+#### `GET /info`
+
+Auth required.  Returns DB metadata.
+
+```json
+{
+  "version": "0.1.22",
+  "labels": ["Person", "Movie"],
+  "relationship_types": ["ACTED_IN", "DIRECTED"],
+  "counts": { "nodes": 8400, "edges": 16002 }
+}
+```
+
+#### `POST /cypher`
+
+Auth required.  Executes a single Cypher statement.
+
+Request:
+```json
+{
+  "query": "MATCH (n:Person) WHERE n.name = $name RETURN n.name",
+  "params": { "name": "alice" }
+}
+```
+
+`params` is optional; omit or set to `null`/`{}` for no parameters.  Values
+are coerced as follows:
+
+| JSON type        | SparrowDB `Value`     |
+|------------------|-----------------------|
+| `null`           | `Null`                |
+| `true`/`false`   | `Bool`                |
+| integer number   | `Int64`               |
+| fractional number| `Float64`             |
+| string           | `String`              |
+| array            | `List` (recursive)    |
+| object           | `Map` (recursive)     |
+
+Response (`200 OK`):
+
+```json
+{
+  "columns": ["n.name"],
+  "rows": [ { "n.name": "alice" } ]
+}
+```
+
+`NodeRef` and `EdgeRef` values are encoded as
+`{"$type":"node","id":"<u64-as-string>"}` to preserve precision across the
+JSON boundary (see `sparrowdb_execution::json::value_to_json`).
+
+#### Errors
+
+All error responses are JSON `{ "error": "<message>" }`.
+
+| Status | Cause                                                         |
+|--------|---------------------------------------------------------------|
+| `400`  | Malformed body, empty query, or non-coercible parameter type. |
+| `401`  | Missing or invalid bearer token.                              |
+| `404`  | Unknown route.                                                |
+| `500`  | Engine error (parse, bind, execute).                          |
+
+### CORS
+
+Phase A serves a permissive CORS policy:
+
+```
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Headers: Authorization, Content-Type
+```
+
+`OPTIONS` preflight requests are answered with `204 No Content` and the
+headers above.
+
+### Library use
+
+The crate also exposes `Server::new(addr, ServerConfig)` for embedding the
+HTTP transport directly into a Rust application — useful for tests and for
+applications that already own a `GraphDb`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ The workspace contains eleven crates. The five that form the core are:
 
 The top-level `sparrowdb` crate re-exports the public API (`GraphDb`, `ReadTx`, `WriteTx`, `Value`, `NodeId`, `EdgeId`, `Error`, `QueryResult`) and owns the SWMR transaction machinery and the in-memory MVCC version store.
 
-The remaining crates are language bindings (`sparrowdb-python`, `sparrowdb-node`, `sparrowdb-ruby`), a CLI (`sparrowdb-cli`), an MCP server (`sparrowdb-mcp`), and a metrics exporter (`sparrowdb-metrics`).
+The remaining crates are language bindings (`sparrowdb-python`, `sparrowdb-node`, `sparrowdb-ruby`), a CLI (`sparrowdb-cli`), an MCP server (`sparrowdb-mcp`), a metrics exporter (`sparrowdb-metrics`), and two network transports — the Bolt-protocol server (`sparrowdb-bolt`, port 7687 by default) for Neo4j-compatible drivers, and an HTTP REST server (`sparrowdb-server`, port 7480 by default) that exposes JSON-over-HTTP for browsers and language-agnostic clients.
 
 ---
 


### PR DESCRIPTION
## Summary

Introduces a new `sparrowdb-server` workspace crate exposing a synchronous
JSON HTTP API for SparrowDB — Phase A of issue #291 / SPA-231. Unblocks
browser/web backends, language-agnostic clients (curl, Go, Java without
drivers), and remote multi-client deployments. Built on `tiny_http` to fit
the existing SWMR engine model. Bolt server (`sparrowdb-bolt`), MCP, and CLI
are untouched per scope discipline.

## Routes (Phase A — JSON only)

- `GET  /health` — no auth, liveness probe (`{ "status": "ok", "version": "..." }`)
- `GET  /info` — auth required; labels, relationship types, node/edge counts
- `POST /cypher` — auth required; `{ query, params? }` → `{ columns, rows }`

JSON ⇄ SparrowDB `Value` coercion handles `Null`/`Bool`/integer/float/string/array/object recursively. Reuses `sparrowdb_execution::json::query_result_to_json` so node/edge IDs preserve `u64` precision via the `{"$type": "...", "id": "..."}` envelope.

## Auth & binding

- Bearer token required by default — supplied via `--token-file <path>` or `SPARROWDB_HTTP_TOKEN`.
- `--no-auth` is **only** accepted when the bind address is loopback (`127.0.0.0/8` / `::1`); refused at startup on any non-loopback interface.
- Defaults: `127.0.0.1:7480`. Port 7480 added to `~/Dev/PORT_REGISTRY.md`.

## CORS

Permissive Phase-1: `Origin: *`, `Methods: POST, GET, OPTIONS`, `Headers: Authorization, Content-Type`. `OPTIONS` preflight returns `204`.

## Out of scope

- SSE / NDJSON streaming → Phase B
- CLI wiring (`sparrowdb-cli` `serve` subcommand) → Phase C
- MCP-over-HTTP — kept distinct from `sparrowdb-mcp` (stdio).

## Files

- `crates/sparrowdb-server/{Cargo.toml,src/{lib,server,auth,handlers,main}.rs,tests/http_integration.rs}`
- Workspace `Cargo.toml`: `members += ["crates/sparrowdb-server"]`
- `docs/api-reference.md`: new HTTP API section
- `docs/architecture.md`: notes the new transport alongside Bolt
- `~/Dev/PORT_REGISTRY.md`: 7480 entry

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --exclude sparrowdb-ruby --all-targets -- -D warnings` (Ruby crate has a pre-existing magnus/rb-sys toolchain mismatch unrelated to this PR)
- [x] `cargo test -p sparrowdb-server` — 10 unit + 8 integration tests pass locally
- [ ] CI (lint + test on Ubuntu Rust 1.95)
- [ ] Manual smoke: `sparrowdb-server --db /tmp/test --no-auth` then `curl localhost:7480/health`
- [ ] Verify `--no-auth --bind 0.0.0.0` is rejected at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)