### PR TITLE
fix(clippy): resolve three lints failing on clean main under Rust 1.97

### DIFF
--- a/crates/sparrowdb-cli/src/main.rs
+++ b/crates/sparrowdb-cli/src/main.rs
@@ -168,13 +168,9 @@ fn main() {
 
 fn cmd_query(db_path: &std::path::Path, cypher: &str) -> Result<(), Box<dyn std::error::Error>> {
     let db = sparrowdb::GraphDb::open(db_path)?;
-    match db.execute(cypher) {
-        Ok(result) => {
-            let json = query_result_to_json(&result);
-            println!("{}", serde_json::to_string_pretty(&json)?);
-        }
-        Err(e) => return Err(e.into()),
-    }
+    let result = db.execute(cypher)?;
+    let json = query_result_to_json(&result);
+    println!("{}", serde_json::to_string_pretty(&json)?);
     Ok(())
 }
 

--- a/crates/sparrowdb-execution/src/engine/expr.rs
+++ b/crates/sparrowdb-execution/src/engine/expr.rs
@@ -57,7 +57,7 @@ impl Engine {
 
             // Pass 2: fall back to any plain NodeRef entry matching the label.
             if found.is_none() {
-                for (_k, v) in vals.iter() {
+                for v in vals.values() {
                     if let Value::NodeRef(nid) = v {
                         let label_id_from_node = (nid.0 >> 32) as u32;
                         if expected_lid.is_none_or(|eid| label_id_from_node == eid) {

--- a/crates/sparrowdb/tests/spa_fulltext.rs
+++ b/crates/sparrowdb/tests/spa_fulltext.rs
@@ -214,7 +214,7 @@ fn call_yield_node_usable_in_return() {
     assert!(
         matches!(&result.rows[0][0], Value::NodeRef(_)),
         "RETURN node should produce a NodeRef, got {:?}",
-        &result.rows[0][0]
+        result.rows[0][0]
     );
 
     // CALL with RETURN node.score — verifies property projection from yielded NodeRef.
@@ -230,7 +230,7 @@ fn call_yield_node_usable_in_return() {
         result2.rows[0][0],
         Value::Int64(expected_val),
         "RETURN node.score should project the stored property value, got {:?}",
-        &result2.rows[0][0]
+        result2.rows[0][0]
     );
 }
 


### PR DESCRIPTION
## Problem

`cargo clippy --all-targets -- -D warnings` **fails on unmodified `main`** with clippy 0.1.97 (2026-07-14). CI uses `dtolnay/rust-toolchain@stable`, so the clippy step fails for every PR regardless of its contents — currently blocking #412 and #413.

Recurring pattern: newer clippy flags code that passed under the version in use when it was written.

## Changes

Three lints, all mechanical and behavior-preserving:

| File | Lint | Change |
|---|---|---|
| `sparrowdb-execution/src/engine/expr.rs:60` | `iter_kv_map` | `for (_k, v) in vals.iter()` → `for v in vals.values()` |
| `sparrowdb-cli/src/main.rs:171` | `question_mark` | `match db.execute(..) { Ok(..) =>, Err(e) => return Err(e.into()) }` → `?` |
| `sparrowdb/tests/spa_fulltext.rs:217,233` | `needless_borrow` | redundant `&` in `assert!`/`assert_eq!` format arguments |

## Verification

- `cargo clippy --workspace --exclude sparrowdb-ruby --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test -p sparrowdb-execution -p sparrowdb-cli` — all green
- `cargo test -p sparrowdb --test spa_fulltext` — 5 passed

`sparrowdb-ruby` is excluded locally because `magnus`/`rb_sys` doesn't compile against the installed Ruby (~79 errors, pre-existing). CI's clippy step runs in the `test` job without a Ruby setup step, so if that crate has its own lints they'll surface there — none of the three fixed here are in it.

## Note

Found while verifying 0.1.22 for release. Kept separate from #412 (CI pipefail) and #413 (duplicate-edge bug) since it's unrelated to both — but it needs to land for either to show green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for query execution, ensuring failures are reported consistently.
  * Preserved full-text search behavior while improving internal result processing.

* **Tests**
  * Updated full-text search checks to more accurately validate returned values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->