### PR TITLE
fix(cypher): CREATE VECTOR INDEX could not be parsed (closes #417)

### DIFF
--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -1498,7 +1498,16 @@ impl Parser {
         };
 
         // `FOR (n:Label)`
+        //
+        // The lexer maps the FOR keyword to the dedicated `Token::For`
+        // (lexer.rs), never to `Token::Ident("FOR")`, so matching only on the
+        // ident form left the token unconsumed and the `expect_tok(LParen)`
+        // below failed with "expected LParen, got For" — CREATE VECTOR INDEX
+        // could not be parsed at all (#417).
         match self.peek().clone() {
+            Token::For => {
+                self.advance();
+            }
             Token::Ident(ref s) if s.eq_ignore_ascii_case("FOR") => {
                 self.advance();
             }


### PR DESCRIPTION
Closes #417.

## Symptom

```cypher
CREATE VECTOR INDEX FOR (n:Memory) ON (n.embedding)
OPTIONS { dimensions: 4, similarity: 'cosine' }
```

```
InvalidArgument("expected LParen, got For")
```

The HNSW vector index (#394) could not be created through Cypher **at all**. Shipped broken in published 0.1.16 and 0.1.22.

## Root cause

The lexer maps the `FOR` keyword to a dedicated `Token::For` (`lexer.rs:393`) and never to `Token::Ident("FOR")`.

`parse_create_vector_index` matched only the ident form:

```rust
match self.peek().clone() {
    Token::Ident(ref s) if s.eq_ignore_ascii_case("FOR") => { self.advance(); }
    _ => {} // tolerate missing FOR
}
self.expect_tok(&Token::LParen)?;   // ← sees Token::For, errors
```

`Token::For` fell through the tolerate-missing-FOR arm without advancing, so the very next `expect_tok(&Token::LParen)` failed on it.

`parse_create_fulltext_index` gets this right — it uses `Token::For` at `parser.rs:1447` and `1456`. The vector-index parser, written later, copied the shape but not the token.

## Fix

Add the `Token::For` arm. The ident arm and the tolerate-missing-`FOR` fallback are both kept, so nothing previously accepted regresses.

## Verification

- `vector_index` integration tests: **16/16** (was 15/16)
- `spa_fulltext`: 5/5 — `CREATE FULLTEXT INDEX` unaffected
- `cargo test -p sparrowdb-cypher` — all green
- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --exclude sparrowdb-ruby --all-targets -- -D warnings` clean

## Context

Fourth bug found while verifying 0.1.22 for release, all of which were invisible because CI reported test failures as green (#412) and `cargo test` fail-fast hid everything after the first failing binary. With this and #416 merged, the only remaining known failure on `main` is #418 (LDBC stubs in `sparrowdb-bench`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of vector index creation statements using the `FOR` keyword.
  * Preserved compatibility with identifier-form and omitted `FOR` syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->