### PR TITLE
fix(wal): don't re-insert checkpointed edges on replay (SPA-191)

### DIFF
--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -3029,18 +3029,46 @@ fn replay_wal_mutations(db_path: &Path, encryption_key: Option<[u8; 32]>) -> Res
                     catalog.get_or_create_rel_type_id(src_label_id, dst_label_id, rel_type)?;
                 let rel_table_id = RelTableId(catalog_rel_id as u32);
 
-                // Idempotency: skip if this edge_id is already in the delta log.
+                let src_node = sparrowdb_common::NodeId(*src);
+                let dst_node = sparrowdb_common::NodeId(*dst);
+                let mut es = EdgeStore::open(db_path, rel_table_id)?;
+
+                // Idempotency: an edge is already durable if it lives in EITHER
+                // the delta log or the checkpointed CSR base.  Both must be
+                // checked (SPA-191 regression):
+                //
+                // CHECKPOINT folds the delta into the CSR base, truncates the
+                // delta, and resets `next_edge_id` to 0 (see
+                // EdgeStore::truncate_delta).  So after a checkpoint the
+                // delta-only check below reads 0, `0 > edge_id` is false for the
+                // first edge, and replay re-inserts an edge that is already in
+                // the base — leaving it counted once in the base and once in the
+                // delta, so queries return it twice.
+                let src_slot = *src & 0xFFFF_FFFF;
+                let dst_slot = *dst & 0xFFFF_FFFF;
+                let in_csr_base = match es.open_fwd() {
+                    Ok(fwd) => {
+                        src_slot < fwd.n_nodes() && fwd.neighbors(src_slot).contains(&dst_slot)
+                    }
+                    // No base file yet — normal before the first checkpoint.
+                    Err(Error::Io(ref e)) if e.kind() == std::io::ErrorKind::NotFound => false,
+                    // Any other failure must not be treated as "absent": doing so
+                    // would re-insert an edge that is already in the base.
+                    Err(e) => return Err(e),
+                };
+                if in_csr_base {
+                    continue; // already folded into the CSR base by a checkpoint
+                }
+
+                // Not in the base — fall back to the delta-log high-water mark.
                 let current_edge_id = sparrowdb_storage::edge_store::EdgeStore::peek_next_edge_id(
                     db_path,
                     rel_table_id,
                 )?;
                 if current_edge_id.0 > *edge_id {
-                    continue; // already written
+                    continue; // already in the delta log
                 }
 
-                let src_node = sparrowdb_common::NodeId(*src);
-                let dst_node = sparrowdb_common::NodeId(*dst);
-                let mut es = EdgeStore::open(db_path, rel_table_id)?;
                 es.create_edge(src_node, rel_table_id, dst_node)?;
 
                 // Re-apply edge properties if present.


### PR DESCRIPTION
## Symptom

An edge created, checkpointed, then read back after reopening the database is returned **twice**.

Found while verifying 0.1.22 for release. Two tests in `spa191_rel_type_persistence.rs` fail — and the split is exact:

| Test | Calls `checkpoint()`? | Before |
|---|---|---|
| `spa191_rel_type_persists_across_sessions` | yes | ❌ `left: 2, right: 1` |
| `spa191_multiple_rel_types_all_persist` | yes | ❌ `left: 2, right: 1` |
| `spa191_rel_type_persists_without_checkpoint` | no | ✅ |
| `spa191_catalog_rel_table_survives_reopen` | no | ✅ |

Only the checkpointing tests fail. These have been failing on `main`; CI reported green because every test step piped into `tee` without `pipefail` — see #412.

## Root cause

`CHECKPOINT` folds the delta log into the CSR base, truncates the delta, and resets `next_edge_id` to 0 (`EdgeStore::truncate_delta`, `edge_store.rs:334`).

The WAL replay idempotency guard (`db.rs:3032`) only consulted the delta log:

```rust
// Idempotency: skip if this edge_id is already in the delta log.
let current_edge_id = EdgeStore::peek_next_edge_id(db_path, rel_table_id)?;
if current_edge_id.0 > *edge_id { continue; }
```

After a checkpoint that reads `0`, so `0 > 0` is false for the first edge and the guard never fires. Replay re-inserts an edge that is already in the CSR base. Reads union base + delta, so the edge appears twice.

## Fix

An edge is durable if it is in **either** the CSR base **or** the delta log. The guard now checks both — base first, then the delta high-water mark.

A missing base file (normal before the first checkpoint) is treated as absent. Any other I/O error propagates rather than being read as "absent", which would re-insert the edge — mirroring the reasoning already applied in `build_sorted_edges`.

This completes an incomplete check rather than working around it: the guard already meant "is this edge already written?", it just consulted one of the two places an edge can live.

## Verification

- **All 4 SPA-191 tests pass** (was 2/4).
- `cargo fmt --all --check` clean.
- Diff is one file, +33/−5. `cargo fmt` touched nothing else.

Full local `cargo test --workspace` verification is limited by two pre-existing environment issues unrelated to this change:

- `sparrowdb-ruby` fails to compile locally (`magnus`/`rb_sys` vs. installed Ruby, 79 errors), so the run excludes it. CI's Ruby job pins 3.3 via `ruby/setup-ruby@v1` and is unaffected.
- `cargo clippy -D warnings` **fails on unmodified `main`** at `crates/sparrowdb-execution/src/engine/expr.rs:60` (`you seem to want to iterate on a map's values`) with clippy 0.1.97. CI uses `dtolnay/rust-toolchain@stable`, so the clippy step will fail for any PR until that one-line lint is fixed separately.

## Follow-up (not in this PR)

`Metapage::wal_checkpoint_lsn` exists, and both `GraphDb::checkpoint`'s doc comment ("publish the new `wal_checkpoint_lsn` to the metapage") and `edge_store.rs:317` ("Recovery will replay from the WAL CheckpointBegin LSN") assume replay is gated on it — but **nothing in the DB layer reads or publishes it**. Gating replay on the checkpoint LSN would prevent this whole class of bug rather than one instance of it, and would let node replay drop its own ad-hoc `disk_hwm` idempotency check. That is a larger change to on-disk metapage semantics and deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE