### PR TITLE
feat(cypher): UNWIND MATCH SET/DELETE + DELETE RETURN (SPA-415)

### DIFF
--- a/crates/sparrowdb-cypher/src/ast.rs
+++ b/crates/sparrowdb-cypher/src/ast.rs
@@ -327,6 +327,34 @@ pub struct MatchMutateStatement {
     /// For SET, there may be multiple items (comma-separated).
     /// For DELETE, this always contains exactly one `Mutation::Delete`.
     pub mutations: Vec<Mutation>,
+    /// Optional RETURN clause after mutations (e.g. `DELETE n RETURN count(n)`).
+    pub return_clause: Option<ReturnClause>,
+}
+
+/// UNWIND … MATCH … SET/DELETE statement (SPA-415).
+///
+/// Iterates a list expression, binding each element to `alias`, then for
+/// each element executes a MATCH + mutation (SET or DELETE).
+///
+/// ```cypher
+/// UNWIND $updates AS row
+/// MATCH (n:Memory {id: row.id})
+/// SET n.score = row.score
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct UnwindMatchMutateStatement {
+    /// The list expression to unwind (e.g. `$updates`).
+    pub expr: Expr,
+    /// Variable bound to each list element (e.g. `row`).
+    pub alias: String,
+    /// The MATCH patterns whose nodes are mutated.
+    pub match_patterns: Vec<PathPattern>,
+    /// Optional WHERE predicate on the MATCH.
+    pub where_clause: Option<Expr>,
+    /// The mutations to apply (SET or DELETE).
+    pub mutations: Vec<Mutation>,
+    /// Optional RETURN clause after mutations.
+    pub return_clause: Option<ReturnClause>,
 }
 
 /// A single projection in a WITH clause: `expr AS alias`.
