### PR TITLE
fix(engine): reject varlen path + trailing hop instead of silently truncating (#421, #418)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# SparrowDB — build and test environment
+
+Machine-specific facts that will otherwise cost you a wrong result. Verified 2026-08-01.
+
+## Isolate CARGO_TARGET_DIR when worktrees build concurrently
+
+Every worktree shares `CARGO_TARGET_DIR=/Volumes/Dev/cargo-target`. With more than one
+worktree or agent building at the same time, `cargo test` can run a binary compiled from
+**another worktree's source**.
+
+```bash
+export CARGO_TARGET_DIR=/Volumes/Dev/target-<pr-number>
+```
+
+Tells that a result is contaminated:
+- test names in the output that don't exist in your file
+- an ignored-count that disagrees with `grep -c '#\[ignore'`
+- a pass where you predicted a failure
+
+Treat any suite result gathered while sibling agents were building as unverified.
+
+## `cargo test --workspace` does not compile here
+
+`sparrowdb-ruby` → `magnus`/`rb_sys` fails against the installed Ruby (~79 errors:
+`RUBY_T_MOVED` not found, `dcompact` missing). Always:
+
+```bash
+cargo test --workspace --exclude sparrowdb-ruby --no-fail-fast
+```
+
+CI is unaffected — its Ruby job pins 3.3 via `ruby/setup-ruby@v1`.
+
+## Always `--no-fail-fast`
+
+`cargo test` stops after a failing test **binary**, so every later binary silently never
+runs. A truncated failure list looks identical to a short one. `cargo clippy` likewise
+stops at the first failing crate — use `--keep-going` to enumerate all lints in one pass.
+
+## The suite is slow
+
+`spa_222_csr_lazy_load` alone runs 5+ minutes; a full run exceeds 60. It is not hung.
+CI runs take ~85 minutes.
+
+## cargo binary
+
+`~/.cargo/bin/cargo` is a broken symlink. Use:
+
+```
+/Users/ryaker/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo
+```
+
+## Two testing rules this repo learned the hard way
+
+1. **Derive expected values from the fixture by hand — never capture program output.**
+   Asserting what the code currently returns freezes bugs in as expected behaviour. Issue
+   #421 (silent variable-length path truncation) was found precisely by hand-deriving an
+   expected result instead of recording the observed one.
+
+2. **Confirm a regression test fails against the pre-fix commit.** `regression_406.rs`
+   shipped as the guard for #406 and passes against the unfixed code — it could never
+   reach the failing state, so it guarded nothing. Check out the fix's parent, run the
+   test, and verify it fails with the reported symptom.

--- a/crates/sparrowdb-bench/tests/ldbc_ic_test.rs
+++ b/crates/sparrowdb-bench/tests/ldbc_ic_test.rs
@@ -259,6 +259,30 @@ fn ic10_recommends_friends_of_friends() {
 }
 
 #[test]
+fn ic12_expert_search_by_tag_class() {
+    let (_dir, db) = db_with_mini_fixture();
+    // Friends {2,3,6}: Bob wrote post 2 → tag Rust → class Technology;
+    // Carol wrote post 3 → tag SocialNetworks → class Science; Frank none.
+    let tech = ic_queries::ic12_expert_search(&db, 1, "Technology").expect("IC12 should not error");
+    assert_eq!(
+        tech,
+        vec![(("Bob".to_string(), "Jones".to_string()), 1)],
+        "IC12: only Bob posted under tag class Technology; got {tech:?}"
+    );
+
+    let science = ic_queries::ic12_expert_search(&db, 1, "Science").expect("IC12 should not error");
+    assert_eq!(
+        science,
+        vec![(("Carol".to_string(), "White".to_string()), 1)],
+        "IC12: only Carol posted under tag class Science; got {science:?}"
+    );
+
+    // No tag maps to OffTopic in tag_hasType_tagclass_0_0.csv.
+    let off = ic_queries::ic12_expert_search(&db, 1, "OffTopic").expect("IC12 should not error");
+    assert!(off.is_empty(), "IC12: no expert for OffTopic; got {off:?}");
+}
+
+#[test]
 #[ignore = "blocked on #421: ic11 uses a variable-length path followed by another hop. \
 Un-ignore when #421 is implemented."]
 fn ic11_job_referral() {

--- a/crates/sparrowdb-bench/tests/ldbc_ic_test.rs
+++ b/crates/sparrowdb-bench/tests/ldbc_ic_test.rs
@@ -104,90 +104,199 @@ fn ic2_unknown_person_returns_empty() {
     );
 }
 
+// ── IC3–IC14 ────────────────────────────────────────────────────────────────
+//
+// These were written against stubs (5865f0e) and asserted `is_empty()`. The
+// queries were implemented in 5b049ff (#279) without updating this file, and
+// CI reported the resulting failures as green (#412), so they went unnoticed.
+//
+// Expectations below are derived by hand from the mini fixture, NOT captured
+// from program output — see #421, where reading the CSVs is what exposed a
+// silent variable-length truncation bug that captured output would have
+// frozen in as "expected".
+//
+// Fixture facts used throughout (Alice = ldbc_id 1):
+//   knows:        1→{2,3,6}; 2→{4,5}; 3→{4,5}; 6→{7}; 7→8; 8→9; 9→10
+//   isLocatedIn:  1,3,7,10→US(1)  2,5,8→UK(2)  4,6,9→Germany(3)
+//   posts:        1,4→Alice  2→Bob  3→Carol  5→Dave
+//   post tags:    1→{Databases,GraphTheory} 2→{Rust} 3→{SocialNetworks}
+//                 4→{Databases} 5→{GraphTheory}
+//   likes:        2→p1, 3→p1, 1→p2, 4→p3, 3→p4
+//   comments:     c1→p1 by Bob, c4→p4 by Dave
+//   forums:       1 "Graph Databases" {1,2,3}; 2 "Rust Programming" {4,5};
+//                 3 "Social Networks" {1,6}
+
 #[test]
-fn ic3_stub_returns_empty() {
+#[ignore = "blocked on #421: ic3 uses (p)-[:knows*1..2]->(f)-[:isLocatedIn]->(place), \
+a variable-length path followed by another hop, which is now rejected rather than \
+silently answered with depth-1 matches only. Correct result for (1, Germany) is \
+[Dave Brown, Frank Miller]. Un-ignore when #421 is implemented."]
+fn ic3_friends_in_countries_returns_both_germans() {
     let (_dir, db) = db_with_mini_fixture();
     let r = ic_queries::ic3_friends_in_countries(&db, 1, "Germany", "France", 14)
-        .expect("IC3 stub should not error");
-    assert!(r.is_empty(), "IC3 stub must return empty Vec");
+        .expect("IC3 should not error");
+    let names: Vec<String> = r.iter().map(|p| p.1.clone()).collect();
+    assert_eq!(
+        names,
+        vec!["Brown".to_string(), "Miller".to_string()],
+        "IC3: Alice's friends within 2 hops located in Germany are Dave Brown (depth 2) \
+         and Frank Miller (depth 1); got {r:?}"
+    );
 }
 
 #[test]
-fn ic4_stub_returns_empty() {
+fn ic4_top_tags_of_friends_posts() {
     let (_dir, db) = db_with_mini_fixture();
-    let r = ic_queries::ic4_top_tags(&db, 1, "2012-01-01", 30).expect("IC4 stub should not error");
-    assert!(r.is_empty(), "IC4 stub must return empty Vec");
+    let r = ic_queries::ic4_top_tags(&db, 1, "2012-01-01", 30).expect("IC4 should not error");
+    // Friends {2,3,6}: Bob→post2→Rust, Carol→post3→SocialNetworks, Frank→no posts.
+    assert_eq!(
+        r,
+        vec![("Rust".to_string(), 1), ("SocialNetworks".to_string(), 1)],
+        "IC4: expected one Rust and one SocialNetworks tag from friends' posts; got {r:?}"
+    );
 }
 
 #[test]
-fn ic5_stub_returns_empty() {
-    let (_dir, db) = db_with_mini_fixture();
-    let r = ic_queries::ic5_forums_with_friends(&db, 1, "2012-01-01")
-        .expect("IC5 stub should not error");
-    assert!(r.is_empty(), "IC5 stub must return empty Vec");
-}
-
-#[test]
-fn ic6_stub_returns_empty() {
-    let (_dir, db) = db_with_mini_fixture();
-    let r = ic_queries::ic6_tag_co_occurrence(&db, 1, "Music").expect("IC6 stub should not error");
-    assert!(r.is_empty(), "IC6 stub must return empty Vec");
-}
-
-#[test]
-fn ic7_stub_returns_empty() {
-    let (_dir, db) = db_with_mini_fixture();
-    let r = ic_queries::ic7_latest_likes(&db, 1).expect("IC7 stub should not error");
-    assert!(r.is_empty(), "IC7 stub must return empty Vec");
-}
-
-#[test]
-fn ic8_stub_returns_empty() {
-    let (_dir, db) = db_with_mini_fixture();
-    let r = ic_queries::ic8_replies(&db, 1).expect("IC8 stub should not error");
-    assert!(r.is_empty(), "IC8 stub must return empty Vec");
-}
-
-#[test]
-fn ic9_stub_returns_empty() {
-    let (_dir, db) = db_with_mini_fixture();
-    let r = ic_queries::ic9_recent_posts_by_friends(&db, 1, "2012-01-01")
-        .expect("IC9 stub should not error");
-    assert!(r.is_empty(), "IC9 stub must return empty Vec");
-}
-
-#[test]
-fn ic10_stub_returns_empty() {
-    let (_dir, db) = db_with_mini_fixture();
-    let r = ic_queries::ic10_friend_recommendations(&db, 1, 3).expect("IC10 stub should not error");
-    assert!(r.is_empty(), "IC10 stub must return empty Vec");
-}
-
-#[test]
-fn ic11_stub_returns_empty() {
+fn ic5_forums_ranked_by_friend_membership() {
     let (_dir, db) = db_with_mini_fixture();
     let r =
-        ic_queries::ic11_job_referral(&db, 1, "Germany", 2005).expect("IC11 stub should not error");
-    assert!(r.is_empty(), "IC11 stub must return empty Vec");
+        ic_queries::ic5_forums_with_friends(&db, 1, "2012-01-01").expect("IC5 should not error");
+    // Forum 1 holds friends 2 and 3 → 2; forum 3 holds friend 6 → 1;
+    // forum 2 holds only 4 and 5, neither a friend of Alice.
+    assert_eq!(
+        r,
+        vec![
+            ("Graph Databases".to_string(), 2),
+            ("Social Networks".to_string(), 1)
+        ],
+        "IC5: expected Graph Databases=2, Social Networks=1; got {r:?}"
+    );
 }
 
 #[test]
-fn ic12_stub_returns_empty() {
+#[ignore = "blocked on #422: ic6 never restricts to posts carrying the input tag — it \
+only excludes that tag from the output, so a tag absent from the graph still returns \
+every friend tag. Un-ignore when #422 is fixed."]
+fn ic6_co_occurring_tags() {
     let (_dir, db) = db_with_mini_fixture();
-    let r = ic_queries::ic12_expert_search(&db, 1, "Writer").expect("IC12 stub should not error");
-    assert!(r.is_empty(), "IC12 stub must return empty Vec");
+    // Only post 2 (Bob, a friend) carries Rust, and it carries no other tag,
+    // so nothing co-occurs with Rust among friends' posts.
+    let r = ic_queries::ic6_tag_co_occurrence(&db, 1, "Rust").expect("IC6 should not error");
+    assert!(
+        r.is_empty(),
+        "IC6: post 2 is the only friend post tagged Rust and has no other tag; got {r:?}"
+    );
+    // A tag no post carries must yield nothing.
+    let none = ic_queries::ic6_tag_co_occurrence(&db, 1, "ZZZ_nonexistent")
+        .expect("IC6 unknown tag should not error");
+    assert!(
+        none.is_empty(),
+        "IC6: unknown tag must return empty; got {none:?}"
+    );
 }
 
 #[test]
-fn ic13_stub_returns_negative_one() {
+fn ic7_likers_of_alices_posts() {
     let (_dir, db) = db_with_mini_fixture();
-    let r = ic_queries::ic13_shortest_path(&db, 1, 10).expect("IC13 stub should not error");
-    assert_eq!(r, -1, "IC13 stub should return -1 (not-found sentinel)");
+    let r = ic_queries::ic7_latest_likes(&db, 1).expect("IC7 should not error");
+    // Alice created posts 1 and 4. Post 1 liked by 2 (Bob) and 3 (Carol);
+    // post 4 liked by 3 (Carol).
+    let names: Vec<String> = r.iter().map(|p| p.1.clone()).collect();
+    assert_eq!(
+        names,
+        vec!["Jones".to_string(), "White".to_string()],
+        "IC7: Bob Jones and Carol White liked Alice's posts; got {r:?}"
+    );
 }
 
 #[test]
-fn ic14_stub_returns_empty() {
+fn ic8_repliers_to_alices_posts() {
     let (_dir, db) = db_with_mini_fixture();
-    let r = ic_queries::ic14_weighted_path(&db, 1, 10).expect("IC14 stub should not error");
-    assert!(r.is_empty(), "IC14 stub must return empty Vec");
+    let r = ic_queries::ic8_replies(&db, 1).expect("IC8 should not error");
+    // Alice's posts are 1 and 4; comment 1 (Bob) replies to post 1,
+    // comment 4 (Dave) replies to post 4.
+    let names: Vec<String> = r.iter().map(|p| p.1.clone()).collect();
+    assert_eq!(
+        names,
+        vec!["Jones".to_string(), "Brown".to_string()],
+        "IC8: Bob Jones and Dave Brown replied to Alice's posts; got {r:?}"
+    );
+}
+
+#[test]
+fn ic9_recent_posts_by_friends() {
+    let (_dir, db) = db_with_mini_fixture();
+    let r = ic_queries::ic9_recent_posts_by_friends(&db, 1, "2012-01-01")
+        .expect("IC9 should not error");
+    // Friends {2,3,6}: Bob wrote post 2, Carol post 3, Frank none.
+    let contents: Vec<String> = r.iter().map(|(_, c)| c.clone()).collect();
+    assert_eq!(
+        contents,
+        vec![
+            "Rust is amazing".to_string(),
+            "Social networks are complex".to_string()
+        ],
+        "IC9: expected Bob's and Carol's posts; got {r:?}"
+    );
+}
+
+#[test]
+fn ic10_recommends_friends_of_friends() {
+    let (_dir, db) = db_with_mini_fixture();
+    let r = ic_queries::ic10_friend_recommendations(&db, 1, 3).expect("IC10 should not error");
+    // Alice knows {2,3,6}. Friends-of-friends: 2→{4,5}, 3→{4,5}, 6→{7}.
+    // Excluding existing friends and Alice herself leaves {4,5,7}.
+    let names: Vec<String> = r.iter().map(|p| p.1.clone()).collect();
+    assert_eq!(
+        names,
+        vec![
+            "Brown".to_string(),
+            "Davis".to_string(),
+            "Wilson".to_string()
+        ],
+        "IC10: expected Dave Brown, Eve Davis, Grace Wilson; got {r:?}"
+    );
+}
+
+#[test]
+#[ignore = "blocked on #421: ic11 uses a variable-length path followed by another hop. \
+Un-ignore when #421 is implemented."]
+fn ic11_job_referral() {
+    let (_dir, db) = db_with_mini_fixture();
+    let r = ic_queries::ic11_job_referral(&db, 1, "Germany", 2005).expect("IC11 should not error");
+    assert!(!r.is_empty(), "IC11 should find referrals; got {r:?}");
+}
+
+#[test]
+fn ic13_shortest_path_alice_to_jack() {
+    let (_dir, db) = db_with_mini_fixture();
+    let hops = ic_queries::ic13_shortest_path(&db, 1, 10).expect("IC13 should not error");
+    // 1→6→7→8→9→10 is 5 hops, shorter than 1→3→5→7→8→9→10 (6) and
+    // 1→2→4→6→7→8→9→10 (7).
+    assert_eq!(hops, 5, "IC13: shortest path 1→10 is 5 hops; got {hops}");
+}
+
+#[test]
+#[ignore = "blocked on #423: ic13 documents \"-1 if no path exists\" but returns 1 for \
+unreachable pairs. Un-ignore when #423 is fixed."]
+fn ic13_unreachable_returns_negative_one() {
+    let (_dir, db) = db_with_mini_fixture();
+    // knows edges are directed and no path leads back to Alice.
+    let hops = ic_queries::ic13_shortest_path(&db, 10, 1).expect("IC13 should not error");
+    assert_eq!(
+        hops, -1,
+        "IC13: 10→1 is unreachable, expected -1; got {hops}"
+    );
+}
+
+#[test]
+fn ic14_finds_a_path_alice_to_jack() {
+    let (_dir, db) = db_with_mini_fixture();
+    let r = ic_queries::ic14_weighted_path(&db, 1, 10).expect("IC14 should not error");
+    // A path exists (see ic13); LDBC IC14 weighting semantics are not pinned
+    // down by this fixture, so assert only that a path is reported.
+    assert!(
+        !r.is_empty(),
+        "IC14: a path from 1 to 10 exists and should be reported; got {r:?}"
+    );
 }

--- a/crates/sparrowdb-execution/src/engine/scan.rs
+++ b/crates/sparrowdb-execution/src/engine/scan.rs
@@ -736,6 +736,31 @@ impl Engine {
             && m.pattern[0].rels.len() == 1
             && m.pattern[0].rels[0].min_hops.is_some();
 
+        // #421: `is_var_len` only recognises a variable-length quantifier when it
+        // is the *only* relationship in the pattern. With a trailing hop —
+        // `(a)-[:R*1..2]->(b)-[:S]->(c)` — `rels.len() == 2`, so `is_two_hop`
+        // wins and `execute_two_hop` treats `*1..2` as a plain single hop,
+        // silently discarding every match at depth >= 2 and returning a
+        // plausible but incomplete result set.
+        //
+        // Executing variable-length expansion followed by further hops is not
+        // implemented. Until it is, reject the pattern loudly: a clear error is
+        // far better than quietly wrong data the caller cannot detect.
+        if m.pattern.len() == 1
+            && m.pattern[0].rels.len() > 1
+            && m.pattern[0]
+                .rels
+                .iter()
+                .any(|r| r.min_hops.is_some() || r.max_hops.is_some())
+        {
+            return Err(sparrowdb_common::Error::InvalidArgument(
+                "variable-length relationship followed by additional hops is not supported \
+                 (e.g. (a)-[:R*1..2]->(b)-[:S]->(c)); split the pattern into separate \
+                 MATCH clauses — see issue #421"
+                    .to_string(),
+            ));
+        }
+
         let column_names = extract_return_column_names(&m.return_clause.items);
 
         // SPA-136: multi-node-pattern MATCH (e.g. MATCH (a), (b) RETURN shortestPath(...))

--- a/crates/sparrowdb-execution/src/engine/scan.rs
+++ b/crates/sparrowdb-execution/src/engine/scan.rs
@@ -746,20 +746,7 @@ impl Engine {
         // Executing variable-length expansion followed by further hops is not
         // implemented. Until it is, reject the pattern loudly: a clear error is
         // far better than quietly wrong data the caller cannot detect.
-        if m.pattern.len() == 1
-            && m.pattern[0].rels.len() > 1
-            && m.pattern[0]
-                .rels
-                .iter()
-                .any(|r| r.min_hops.is_some() || r.max_hops.is_some())
-        {
-            return Err(sparrowdb_common::Error::InvalidArgument(
-                "variable-length relationship followed by additional hops is not supported \
-                 (e.g. (a)-[:R*1..2]->(b)-[:S]->(c)); split the pattern into separate \
-                 MATCH clauses — see issue #421"
-                    .to_string(),
-            ));
-        }
+        reject_varlen_with_trailing_hops(m)?;
 
         let column_names = extract_return_column_names(&m.return_clause.items);
 
@@ -1288,6 +1275,12 @@ impl Engine {
         };
 
         let column_names = extract_return_column_names(&om.return_clause.items);
+
+        // #421: this arm swallows InvalidArgument into a NULL row, which would
+        // turn the unsupported-pattern error below into silent nulls — exactly
+        // the silent-wrongness the guard exists to prevent. Check first so the
+        // error propagates instead of being absorbed.
+        reject_varlen_with_trailing_hops(&match_stmt)?;
 
         let result = self.execute_match(&match_stmt);
 
@@ -2734,4 +2727,39 @@ impl Engine {
             .collect();
         Value::List(label_strings)
     }
+}
+
+/// Reject `(a)-[:R*m..n]->(b)-[:S]->(c)` — a variable-length relationship
+/// followed by further hops (#421).
+///
+/// `is_var_len` in `execute_match` only recognises a variable-length quantifier
+/// when the varlen rel is the *only* relationship in the pattern. With a
+/// trailing hop `rels.len() >= 2`, so `is_two_hop`/`is_n_hop` wins and the
+/// quantifier is silently discarded — every match at depth >= 2 disappears and
+/// the caller gets a plausible but incomplete result set.
+///
+/// Executing varlen expansion followed by further hops is not implemented.
+/// Until it is, fail loudly: undetectable wrong data is worse than an error.
+///
+/// Must be called by every path that can dispatch such a pattern. In
+/// particular `execute_optional_match` has to call it *before* delegating,
+/// because that function absorbs `InvalidArgument` into a NULL row and would
+/// otherwise convert this error back into silent wrongness.
+pub(crate) fn reject_varlen_with_trailing_hops(m: &MatchStatement) -> Result<()> {
+    for pat in &m.pattern {
+        if pat.rels.len() > 1
+            && pat
+                .rels
+                .iter()
+                .any(|r| r.min_hops.is_some() || r.max_hops.is_some())
+        {
+            return Err(sparrowdb_common::Error::InvalidArgument(
+                "variable-length relationship followed by additional hops is not supported \
+                 (e.g. (a)-[:R*1..2]->(b)-[:S]->(c)); split the pattern into separate \
+                 MATCH clauses — see issue #421"
+                    .to_string(),
+            ));
+        }
+    }
+    Ok(())
 }

--- a/crates/sparrowdb/tests/spa_111_ldbc_ic3_ic14.rs
+++ b/crates/sparrowdb/tests/spa_111_ldbc_ic3_ic14.rs
@@ -30,6 +30,9 @@ fn load_mini_db() -> (tempfile::TempDir, GraphDb) {
 // ── IC3 ─────────────────────────────────────────────────────────────────────
 
 #[test]
+#[ignore = "blocked on #421: this query uses (a)-[:knows*1..2]->(b)-[:isLocatedIn]->(c), \
+which silently returned only depth-1 matches. Now rejected outright rather than \
+answered incompletely. Un-ignore when variable-length + hop traversal is implemented."]
 fn ic3_friends_in_country() {
     let (_dir, db) = load_mini_db();
 
@@ -175,6 +178,8 @@ fn ic10_friend_recommendations() {
 // ── IC11 ────────────────────────────────────────────────────────────────────
 
 #[test]
+#[ignore = "blocked on #421: variable-length relationship followed by additional hops. \
+Un-ignore when that traversal shape is implemented."]
 fn ic11_job_referral() {
     let (_dir, db) = load_mini_db();
 


### PR DESCRIPTION
Closes #418. Mitigates #421.

## The bug (#421)

```cypher
MATCH (a)-[:R*1..2]->(b)-[:S]->(c)   -- returns only depth-1 matches, no error
```

`scan.rs` recognised a variable-length quantifier only when the varlen relationship was the **only** one in the pattern:

```rust
let is_var_len = m.pattern.len() == 1
    && m.pattern[0].rels.len() == 1        // ← 1 rel only
    && m.pattern[0].rels[0].min_hops.is_some();
```

Add a trailing hop → `rels.len() == 2` → `is_two_hop` wins → `execute_two_hop` treats `*1..2` as a plain single hop and drops the quantifier. Same for `execute_n_hop` at 3+ rels.

Verified on the LDBC mini fixture:

| Query | Rows |
|---|---|
| `-[:knows*1..2]->(f)` | 8 — includes Dave at depth 2 ✅ |
| `-[:knows*1..2]->(f)-[:isLocatedIn]->(pl)` | 3 — the 1-hop set only ❌ |

Dave is in Germany and must appear. Silently wrong results, present in published 0.1.16 and 0.1.22.

## What this PR does

Rejects the pattern with a clear error naming #421. For a database, undetectable wrong data is worse than a loud failure.

**Cost, stated plainly:** LDBC IC3 and IC11 now error rather than returning incomplete answers. Their tests are `#[ignore]`d against #421. If you would rather keep partial results with a documented caveat, this guard is one `if` block to remove — say so and I will.

Implementing real varlen-then-hop traversal (expand the varlen to intermediate bindings, then apply remaining hops, handling projection/WHERE/DISTINCT across the join) is a feature in its own right and deserves its own design.

## LDBC assertions rewritten (#418)

The IC tests asserted `is_empty()` from the stub era (`5865f0e`). `5b049ff` (#279) implemented IC3–IC14 and never updated the file; masked CI (#412) hid the failures.

New expectations are **derived by hand from the fixture CSVs**, not captured from program output. That distinction mattered: deriving IC3's expected result — Alice's 2-hop neighbours in Germany are Dave *and* Frank, not Frank alone — is exactly what exposed #421. Capturing output would have frozen the bug in as expected behaviour and made it permanently invisible.

Each assertion carries the derivation in a comment, e.g. IC10:

> Alice knows {2,3,6}. Friends-of-friends: 2→{4,5}, 3→{4,5}, 6→{7}. Excluding existing friends and Alice herself leaves {4,5,7} → Dave Brown, Eve Davis, Grace Wilson.

## Two further bugs found while deriving

Both `#[ignore]`d against their issues rather than asserted:

- **#422** — `ic6_tag_co_occurrence` never restricts to posts carrying the input tag; it only excludes that tag from output, so `ic6(1, "ZZZ_nonexistent")` returns every friend tag.
- **#423** — `ic13_shortest_path` documents "-1 if no path exists" but returns `1` for unreachable pairs, so callers cannot distinguish adjacent from disconnected.

## Verification

- `cargo test -p sparrowdb --no-fail-fast` — all green
- `cargo test -p sparrowdb-bench --no-fail-fast` — 12 passed, 4 ignored
- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --exclude sparrowdb-ruby --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation to reject unsupported variable-length relationship patterns instead of returning incomplete results.
  - Improved handling of graph query patterns with additional relationship hops.

- **Tests**
  - Replaced placeholder integration tests with fixture-based behavioral coverage for multiple LDBC queries.
  - Documented and temporarily skipped scenarios blocked by known query limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->