@@ -501,6 +529,8 @@ pub enum Statement {
     /// MATCH … MERGE (a)-[r:TYPE]->(b) — find-or-create a relationship (SPA-233).
     MatchMergeRel(MatchMergeRelStatement),
     MatchMutate(MatchMutateStatement),
+    /// UNWIND … MATCH … SET/DELETE — batched mutations via list parameter (SPA-415).
+    UnwindMatchMutate(UnwindMatchMutateStatement),
     OptionalMatch(OptionalMatchStatement),
     MatchOptionalMatch(MatchOptionalMatchStatement),
     Union(UnionStatement),

--- a/crates/sparrowdb-cypher/src/binder.rs
+++ b/crates/sparrowdb-cypher/src/binder.rs
@@ -14,8 +14,8 @@ use sparrowdb_catalog::catalog::Catalog;
 use sparrowdb_common::Result;
 
 use crate::ast::{
-    MatchMergeRelStatement, MatchMutateStatement, MatchOptionalMatchStatement, MatchStatement,
-    MatchWithStatement, PathPattern, Statement,
+    MatchMergeRelStatement, MatchOptionalMatchStatement, MatchStatement,
+    MatchWithStatement, PathPattern, Statement, UnwindMatchMutateStatement,
 };
 
 /// A bound statement — the AST annotated with resolved catalog IDs.
@@ -57,7 +57,8 @@ pub fn bind(stmt: Statement, catalog: &Catalog) -> Result<BoundStatement> {
         // MATCH…MERGE relationship: validate the MATCH patterns (labels must
         // exist); the rel type may not exist yet — merge_edge will create it.
         Statement::MatchMergeRel(mm) => bind_match_merge_rel(mm, catalog)?,
-        Statement::MatchMutate(mm) => bind_match_mutate(mm, catalog)?,
+        Statement::MatchMutate(mm) => bind_match_mutate_patterns(&mm.match_patterns, catalog)?,
+        Statement::UnwindMatchMutate(umm) => bind_unwind_match_mutate(umm, catalog)?,
         // OPTIONAL MATCH: label/rel-type may not exist yet — that is exactly
         // the case that produces NULL rows.  Skip existence checks.
         Statement::OptionalMatch(_) => {}
@@ -92,13 +93,19 @@ fn bind_match_with(mw: &MatchWithStatement, catalog: &Catalog) -> Result<()> {
     Ok(())
 }
 
-fn bind_match_mutate(mm: &MatchMutateStatement, catalog: &Catalog) -> Result<()> {
-    for pat in &mm.match_patterns {
+fn bind_match_mutate_patterns(patterns: &[PathPattern], catalog: &Catalog) -> Result<()> {
+    for pat in patterns {
         bind_path_pattern(pat, catalog)?;
     }
     // The mutation itself (SET/DELETE) targets variables already bound by
     // the MATCH patterns — no additional catalog lookups are needed here.
     Ok(())
+}
+
+fn bind_unwind_match_mutate(umm: &UnwindMatchMutateStatement, catalog: &Catalog) -> Result<()> {
+    // UNWIND expression uses parameters ($param) — no catalog binding needed.
+    // MATCH patterns must reference existing labels/rel-types.
+    bind_match_mutate_patterns(&umm.match_patterns, catalog)
 }
 
 fn bind_match_merge_rel(mm: &MatchMergeRelStatement, catalog: &Catalog) -> Result<()> {

--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -11,7 +11,7 @@ use crate::ast::{
     MatchOptionalMatchStatement, MatchStatement, MergeStatement, Mutation, NodePattern,
     OptionalMatchStatement, PathPattern, PipelineStage, PipelineStatement, PropEntry, RelPattern,
     ReturnClause, ReturnItem, ShortestPathExpr, SortDir, Statement, UnionStatement,
-    UnwindStatement, WithClause, WithItem,
+    UnwindMatchMutateStatement, UnwindStatement, WithClause, WithItem,
 };
 use crate::lexer::{tokenize, Token};
 
@@ -353,10 +353,12 @@ impl Parser {
                 // MATCH ... SET var.prop = expr [, var.prop = expr ...]
                 self.advance();
                 let mutations = self.parse_set_items()?;
+                let return_clause = self.parse_optional_return()?;
                 Ok(Statement::MatchMutate(MatchMutateStatement {
                     match_patterns: patterns,
                     where_clause: None,
                     mutations,
+                    return_clause,
                 }))
             }
             Token::Detach => {
@@ -364,20 +366,24 @@ impl Parser {
                 self.advance();
                 self.expect_tok(&Token::Delete)?;
                 let var = self.expect_ident()?;
+                let return_clause = self.parse_optional_return()?;
                 Ok(Statement::MatchMutate(MatchMutateStatement {
                     match_patterns: patterns,
                     where_clause: None,
                     mutations: vec![Mutation::Delete { var, detach: true }],
+                    return_clause,
                 }))
             }
             Token::Delete => {
                 // MATCH ... DELETE var
                 self.advance();
                 let var = self.expect_ident()?;
+                let return_clause = self.parse_optional_return()?;
                 Ok(Statement::MatchMutate(MatchMutateStatement {
                     match_patterns: patterns,
                     where_clause: None,
                     mutations: vec![Mutation::Delete { var, detach: false }],
+                    return_clause,
                 }))
             }
             Token::Where => {
@@ -388,10 +394,12 @@ impl Parser {
                     Token::Set => {
                         self.advance();
                         let mutations = self.parse_set_items()?;
+                        let return_clause = self.parse_optional_return()?;
                         Ok(Statement::MatchMutate(MatchMutateStatement {
                             match_patterns: patterns,
                             where_clause: Some(where_expr),
                             mutations,
+                            return_clause,
                         }))
                     }
                     Token::Detach => {
@@ -399,19 +407,23 @@ impl Parser {
                         self.advance();
                         self.expect_tok(&Token::Delete)?;
                         let var = self.expect_ident()?;
+                        let return_clause = self.parse_optional_return()?;
                         Ok(Statement::MatchMutate(MatchMutateStatement {
                             match_patterns: patterns,
                             where_clause: Some(where_expr),
                             mutations: vec![Mutation::Delete { var, detach: true }],
+                            return_clause,
                         }))
                     }
                     Token::Delete => {
                         self.advance();
                         let var = self.expect_ident()?;
+                        let return_clause = self.parse_optional_return()?;
                         Ok(Statement::MatchMutate(MatchMutateStatement {
                             match_patterns: patterns,
                             where_clause: Some(where_expr),
                             mutations: vec![Mutation::Delete { var, detach: false }],
+                            return_clause,
                         }))
                     }
                     Token::With => {
@@ -1620,8 +1632,12 @@ impl Parser {
         // If the next token is WITH or MATCH, this is a pipeline:
         //   UNWIND … WITH … RETURN  (SPA-134)
         //   UNWIND … MATCH … RETURN (SPA-237)
-        if matches!(self.peek(), Token::With | Token::Match) {
+        //   UNWIND … MATCH … SET/DELETE … [RETURN] (SPA-415)
+        if matches!(self.peek(), Token::With) {
             return self.parse_pipeline_continuation(None, None, Some((expr, alias)), vec![]);
+        }
+        if matches!(self.peek(), Token::Match) {
+            return self.parse_unwind_match_mutate(expr, alias);
         }
 
         self.expect_tok(&Token::Return)?;
@@ -1673,6 +1689,90 @@ impl Parser {
         }
         self.expect_tok(&Token::RBracket)?;
         Ok(Expr::List(elems))
+    }
+
+    // ── UNWIND … MATCH … SET/DELETE (SPA-415) ────────────────────────────────
+
+    /// Parse `UNWIND <expr> AS <var> MATCH <patterns> SET/DELETE ... [RETURN ...]`.
+    ///
+    /// The UNWIND keyword and expression have already been consumed by
+    /// `parse_unwind`.  This function handles the MATCH + mutation tail.
+    fn parse_unwind_match_mutate(&mut self, expr: Expr, alias: String) -> Result<Statement> {
+        self.expect_tok(&Token::Match)?;
+        let patterns = self.parse_pattern_list()?;
+
+        // Dispatch on the next token to determine the mutation type, reusing
+        // the same logic as parse_match_or_match_mutate.
+        let (where_clause, mutations) = match self.peek().clone() {
+            Token::Set => {
+                self.advance();
+                (None, self.parse_set_items()?)
+            }
+            Token::Detach => {
+                self.advance();
+                self.expect_tok(&Token::Delete)?;
+                let var = self.expect_ident()?;
+                (None, vec![Mutation::Delete { var, detach: true }])
+            }
+            Token::Delete => {
+                self.advance();
+                let var = self.expect_ident()?;
+                (None, vec![Mutation::Delete { var, detach: false }])
+            }
+            Token::Where => {
+                self.advance();
+                let where_expr = self.parse_expr()?;
+                let mutations = match self.peek().clone() {
+                    Token::Set => {
+                        self.advance();
+                        self.parse_set_items()?
+                    }
+                    Token::Detach => {
+                        self.advance();
+                        self.expect_tok(&Token::Delete)?;
+                        let var = self.expect_ident()?;
+                        vec![Mutation::Delete { var, detach: true }]
+                    }
+                    Token::Delete => {
+                        self.advance();
+                        let var = self.expect_ident()?;
+                        vec![Mutation::Delete { var, detach: false }]
+                    }
+                    other => {
+                        return Err(Error::InvalidArgument(format!(
+                            "expected SET, DELETE, or DETACH DELETE after WHERE in UNWIND MATCH, got {:?}",
+                            other
+                        )));
+                    }
+                };
+                (Some(where_expr), mutations)
+            }
+            other => {
+                return Err(Error::InvalidArgument(format!(
+                    "expected SET, DELETE, DETACH DELETE, or WHERE after UNWIND MATCH patterns, got {:?}",
+                    other
+                )));
+            }
+        };
+
+        // Optional RETURN clause after mutations.
+        let return_clause = if matches!(self.peek(), Token::Return) {
+            self.advance();
+            let items = self.parse_return_items()?;
+            Some(ReturnClause { items })
+        } else {
+            None
+        };
+
+        Ok(Statement::UnwindMatchMutate(UnwindMatchMutateStatement {
+                expr,
+                alias,
+                match_patterns: patterns,
+                where_clause,
+                mutations,
+                return_clause,
+            },
+        ))
     }
 
     fn parse_create_body(&mut self) -> Result<CreateStatement> {
@@ -2522,6 +2622,19 @@ impl Parser {
     }
 
     // ── RETURN items ──────────────────────────────────────────────────────────
+
+    /// Parse an optional RETURN clause that may follow a mutation (SET/DELETE).
+    ///
+    /// Returns `None` when the next token is not `RETURN`.
+    fn parse_optional_return(&mut self) -> Result<Option<ReturnClause>> {
+        if matches!(self.peek(), Token::Return) {
+            self.advance();
+            let items = self.parse_return_items()?;
+            Ok(Some(ReturnClause { items }))
+        } else {
+            Ok(None)
+        }
+    }
 
     fn parse_return_items(&mut self) -> Result<Vec<ReturnItem>> {
         if matches!(self.peek(), Token::Star) {

--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -1637,7 +1637,24 @@ impl Parser {
             return self.parse_pipeline_continuation(None, None, Some((expr, alias)), vec![]);
         }
         if matches!(self.peek(), Token::Match) {
-            return self.parse_unwind_match_mutate(expr, alias);
+            self.advance(); // consume MATCH
+            let patterns = self.parse_pattern_list()?;
+
+            // Peek ahead to decide: mutation (SET/DELETE/WHERE) or read pipeline?
+            match self.peek().clone() {
+                Token::Set | Token::Delete | Token::Detach | Token::Where => {
+                    return self.parse_unwind_match_mutate_tail(expr, alias, patterns);
+                }
+                _ => {
+                    // Read pipeline: UNWIND ... MATCH ... RETURN/WITH/...
+                    return self.parse_pipeline_continuation(
+                        Some(patterns),
+                        None,
+                        Some((expr, alias)),
+                        vec![],
+                    );
+                }
+            }
         }
 
         self.expect_tok(&Token::Return)?;
@@ -1693,13 +1710,16 @@ impl Parser {
 
     // ── UNWIND … MATCH … SET/DELETE (SPA-415) ────────────────────────────────
 
-    /// Parse `UNWIND <expr> AS <var> MATCH <patterns> SET/DELETE ... [RETURN ...]`.
-    ///
-    /// The UNWIND keyword and expression have already been consumed by
-    /// `parse_unwind`.  This function handles the MATCH + mutation tail.
-    fn parse_unwind_match_mutate(&mut self, expr: Expr, alias: String) -> Result<Statement> {
-        self.expect_tok(&Token::Match)?;
-        let patterns = self.parse_pattern_list()?;
+    /// Parse the mutation tail after `UNWIND … AS alias MATCH patterns`
+    /// have already been consumed by the caller.  The caller is responsible
+    /// for peeking at the token after `patterns` to decide whether this is
+    /// a mutation (SET/DELETE/DETACH/WHERE) or a read pipeline.
+    fn parse_unwind_match_mutate_tail(
+        &mut self,
+        expr: Expr,
+        alias: String,
+        patterns: Vec<PathPattern>,
+    ) -> Result<Statement> {
 
         // Dispatch on the next token to determine the mutation type, reusing
         // the same logic as parse_match_or_match_mutate.

--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -677,28 +677,37 @@ impl Parser {
     /// Called after the `SET` keyword has already been consumed.
     /// Returns a `Vec<Mutation::Set>` with at least one item.
     fn parse_set_items(&mut self) -> Result<Vec<Mutation>> {
+        self.parse_set_items_inner(false)
+    }
+
+    /// Variant that allows `PropAccess` values (e.g. `row.score`) in SET,
+    /// used inside `UNWIND … MATCH … SET` where the caller resolves row
+    /// references at execution time (SPA-415).
+    fn parse_set_items_allow_prop(&mut self) -> Result<Vec<Mutation>> {
+        self.parse_set_items_inner(true)
+    }
+
+    fn parse_set_items_inner(&mut self, allow_prop_access: bool) -> Result<Vec<Mutation>> {
         let mut items = Vec::new();
         loop {
             let var = self.expect_ident()?;
             self.expect_tok(&Token::Dot)?;
-            // Use advance_as_prop_name so keyword tokens (e.g. `match`, `count`)
-            // are accepted as property names, consistent with SPA-265 behavior.
             let prop = self.advance_as_prop_name()?;
             self.expect_tok(&Token::Eq)?;
             let value = self.parse_expr()?;
             // Guard: the write helpers (expr_to_value / expr_to_value_with_params)
-            // only materialise Expr::Literal values.  Any other expression (e.g.
-            // arithmetic, property access) would be silently coerced to
-            // Value::Int64(0) and corrupt data.  Reject them at parse time until
-            // a full expression evaluator is wired into the SET path.
-            if !matches!(value, Expr::Literal(_)) {
+            // only materialise Expr::Literal values.  PropAccess is allowed when
+            // the caller (UNWIND … MATCH … SET) resolves it at execution time.
+            let is_literal = matches!(value, Expr::Literal(_));
+            let is_prop = matches!(value, Expr::PropAccess { .. });
+            if !is_literal && !(allow_prop_access && is_prop) {
                 return Err(Error::InvalidArgument(
                     "SET property value must be a literal or $parameter".into(),
                 ));
             }
             items.push(Mutation::Set { var, prop, value });
             if matches!(self.peek(), Token::Comma) {
-                self.advance(); // consume the comma
+                self.advance();
             } else {
                 break;
             }
@@ -1726,7 +1735,7 @@ impl Parser {
         let (where_clause, mutations) = match self.peek().clone() {
             Token::Set => {
                 self.advance();
-                (None, self.parse_set_items()?)
+                (None, self.parse_set_items_allow_prop()?)
             }
             Token::Detach => {
                 self.advance();
@@ -1745,7 +1754,7 @@ impl Parser {
                 let mutations = match self.peek().clone() {
                     Token::Set => {
                         self.advance();
-                        self.parse_set_items()?
+                        self.parse_set_items_allow_prop()?
                     }
                     Token::Detach => {
                         self.advance();

--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -1756,13 +1756,7 @@ impl Parser {
         };
 
         // Optional RETURN clause after mutations.
-        let return_clause = if matches!(self.peek(), Token::Return) {
-            self.advance();
-            let items = self.parse_return_items()?;
-            Some(ReturnClause { items })
-        } else {
-            None
-        };
+        let return_clause = self.parse_optional_return()?;
 
         Ok(Statement::UnwindMatchMutate(UnwindMatchMutateStatement {
                 expr,

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -882,6 +882,7 @@ impl Engine {
             Statement::Merge(_)
             | Statement::MatchMergeRel(_)
             | Statement::MatchMutate(_)
+            | Statement::UnwindMatchMutate(_)
             | Statement::MatchCreate(_) => Err(sparrowdb_common::Error::InvalidArgument(
                 "mutation statements must be executed via execute_mutation".into(),
             )),
@@ -937,6 +938,7 @@ impl Engine {
             Statement::Merge(_)
             | Statement::MatchMergeRel(_)
             | Statement::MatchMutate(_)
+            | Statement::UnwindMatchMutate(_)
             | Statement::MatchCreate(_) => true,
             // All standalone CREATE statements must go through the
             // write-transaction path to ensure WAL durability and correct

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -741,7 +741,7 @@ impl GraphDb {
                 Statement::Merge(ref m) => self.execute_merge(m),
                 Statement::MatchMutate(ref mm) => self.execute_match_mutate_deadline(mm, deadline),
                 Statement::UnwindMatchMutate(ref umm) => {
-                    self.execute_unwind_match_mutate(umm)
+                    self.execute_unwind_match_mutate_deadline(umm, deadline)
                 }
                 Statement::MatchCreate(ref mc) => self.execute_match_create_deadline(mc, deadline),
                 Statement::Create(ref c) => self.execute_create_standalone(c),
@@ -1623,10 +1623,10 @@ impl GraphDb {
         match return_clause {
             None => Ok(QueryResult::empty(vec![])),
             Some(rc) => {
-                // Simple heuristic: if RETURN has a single count-like item,
-                // return the count.  Full RETURN expression evaluation for
-                // mutations is deferred to a future engine extension.
-                if rc.items.len() == 1 {
+                // Only honour RETURN when the expression is count(n) / count(*).
+                // Full RETURN expression evaluation for mutations is deferred
+                // to a future engine extension.
+                if rc.items.len() == 1 && is_count_expr(&rc.items[0].expr) {
                     let col = rc.items[0]
                         .alias
                         .clone()
@@ -1653,7 +1653,7 @@ impl GraphDb {
         params: &HashMap<String, sparrowdb_execution::Value>,
     ) -> Result<QueryResult> {
         let list = eval_unwind_list(&umm.expr, params)?;
-        self.execute_unwind_mutate_inner(umm, list.as_slice(), Some(params))
+        self.execute_unwind_mutate_inner(umm, list.as_slice(), Some(params), None)
     }
 
     /// Execute `UNWIND [literal] AS var MATCH ... SET/DELETE` without params.
@@ -1675,18 +1675,55 @@ impl GraphDb {
                 ));
             }
         };
-        self.execute_unwind_mutate_inner(umm, list.as_slice(), None)
+        self.execute_unwind_mutate_inner(umm, list.as_slice(), None, None)
+    }
+
+    /// Deadline-aware variant (fixes #310).
+    fn execute_unwind_match_mutate_deadline(
+        &self,
+        umm: &sparrowdb_cypher::ast::UnwindMatchMutateStatement,
+        deadline: std::time::Instant,
+    ) -> Result<QueryResult> {
+        // Evaluate the UNWIND list from the expression (non-params path).
+        let list = match &umm.expr {
+            sparrowdb_cypher::ast::Expr::List(items) => items
+                .iter()
+                .map(|e| {
+                    let sv = expr_to_value(e);
+                    Ok(storage_value_to_exec(&sv))
+                })
+                .collect::<Result<Vec<_>>>()?,
+            _ => {
+                return Err(Error::InvalidArgument(
+                    "UNWIND MATCH SET/DELETE with timeout requires a list literal".into(),
+                ));
+            }
+        };
+        self.execute_unwind_mutate_inner(umm, list.as_slice(), None, Some(deadline))
     }
 
     /// Shared inner: iterate UNWIND elements, apply mutations per row, single tx.
     ///
     /// When `params` is `Some`, the engine and `resolve_set_value` can resolve
     /// `$param` references in `where_clause` and `SET` value expressions.
+    ///
+    /// When `deadline` is `Some`, each iteration checks elapsed time and returns
+    /// `Err(Timeout)` if the caller's deadline has passed (fixes #310).
+    ///
+    /// **Visibility limitation**: each UNWIND row is scanned against committed
+    /// storage — earlier rows' mutations within the same transaction are NOT
+    /// visible to later rows' MATCH scans.  This is by design: the single-pass
+    /// engine reuses the same read snapshot for all iterations, matching the
+    /// semantics of `UNWIND` in standard Cypher (all rows see the same pre-query
+    /// state).  Use cases that require row-to-row visibility (e.g. accumulating
+    /// mutations on the same node across iterations) must issue separate
+    /// statements.
     fn execute_unwind_mutate_inner(
         &self,
         umm: &sparrowdb_cypher::ast::UnwindMatchMutateStatement,
         list: &[sparrowdb_execution::Value],
         params: Option<&HashMap<String, sparrowdb_execution::Value>>,
+        deadline: Option<std::time::Instant>,
     ) -> Result<QueryResult> {
         if list.is_empty() {
             return Ok(QueryResult::empty(vec![]));
@@ -1708,6 +1745,11 @@ impl GraphDb {
         let mut has_detach_delete = false;
 
         for element in list {
+            // Honour caller's deadline between iterations (fixes #310).
+            if let Some(dl) = deadline {
+                Self::check_deadline(dl)?;
+            }
+
             // Each element must be a Map (e.g. {id: "m1", score: 0.5}).
             let row = match element {
                 sparrowdb_execution::Value::Map(entries) => entries,
@@ -3089,6 +3131,18 @@ impl GraphDb {
         self.invalidate_csr_map();
         Ok(())
     }
+}
+
+// ── RETURN helpers ──────────────────────────────────────────────────────────
+
+/// Check whether an expression is a `count(n)` or `count(*)` aggregate call.
+fn is_count_expr(expr: &sparrowdb_cypher::ast::Expr) -> bool {
+    use sparrowdb_cypher::ast::Expr;
+    matches!(
+        expr,
+        Expr::FnCall { name, .. } if name.eq_ignore_ascii_case("count")
+            || name == "COUNT"
+    ) || matches!(expr, Expr::CountStar)
 }
 
 // ── UNWIND helpers (SPA-415) ────────────────────────────────────────────────

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -1630,7 +1630,7 @@ impl GraphDb {
                     let col = rc.items[0]
                         .alias
                         .clone()
-                        .unwrap_or_else(|| format!("count({})", count));
+                        .unwrap_or_else(|| "count(n)".to_string());
                     Ok(QueryResult {
                         columns: vec![col],
                         rows: vec![vec![sparrowdb_execution::Value::Int64(count as i64)]],
@@ -1653,7 +1653,7 @@ impl GraphDb {
         params: &HashMap<String, sparrowdb_execution::Value>,
     ) -> Result<QueryResult> {
         let list = eval_unwind_list(&umm.expr, params)?;
-        self.execute_unwind_mutate_inner(umm, list.as_slice())
+        self.execute_unwind_mutate_inner(umm, list.as_slice(), Some(params))
     }
 
     /// Execute `UNWIND [literal] AS var MATCH ... SET/DELETE` without params.
@@ -1675,14 +1675,18 @@ impl GraphDb {
                 ));
             }
         };
-        self.execute_unwind_mutate_inner(umm, list.as_slice())
+        self.execute_unwind_mutate_inner(umm, list.as_slice(), None)
     }
 
     /// Shared inner: iterate UNWIND elements, apply mutations per row, single tx.
+    ///
+    /// When `params` is `Some`, the engine and `resolve_set_value` can resolve
+    /// `$param` references in `where_clause` and `SET` value expressions.
     fn execute_unwind_mutate_inner(
         &self,
         umm: &sparrowdb_cypher::ast::UnwindMatchMutateStatement,
         list: &[sparrowdb_execution::Value],
+        params: Option<&HashMap<String, sparrowdb_execution::Value>>,
     ) -> Result<QueryResult> {
         if list.is_empty() {
             return Ok(QueryResult::empty(vec![]));
@@ -1690,12 +1694,16 @@ impl GraphDb {
 
         let mut tx = self.begin_write()?;
         let csrs = self.cached_csr_map();
-        let engine = Engine::new(
+        let mut engine = Engine::new(
             NodeStore::open(&self.inner.path)?,
             self.catalog_snapshot(),
             csrs,
             &self.inner.path,
         );
+        // Configure engine with params so WHERE clause can resolve $param.
+        if let Some(p) = params {
+            engine = engine.with_params(p.clone());
+        }
         let mut total_mutated: u64 = 0;
         let mut has_detach_delete = false;
 
@@ -1705,8 +1713,8 @@ impl GraphDb {
                 sparrowdb_execution::Value::Map(entries) => entries,
                 _ => {
                     return Err(Error::InvalidArgument(format!(
-                        "UNWIND element must be a map (e.g. {{id: '...', score: 0.5}}), got {:?}",
-                        std::mem::discriminant(element)
+                        "UNWIND element must be a map (e.g. {{id: '...', score: 0.5}}), got {}",
+                        element
                     )));
                 }
             };
@@ -1734,7 +1742,7 @@ impl GraphDb {
             for mutation in &umm.mutations {
                 match mutation {
                     sparrowdb_cypher::ast::Mutation::Set { prop, value, .. } => {
-                        let sv = resolve_set_value(value, &umm.alias, row);
+                        let sv = resolve_set_value(value, &umm.alias, row, params)?;
                         for node_id in &matching_ids {
                             tx.set_property(*node_id, prop, sv.clone())?;
                         }
@@ -3095,9 +3103,8 @@ fn eval_unwind_list(
             match params.get(name.as_str()) {
                 Some(sparrowdb_execution::Value::List(items)) => Ok(items.clone()),
                 Some(other) => Err(Error::InvalidArgument(format!(
-                    "UNWIND parameter ${} must be a list, got {:?}",
-                    name,
-                    std::mem::discriminant(other)
+                    "UNWIND parameter ${} must be a list, got {}",
+                    name, other
                 ))),
                 None => Err(Error::InvalidArgument(format!(
                     "UNWIND parameter ${} not found in params",
@@ -3185,24 +3192,29 @@ fn exec_value_to_expr_literal(v: &sparrowdb_execution::Value) -> sparrowdb_cyphe
 
 /// Resolve a mutation SET value expression to a storage-layer Value.
 /// If the value is `alias.prop`, look it up from the row map; otherwise
-/// evaluate it directly via `expr_to_value`.
+/// evaluate it via `expr_to_value_with_params` when params are available,
+/// falling back to `expr_to_value` for literal-only expressions.
 fn resolve_set_value(
     value: &sparrowdb_cypher::ast::Expr,
     alias: &str,
     row: &[(String, sparrowdb_execution::Value)],
-) -> Value {
+    params: Option<&HashMap<String, sparrowdb_execution::Value>>,
+) -> crate::Result<Value> {
     use sparrowdb_cypher::ast::Expr;
     if let Expr::PropAccess { var, prop } = value {
         if var == alias {
             for (key, val) in row {
                 if key == prop {
-                    return exec_value_to_storage(val);
+                    return Ok(exec_value_to_storage(val));
                 }
             }
         }
     }
-    // Fall back to standard literal evaluation.
-    expr_to_value(value)
+    // Fall back: use params-aware evaluation when available, otherwise literal-only.
+    match params {
+        Some(p) => expr_to_value_with_params(value, p),
+        None => Ok(expr_to_value(value)),
+    }
 }
 
 /// Migrate WAL segments from legacy v21 (CRC32 IEEE) to v2 (CRC32C Castagnoli).

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -7,9 +7,9 @@
 use crate::batch::augment_rows_with_pending;
 use crate::helpers::{
     build_label_row_counts_from_disk, collect_maintenance_params, dir_size_bytes, eval_expr_merge,
-    expr_to_value, expr_to_value_with_params, fnv1a_col_id, is_edge_delete_mutation,
-    is_reserved_label, literal_to_value, load_constraints, load_vector_indexes, open_csr_map,
-    save_constraints, storage_value_to_exec, try_open_csr_map,
+    exec_value_to_storage, expr_to_value, expr_to_value_with_params, fnv1a_col_id,
+    is_edge_delete_mutation, is_reserved_label, literal_to_value, load_constraints,
+    load_vector_indexes, open_csr_map, save_constraints, storage_value_to_exec, try_open_csr_map,
 };
 use crate::read_tx::ReadTx;
 use crate::types::{DbInner, NodeVersions, PendingOp, VersionStore, WriteBuffer, WriteGuard};
@@ -539,6 +539,7 @@ impl GraphDb {
                 Statement::Merge(ref m) => self.execute_merge(m),
                 Statement::MatchMergeRel(ref mm) => self.execute_match_merge_rel(mm),
                 Statement::MatchMutate(ref mm) => self.execute_match_mutate(mm),
+                Statement::UnwindMatchMutate(ref umm) => self.execute_unwind_match_mutate(umm),
                 Statement::MatchCreate(ref mc) => self.execute_match_create(mc),
                 // Standalone CREATE with edges — must go through WriteTx so
                 // create_edge can register the rel type and write the WAL.
@@ -622,15 +623,16 @@ impl GraphDb {
             // Mutations don't use the read pipeline — fall through to the
             // standard mutation paths (write transactions are unaffected).
             match bound.inner {
-                Statement::Merge(ref m) => self.execute_merge(m),
-                Statement::MatchMergeRel(ref mm) => self.execute_match_merge_rel(mm),
-                Statement::MatchMutate(ref mm) => self.execute_match_mutate(mm),
-                Statement::MatchCreate(ref mc) => self.execute_match_create(mc),
-                Statement::Create(ref c) => self.execute_create_standalone(c),
-                _ => unreachable!(),
-            }
-        } else {
-            let _span = info_span!("sparrowdb.query_chunked").entered();
+            Statement::Merge(ref m) => self.execute_merge(m),
+            Statement::MatchMergeRel(ref mm) => self.execute_match_merge_rel(mm),
+            Statement::MatchMutate(ref mm) => self.execute_match_mutate(mm),
+            Statement::UnwindMatchMutate(ref umm) => self.execute_unwind_match_mutate(umm),
+            Statement::MatchCreate(ref mc) => self.execute_match_create(mc),
+            Statement::Create(ref c) => self.execute_create_standalone(c),
+            _ => unreachable!(),
+        }
+    } else {
+        let _span = info_span!("sparrowdb.query_chunked").entered();
 
             let mut engine = {
                 let _open_span = info_span!("sparrowdb.open_engine").entered();
@@ -738,6 +740,9 @@ impl GraphDb {
             return match bound.inner {
                 Statement::Merge(ref m) => self.execute_merge(m),
                 Statement::MatchMutate(ref mm) => self.execute_match_mutate_deadline(mm, deadline),
+                Statement::UnwindMatchMutate(ref umm) => {
+                    self.execute_unwind_match_mutate(umm)
+                }
                 Statement::MatchCreate(ref mc) => self.execute_match_create_deadline(mc, deadline),
                 Statement::Create(ref c) => self.execute_create_standalone(c),
                 _ => unreachable!(),
@@ -1225,6 +1230,9 @@ impl GraphDb {
             return match bound.inner {
                 Stmt::Merge(ref m) => self.execute_merge_with_params(m, &params),
                 Stmt::MatchMutate(ref mm) => self.execute_match_mutate_with_params(mm, &params),
+                Stmt::UnwindMatchMutate(ref umm) => {
+                    self.execute_unwind_match_mutate_with_params(umm, &params)
+                }
                 _ => Err(Error::InvalidArgument(
                     "execute_with_params: parameterized MATCH...CREATE and standalone CREATE \
                      are not yet supported; use MERGE or MATCH...SET with $params"
@@ -1600,7 +1608,160 @@ impl GraphDb {
             self.invalidate_csr_map();
         }
 
-        Ok(QueryResult::empty(vec![]))
+        Self::build_mutate_return(&mm.return_clause, matching_ids.len() as u64)
+    }
+
+    /// Build a QueryResult from an optional RETURN clause after a mutation.
+    ///
+    /// When `return_clause` is `None`, returns an empty result (backward compat).
+    /// When present and the RETURN expression is `count(n)`, returns one row
+    /// with the mutation count.
+    fn build_mutate_return(
+        return_clause: &Option<sparrowdb_cypher::ast::ReturnClause>,
+        count: u64,
+    ) -> Result<QueryResult> {
+        match return_clause {
+            None => Ok(QueryResult::empty(vec![])),
+            Some(rc) => {
+                // Simple heuristic: if RETURN has a single count-like item,
+                // return the count.  Full RETURN expression evaluation for
+                // mutations is deferred to a future engine extension.
+                if rc.items.len() == 1 {
+                    let col = rc.items[0]
+                        .alias
+                        .clone()
+                        .unwrap_or_else(|| format!("count({})", count));
+                    Ok(QueryResult {
+                        columns: vec![col],
+                        rows: vec![vec![sparrowdb_execution::Value::Int64(count as i64)]],
+                    })
+                } else {
+                    Ok(QueryResult::empty(vec![]))
+                }
+            }
+        }
+    }
+
+    // ── UNWIND … MATCH … SET/DELETE execution (SPA-415) ─────────────────────
+
+    /// Execute `UNWIND $param AS var MATCH ... SET/DELETE` with runtime
+    /// parameter bindings.  Evaluates the UNWIND list, then for each element
+    /// runs the MATCH + mutation inside a single write transaction.
+    fn execute_unwind_match_mutate_with_params(
+        &self,
+        umm: &sparrowdb_cypher::ast::UnwindMatchMutateStatement,
+        params: &HashMap<String, sparrowdb_execution::Value>,
+    ) -> Result<QueryResult> {
+        let list = eval_unwind_list(&umm.expr, params)?;
+        self.execute_unwind_mutate_inner(umm, list.as_slice())
+    }
+
+    /// Execute `UNWIND [literal] AS var MATCH ... SET/DELETE` without params.
+    fn execute_unwind_match_mutate(
+        &self,
+        umm: &sparrowdb_cypher::ast::UnwindMatchMutateStatement,
+    ) -> Result<QueryResult> {
+        let list = match &umm.expr {
+            sparrowdb_cypher::ast::Expr::List(items) => items
+                .iter()
+                .map(|e| {
+                    let sv = expr_to_value(e);
+                    Ok(storage_value_to_exec(&sv))
+                })
+                .collect::<Result<Vec<_>>>()?,
+            _ => {
+                return Err(Error::InvalidArgument(
+                    "UNWIND MATCH SET/DELETE without parameters requires a list literal".into(),
+                ));
+            }
+        };
+        self.execute_unwind_mutate_inner(umm, list.as_slice())
+    }
+
+    /// Shared inner: iterate UNWIND elements, apply mutations per row, single tx.
+    fn execute_unwind_mutate_inner(
+        &self,
+        umm: &sparrowdb_cypher::ast::UnwindMatchMutateStatement,
+        list: &[sparrowdb_execution::Value],
+    ) -> Result<QueryResult> {
+        if list.is_empty() {
+            return Ok(QueryResult::empty(vec![]));
+        }
+
+        let mut tx = self.begin_write()?;
+        let csrs = self.cached_csr_map();
+        let engine = Engine::new(
+            NodeStore::open(&self.inner.path)?,
+            self.catalog_snapshot(),
+            csrs,
+            &self.inner.path,
+        );
+        let mut total_mutated: u64 = 0;
+        let mut has_detach_delete = false;
+
+        for element in list {
+            // Each element must be a Map (e.g. {id: "m1", score: 0.5}).
+            let row = match element {
+                sparrowdb_execution::Value::Map(entries) => entries,
+                _ => {
+                    return Err(Error::InvalidArgument(format!(
+                        "UNWIND element must be a map (e.g. {{id: '...', score: 0.5}}), got {:?}",
+                        std::mem::discriminant(element)
+                    )));
+                }
+            };
+
+            // Build a temporary MatchMutateStatement with inline property
+            // filters resolved from the row values.
+            let resolved_patterns: Vec<sparrowdb_cypher::ast::PathPattern> = umm
+                .match_patterns
+                .iter()
+                .map(|pat| resolve_pattern_props(pat, &umm.alias, row))
+                .collect();
+
+            let resolved_mm = sparrowdb_cypher::ast::MatchMutateStatement {
+                match_patterns: resolved_patterns,
+                where_clause: umm.where_clause.clone(),
+                mutations: umm.mutations.clone(),
+                return_clause: None,
+            };
+
+            let matching_ids = engine.scan_match_mutate(&resolved_mm)?;
+            if matching_ids.is_empty() {
+                continue;
+            }
+
+            for mutation in &umm.mutations {
+                match mutation {
+                    sparrowdb_cypher::ast::Mutation::Set { prop, value, .. } => {
+                        let sv = resolve_set_value(value, &umm.alias, row);
+                        for node_id in &matching_ids {
+                            tx.set_property(*node_id, prop, sv.clone())?;
+                        }
+                    }
+                    sparrowdb_cypher::ast::Mutation::Delete { detach: true, .. } => {
+                        has_detach_delete = true;
+                        for node_id in &matching_ids {
+                            tx.detach_delete_node(*node_id)?;
+                        }
+                    }
+                    sparrowdb_cypher::ast::Mutation::Delete { detach: false, .. } => {
+                        for node_id in &matching_ids {
+                            tx.delete_node(*node_id)?;
+                        }
+                    }
+                }
+            }
+            total_mutated += matching_ids.len() as u64;
+        }
+
+        tx.commit()?;
+        self.invalidate_catalog();
+        if has_detach_delete {
+            self.invalidate_csr_map();
+        }
+
+        Self::build_mutate_return(&umm.return_clause, total_mutated)
     }
 
     /// Internal: execute a MATCH … SET / DELETE by scanning then writing.
@@ -1631,20 +1792,21 @@ impl GraphDb {
         // SPA-219: `MATCH (a)-[r:REL]->(b) DELETE r` — edge delete path.
         if is_edge_delete_mutation(mm) {
             let edges = engine.scan_match_mutate_edges(mm)?;
+            let edge_count = edges.len();
             for (src, dst, rel_type) in edges {
                 tx.delete_edge(src, dst, &rel_type)?;
             }
             tx.commit()?;
             self.invalidate_csr_map();
             self.invalidate_catalog();
-            return Ok(QueryResult::empty(vec![]));
+            return Self::build_mutate_return(&mm.return_clause, edge_count as u64);
         }
 
         // Collect matching node ids via the engine's scan (lock already held).
         let matching_ids = engine.scan_match_mutate(mm)?;
 
         if matching_ids.is_empty() {
-            return Ok(QueryResult::empty(vec![]));
+            return Self::build_mutate_return(&mm.return_clause, 0);
         }
 
         let mut has_detach_delete = false;
@@ -1675,7 +1837,7 @@ impl GraphDb {
         if has_detach_delete {
             self.invalidate_csr_map();
         }
-        Ok(QueryResult::empty(vec![]))
+        Self::build_mutate_return(&mm.return_clause, matching_ids.len() as u64)
     }
 
     /// Deadline-aware variant of [`execute_match_mutate`] (fixes #310).
@@ -1748,7 +1910,8 @@ impl GraphDb {
         if has_detach_delete {
             self.invalidate_csr_map();
         }
-        Ok(QueryResult::empty(vec![]))
+        // Honor optional RETURN clause.
+        Self::build_mutate_return(&mm.return_clause, matching_ids.len() as u64)
     }
 
     /// Internal: execute a `MATCH … CREATE (a)-[:R]->(b)` statement.
@@ -2287,6 +2450,16 @@ impl GraphDb {
                     has_detach_delete = true;
                 }
             }
+            if let sparrowdb_cypher::ast::Statement::UnwindMatchMutate(ref umm) = bound.inner {
+                if umm.mutations.iter().any(|m| {
+                    matches!(
+                        m,
+                        sparrowdb_cypher::ast::Mutation::Delete { detach: true, .. }
+                    )
+                }) {
+                    has_detach_delete = true;
+                }
+            }
 
             let result = if Engine::is_mutation(&bound.inner) {
                 self.execute_batch_mutation(bound.inner, &mut tx)?
@@ -2463,6 +2636,7 @@ impl GraphDb {
                     for (src, dst, rel_type) in edges {
                         tx.delete_edge(src, dst, &rel_type)?;
                     }
+                    Ok(QueryResult::empty(vec![]))
                 } else {
                     let matching_ids = engine.scan_match_mutate(mm)?;
                     for mutation in &mm.mutations {
@@ -2485,9 +2659,15 @@ impl GraphDb {
                             }
                         }
                     }
+                    Ok(QueryResult::empty(vec![]))
                 }
-                Ok(QueryResult::empty(vec![]))
             }
+
+            Statement::UnwindMatchMutate(_) => Err(Error::InvalidArgument(
+                "UNWIND...MATCH...SET/DELETE is not yet supported in batch execution; \
+                 use execute_with_params instead"
+                    .into(),
+            )),
 
             Statement::MatchCreate(ref mc) => {
                 for (_, rel_pat, _) in &mc.create.edges {
@@ -2901,6 +3081,128 @@ impl GraphDb {
         self.invalidate_csr_map();
         Ok(())
     }
+}
+
+// ── UNWIND helpers (SPA-415) ────────────────────────────────────────────────
+
+/// Evaluate a UNWIND expression to a list of `Value`s.
+fn eval_unwind_list(
+    expr: &sparrowdb_cypher::ast::Expr,
+    params: &HashMap<String, sparrowdb_execution::Value>,
+) -> Result<Vec<sparrowdb_execution::Value>> {
+    match expr {
+        sparrowdb_cypher::ast::Expr::Literal(sparrowdb_cypher::ast::Literal::Param(name)) => {
+            match params.get(name.as_str()) {
+                Some(sparrowdb_execution::Value::List(items)) => Ok(items.clone()),
+                Some(other) => Err(Error::InvalidArgument(format!(
+                    "UNWIND parameter ${} must be a list, got {:?}",
+                    name,
+                    std::mem::discriminant(other)
+                ))),
+                None => Err(Error::InvalidArgument(format!(
+                    "UNWIND parameter ${} not found in params",
+                    name
+                ))),
+            }
+        }
+        _ => Err(Error::InvalidArgument(
+            "UNWIND expression must be a $param bound to a list".into(),
+        )),
+    }
+}
+
+/// Resolve inline property filters in a PathPattern by replacing
+/// `alias.prop` references with literal values from the UNWIND row.
+fn resolve_pattern_props(
+    pat: &sparrowdb_cypher::ast::PathPattern,
+    alias: &str,
+    row: &[(String, sparrowdb_execution::Value)],
+) -> sparrowdb_cypher::ast::PathPattern {
+    use sparrowdb_cypher::ast::{Expr, Literal, NodePattern, PropEntry};
+
+    let nodes: Vec<NodePattern> = pat
+        .nodes
+        .iter()
+        .map(|np| {
+            let props: Vec<PropEntry> = np
+                .props
+                .iter()
+                .map(|pe| {
+                    let resolved_expr = row_expr_to_literal(&pe.value, alias, row);
+                    PropEntry {
+                        key: pe.key.clone(),
+                        value: resolved_expr,
+                    }
+                })
+                .collect();
+            NodePattern {
+                var: np.var.clone(),
+                labels: np.labels.clone(),
+                props,
+            }
+        })
+        .collect();
+
+    sparrowdb_cypher::ast::PathPattern {
+        path_var: pat.path_var.clone(),
+        nodes,
+        rels: pat.rels.clone(),
+    }
+}
+
+/// Resolve an expression that references `alias.prop` to a literal Expr.
+/// If the expression is `alias.prop`, look up `prop` in the row map and
+/// return the corresponding `Expr::Literal`. Otherwise return the expr as-is.
+fn row_expr_to_literal(
+    expr: &sparrowdb_cypher::ast::Expr,
+    alias: &str,
+    row: &[(String, sparrowdb_execution::Value)],
+) -> sparrowdb_cypher::ast::Expr {
+    use sparrowdb_cypher::ast::{Expr, Literal};
+    if let Expr::PropAccess { var, prop } = expr {
+        if var == alias {
+            for (key, val) in row {
+                if key == prop {
+                    return exec_value_to_expr_literal(val);
+                }
+            }
+        }
+    }
+    expr.clone()
+}
+
+/// Convert a sparrowdb_execution::Value to an Expr::Literal for inline props.
+fn exec_value_to_expr_literal(v: &sparrowdb_execution::Value) -> sparrowdb_cypher::ast::Expr {
+    use sparrowdb_cypher::ast::{Expr, Literal};
+    match v {
+        sparrowdb_execution::Value::String(s) => Expr::Literal(Literal::String(s.clone())),
+        sparrowdb_execution::Value::Int64(n) => Expr::Literal(Literal::Int(*n)),
+        sparrowdb_execution::Value::Float64(f) => Expr::Literal(Literal::Float(*f)),
+        sparrowdb_execution::Value::Bool(b) => Expr::Literal(Literal::Bool(*b)),
+        _ => Expr::Literal(Literal::Null),
+    }
+}
+
+/// Resolve a mutation SET value expression to a storage-layer Value.
+/// If the value is `alias.prop`, look it up from the row map; otherwise
+/// evaluate it directly via `expr_to_value`.
+fn resolve_set_value(
+    value: &sparrowdb_cypher::ast::Expr,
+    alias: &str,
+    row: &[(String, sparrowdb_execution::Value)],
+) -> Value {
+    use sparrowdb_cypher::ast::Expr;
+    if let Expr::PropAccess { var, prop } = value {
+        if var == alias {
+            for (key, val) in row {
+                if key == prop {
+                    return exec_value_to_storage(val);
+                }
+            }
+        }
+    }
+    // Fall back to standard literal evaluation.
+    expr_to_value(value)
 }
 
 /// Migrate WAL segments from legacy v21 (CRC32 IEEE) to v2 (CRC32C Castagnoli).


### PR DESCRIPTION
Adds two new Cypher capabilities to SparrowDB:

1. UNWIND ... MATCH ... SET/DELETE [RETURN ...]
   - New AST variant: UnwindMatchMutateStatement
   - Parser: parse_unwind() extended to handle MATCH + mutation tail
   - Binder: binds MATCH patterns, UNWIND expr uses
   - Engine: is_mutation() returns true for UnwindMatchMutate
   - db.rs: execute_unwind_match_mutate_with_params() evaluates
     the UNWIND list and applies mutations per-row within a single
     write transaction (eliminates N+1 query parse overhead)

2. DELETE ... RETURN count(n)
   - MatchMutateStatement gains optional return_clause field
   - Parser: parse_match_or_match_mutate() parses RETURN after SET/DELETE
   - db.rs: build_mutate_return() helper returns mutation count
   - All three mutation paths (direct, deadline, with-params) updated

These capabilities enable awknow-rs to replace N indidvidual
MATCH...SET queries with a single UNWIND query, and replace
COUNT-then-DELETE with a single DELETE...RETURN query.

Closes the N+1 and COUNT+DELETE anti-patterns in SparrowGraphAccess.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MATCH ... SET/DELETE now accepts an optional RETURN clause so mutations can return results (e.g., mutation counts).
  * UNWIND ... AS ... MATCH ... SET/DELETE added to batch mutations over list elements, with optional RETURN to aggregate results across the batch; supports using element fields in MATCH/SET expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->