### PR TITLE
fix(bench): ic6 applies its tag filter; ic13 returns -1 when unreachable (closes #422, #423)

### DIFF
--- a/crates/sparrowdb-bench/src/ic_queries.rs
+++ b/crates/sparrowdb-bench/src/ic_queries.rs
@@ -14,7 +14,7 @@
 
 use sparrowdb::GraphDb;
 use sparrowdb_execution::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 // ── Result types ──────────────────────────────────────────────────────────────
 
@@ -138,6 +138,10 @@ pub fn ic3_friends_in_countries(
 /// **IC4** — Tags on posts created by direct friends.
 ///
 /// Two-step: first get friend IDs, then query posts by those creators.
+///
+/// Ties on `cnt` are broken by `tag.name ASC` so the ordering is total and the
+/// result is reproducible across runs — otherwise equal-count tags come back in
+/// whatever order the aggregation happens to produce.
 pub fn ic4_top_tags(
     db: &GraphDb,
     person_id: i64,
@@ -174,7 +178,7 @@ pub fn ic4_top_tags(
         "MATCH (post:Post)-[:hasTag]->(tag:Tag) \
          WHERE post.ldbc_id IN [{}] \
          RETURN tag.name, COUNT(*) AS cnt \
-         ORDER BY cnt DESC LIMIT 10",
+         ORDER BY cnt DESC, tag.name ASC LIMIT 10",
         post_ids_list.join(", ")
     );
     let result = db.execute(&tag_query)?;
@@ -218,9 +222,23 @@ pub fn ic5_forums_with_friends(
 
 // ── IC6 — Tag co-occurrence ─────────────────────────────────────────────────
 
-/// **IC6** — Tags on posts by friends, excluding a given tag.
+/// **IC6** — Tags that co-occur with `tag_name` on the person's friends' posts.
 ///
-/// Two-step: reuses IC4 post discovery, filters tags.
+/// LDBC IC6 asks: among the posts *carrying* `tag_name` that were created by the
+/// person's friends, which other tags appear? Three steps, because the engine
+/// cannot chain these hops in one pattern:
+///
+/// 1. friends of `person_id`,
+/// 2. posts created by those friends,
+/// 3. of those, the posts carrying `tag_name` — then count the *other* tags on
+///    exactly those posts.
+///
+/// Step 3's first half is the restriction that was missing (#422): the query
+/// previously counted every tag on every friend post and merely excluded
+/// `tag_name` from the output, so a tag carried by no friend post — or absent
+/// from the graph entirely — still returned the full set of friends' tags.
+///
+/// Ties on `cnt` are broken by `tag.name ASC` for a reproducible ordering.
 pub fn ic6_tag_co_occurrence(
     db: &GraphDb,
     person_id: i64,
@@ -249,14 +267,36 @@ pub fn ic6_tag_co_occurrence(
         return Ok(Vec::new());
     }
 
+    // Step 2: narrow the friends' posts to those actually carrying `tag_name`.
+    // Without this the tag argument only ever suppressed a row in the output.
     let post_ids_list: Vec<String> = post_ids.iter().map(|id| id.to_string()).collect();
+    let tagged_query = format!(
+        "MATCH (post:Post)-[:hasTag]->(tag:Tag) \
+         WHERE post.ldbc_id IN [{}] AND tag.name = $tagName \
+         RETURN post.ldbc_id",
+        post_ids_list.join(", ")
+    );
+    let tagged_params = HashMap::from([("tagName".into(), Value::String(tag_name.into()))]);
+    let tagged_result = db.execute_with_params(&tagged_query, tagged_params)?;
+    let tagged_post_ids: Vec<i64> = tagged_result
+        .rows
+        .iter()
+        .map(|row| value_to_i64(&row[0]))
+        .collect();
+
+    if tagged_post_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Step 3: count the other tags carried by exactly those posts.
+    let tagged_ids_list: Vec<String> = tagged_post_ids.iter().map(|id| id.to_string()).collect();
     let params = HashMap::from([("tagName".into(), Value::String(tag_name.into()))]);
     let tag_query = format!(
         "MATCH (post:Post)-[:hasTag]->(tag:Tag) \
          WHERE post.ldbc_id IN [{}] AND tag.name <> $tagName \
          RETURN tag.name, COUNT(*) AS cnt \
-         ORDER BY cnt DESC LIMIT 10",
-        post_ids_list.join(", ")
+         ORDER BY cnt DESC, tag.name ASC LIMIT 10",
+        tagged_ids_list.join(", ")
     );
     let result = db.execute_with_params(&tag_query, params)?;
     Ok(result
@@ -474,27 +514,81 @@ pub fn ic12_expert_search(
 
 // ── IC13 — Shortest path ────────────────────────────────────────────────────
 
+/// Hop ceiling for [`ic13_shortest_path`]. Matches the bound the engine's
+/// `shortestPath()` used, so a path longer than this reads as "no path".
+const IC13_MAX_HOPS: i64 = 10;
+
+/// Does a `Person` with this `ldbc_id` exist?
+fn person_exists(db: &GraphDb, person_id: i64) -> sparrowdb::Result<bool> {
+    let cypher = "MATCH (p:Person {ldbc_id: $personId}) RETURN p.ldbc_id LIMIT 1";
+    let params = HashMap::from([("personId".into(), Value::Int64(person_id))]);
+    Ok(!db.execute_with_params(cypher, params)?.rows.is_empty())
+}
+
 /// **IC13** — Shortest path length between two persons via KNOWS.
 ///
-/// Returns the hop count, or -1 if no path exists.
+/// Returns the hop count, or -1 if no path exists within [`IC13_MAX_HOPS`].
+/// `knows` edges are followed in their stored direction only, matching how the
+/// rest of this module traverses them.
+///
+/// # Why this does not use `shortestPath()`
+///
+/// The engine's `shortestPath((a)-[:knows*]->(b))` is unusable here (#423). Its
+/// BFS is invoked with an empty relationship-type filter, so it walks *every*
+/// edge type rather than just `knows`, and it decides it has arrived by
+/// comparing storage slots alone, without comparing labels — so the slot-N node
+/// of any label counts as a hit. On the LDBC mini fixture both faults combine:
+/// person 10 has one outgoing edge, `isLocatedIn` to Place slot 0, and the
+/// target person 1 sits at Person slot 0, so the engine reports a 1-hop path
+/// between two persons that are not connected at all. That lives in
+/// `sparrowdb-execution` (`engine/expr.rs::eval_shortest_path_expr`, which
+/// passes `&[]` to `bfs_shortest_path`), outside this crate.
+///
+/// So IC13 does its own level-synchronous BFS in the bench layer — one Cypher
+/// query per hop, over `knows` only, keyed on `ldbc_id` rather than slots.
 pub fn ic13_shortest_path(
     db: &GraphDb,
     person1_id: i64,
     person2_id: i64,
 ) -> sparrowdb::Result<i64> {
-    let cypher = "\
-        MATCH (a:Person {ldbc_id: $person1Id}), (b:Person {ldbc_id: $person2Id}) \
-        RETURN shortestPath((a)-[:knows*]->(b))";
-
-    let params = HashMap::from([
-        ("person1Id".into(), Value::Int64(person1_id)),
-        ("person2Id".into(), Value::Int64(person2_id)),
-    ]);
-    let result = db.execute_with_params(cypher, params)?;
-    if result.rows.is_empty() || result.rows[0].is_empty() {
-        return Ok(-1);
+    if person1_id == person2_id {
+        return Ok(if person_exists(db, person1_id)? {
+            0
+        } else {
+            -1
+        });
     }
-    Ok(value_to_i64(&result.rows[0][0]))
+
+    let mut visited: HashSet<i64> = HashSet::from([person1_id]);
+    let mut frontier: Vec<i64> = vec![person1_id];
+
+    for depth in 1..=IC13_MAX_HOPS {
+        let ids_list: Vec<String> = frontier.iter().map(|id| id.to_string()).collect();
+        let cypher = format!(
+            "MATCH (p:Person)-[:knows]->(friend:Person) \
+             WHERE p.ldbc_id IN [{}] \
+             RETURN DISTINCT friend.ldbc_id",
+            ids_list.join(", ")
+        );
+        let result = db.execute(&cypher)?;
+
+        let mut next_frontier: Vec<i64> = Vec::new();
+        for row in &result.rows {
+            let neighbor = value_to_i64(&row[0]);
+            if neighbor == person2_id {
+                return Ok(depth);
+            }
+            if visited.insert(neighbor) {
+                next_frontier.push(neighbor);
+            }
+        }
+        if next_frontier.is_empty() {
+            break;
+        }
+        frontier = next_frontier;
+    }
+
+    Ok(-1)
 }
 
 // ── IC14 — Weighted shortest path ───────────────────────────────────────────

--- a/crates/sparrowdb-bench/tests/ldbc_ic_test.rs
+++ b/crates/sparrowdb-bench/tests/ldbc_ic_test.rs
@@ -223,6 +223,8 @@ fn ic6_co_occurring_tags() {
     // satisfiable by an ic6 that always returns empty. IC4 walks the same
     // friend→post→tag pipeline without the tag restriction, so its non-emptiness
     // proves the empties are the restriction at work, not a dead query.
+    // Tracked in #428 — a friend-owned multi-tag post would let IC6 be asserted
+    // positively and retire this guard.
     let ic4 = ic_queries::ic4_top_tags(&db, 1, "2012-01-01", 30).expect("IC4 should not error");
     assert!(
         !ic4.is_empty(),

--- a/crates/sparrowdb-bench/tests/ldbc_ic_test.rs
+++ b/crates/sparrowdb-bench/tests/ldbc_ic_test.rs
@@ -126,11 +126,10 @@ fn ic2_unknown_person_returns_empty() {
 //   forums:       1 "Graph Databases" {1,2,3}; 2 "Rust Programming" {4,5};
 //                 3 "Social Networks" {1,6}
 
+// Un-ignored once #421 shipped (6254f91): a variable-length path followed by
+// another hop now returns depth-2 matches instead of silently truncating to
+// depth 1. Dave Brown is the depth-2 match this used to lose.
 #[test]
-#[ignore = "blocked on #421: ic3 uses (p)-[:knows*1..2]->(f)-[:isLocatedIn]->(place), \
-a variable-length path followed by another hop, which is now rejected rather than \
-silently answered with depth-1 matches only. Correct result for (1, Germany) is \
-[Dave Brown, Frank Miller]. Un-ignore when #421 is implemented."]
 fn ic3_friends_in_countries_returns_both_germans() {
     let (_dir, db) = db_with_mini_fixture();
     let r = ic_queries::ic3_friends_in_countries(&db, 1, "Germany", "France", 14)
@@ -320,9 +319,8 @@ fn ic12_expert_search_by_tag_class() {
     assert!(off.is_empty(), "IC12: no expert for OffTopic; got {off:?}");
 }
 
+// Un-ignored once #421 shipped (6254f91) — see ic3 above.
 #[test]
-#[ignore = "blocked on #421: ic11 uses a variable-length path followed by another hop. \
-Un-ignore when #421 is implemented."]
 fn ic11_job_referral() {
     let (_dir, db) = db_with_mini_fixture();
     let r = ic_queries::ic11_job_referral(&db, 1, "Germany", 2005).expect("IC11 should not error");

--- a/crates/sparrowdb-bench/tests/ldbc_ic_test.rs
+++ b/crates/sparrowdb-bench/tests/ldbc_ic_test.rs
@@ -174,24 +174,60 @@ fn ic5_forums_ranked_by_friend_membership() {
 }
 
 #[test]
-#[ignore = "blocked on #422: ic6 never restricts to posts carrying the input tag — it \
-only excludes that tag from the output, so a tag absent from the graph still returns \
-every friend tag. Un-ignore when #422 is fixed."]
 fn ic6_co_occurring_tags() {
     let (_dir, db) = db_with_mini_fixture();
-    // Only post 2 (Bob, a friend) carries Rust, and it carries no other tag,
-    // so nothing co-occurs with Rust among friends' posts.
+
+    // Alice's friend posts are 2 (Bob, {Rust}) and 3 (Carol, {SocialNetworks});
+    // Frank has none. Every expectation below follows from those two posts.
+
+    // Only post 2 carries Rust, and it carries no other tag, so nothing
+    // co-occurs with Rust among friends' posts.
     let r = ic_queries::ic6_tag_co_occurrence(&db, 1, "Rust").expect("IC6 should not error");
     assert!(
         r.is_empty(),
         "IC6: post 2 is the only friend post tagged Rust and has no other tag; got {r:?}"
     );
+
+    // Symmetric case: only post 3 carries SocialNetworks, and it too is
+    // single-tagged.
+    let sn =
+        ic_queries::ic6_tag_co_occurrence(&db, 1, "SocialNetworks").expect("IC6 should not error");
+    assert!(
+        sn.is_empty(),
+        "IC6: post 3 is the only friend post tagged SocialNetworks and has no other tag; got {sn:?}"
+    );
+
+    // The #422 headline case. Databases sits on posts 1 and 4, both created by
+    // Alice herself — no *friend* post carries it, so no friend post survives
+    // the restriction and nothing can co-occur. Before the fix this returned
+    // [(Rust,1), (SocialNetworks,1)]: every friend tag except the input one.
+    let db_tag =
+        ic_queries::ic6_tag_co_occurrence(&db, 1, "Databases").expect("IC6 should not error");
+    assert!(
+        db_tag.is_empty(),
+        "IC6: Databases is only on Alice's own posts 1 and 4, never a friend's; got {db_tag:?}"
+    );
+
     // A tag no post carries must yield nothing.
     let none = ic_queries::ic6_tag_co_occurrence(&db, 1, "ZZZ_nonexistent")
         .expect("IC6 unknown tag should not error");
     assert!(
         none.is_empty(),
         "IC6: unknown tag must return empty; got {none:?}"
+    );
+
+    // Liveness guard. Every IC6 expectation the mini fixture can express is
+    // empty: the only multi-tag post is 1 ({Databases, GraphTheory}), it belongs
+    // to Alice, and nobody `knows` Alice (person 1 is never a knows target), so
+    // post 1 is never anyone's friend post. That makes the assertions above
+    // satisfiable by an ic6 that always returns empty. IC4 walks the same
+    // friend→post→tag pipeline without the tag restriction, so its non-emptiness
+    // proves the empties are the restriction at work, not a dead query.
+    let ic4 = ic_queries::ic4_top_tags(&db, 1, "2012-01-01", 30).expect("IC4 should not error");
+    assert!(
+        !ic4.is_empty(),
+        "IC6 liveness: IC4 shares IC6's friend→post→tag pipeline and must be non-empty, \
+         otherwise IC6's empty results prove nothing; got {ic4:?}"
     );
 }
 
@@ -301,16 +337,60 @@ fn ic13_shortest_path_alice_to_jack() {
 }
 
 #[test]
-#[ignore = "blocked on #423: ic13 documents \"-1 if no path exists\" but returns 1 for \
-unreachable pairs. Un-ignore when #423 is fixed."]
 fn ic13_unreachable_returns_negative_one() {
     let (_dir, db) = db_with_mini_fixture();
-    // knows edges are directed and no path leads back to Alice.
+    // knows edges are directed and no path leads back to Alice. Person 10
+    // appears only as a target (9→10) and has no outgoing knows edge at all.
     let hops = ic_queries::ic13_shortest_path(&db, 10, 1).expect("IC13 should not error");
     assert_eq!(
         hops, -1,
         "IC13: 10→1 is unreachable, expected -1; got {hops}"
     );
+
+    // Person 2 does have outgoing knows edges (2→4, 2→5), but none of them lead
+    // back to 1 — 1 is never a knows target. This separates "source is a dead
+    // end" from "genuinely unreachable"; the pre-fix engine reported 1 hop here
+    // too, via 2 -[:likes]-> Post slot 0 colliding with Person slot 0.
+    let back = ic_queries::ic13_shortest_path(&db, 2, 1).expect("IC13 should not error");
+    assert_eq!(
+        back, -1,
+        "IC13: 2→1 is unreachable (1 is never a knows target); got {back}"
+    );
+
+    // A person absent from the fixture is unreachable in both directions.
+    let missing_dst = ic_queries::ic13_shortest_path(&db, 1, 9999).expect("IC13 should not error");
+    assert_eq!(
+        missing_dst, -1,
+        "IC13: person 9999 does not exist; got {missing_dst}"
+    );
+    let missing_src = ic_queries::ic13_shortest_path(&db, 9999, 1).expect("IC13 should not error");
+    assert_eq!(
+        missing_src, -1,
+        "IC13: person 9999 does not exist; got {missing_src}"
+    );
+}
+
+#[test]
+fn ic13_directed_and_self_paths() {
+    let (_dir, db) = db_with_mini_fixture();
+    // 1→2 is a stored knows edge, so exactly 1 hop forward...
+    let fwd = ic_queries::ic13_shortest_path(&db, 1, 2).expect("IC13 should not error");
+    assert_eq!(fwd, 1, "IC13: 1→2 is a direct knows edge; got {fwd}");
+    // ...and 0 hops to oneself.
+    let same = ic_queries::ic13_shortest_path(&db, 1, 1).expect("IC13 should not error");
+    assert_eq!(
+        same, 0,
+        "IC13: a person is 0 hops from themselves; got {same}"
+    );
+    // A person who does not exist is not 0 hops from themselves.
+    let ghost = ic_queries::ic13_shortest_path(&db, 9999, 9999).expect("IC13 should not error");
+    assert_eq!(
+        ghost, -1,
+        "IC13: person 9999 does not exist, so there is no path; got {ghost}"
+    );
+    // 1→6→7→8→9 is 4 hops (1→3→5→7→8→9 is 5, 1→2→4→6→7→8→9 is 6).
+    let iris = ic_queries::ic13_shortest_path(&db, 1, 9).expect("IC13 should not error");
+    assert_eq!(iris, 4, "IC13: shortest path 1→9 is 4 hops; got {iris}");
 }
 
 #[test]

--- a/crates/sparrowdb/tests/spa_111_ldbc_ic3_ic14.rs
+++ b/crates/sparrowdb/tests/spa_111_ldbc_ic3_ic14.rs
@@ -1,7 +1,10 @@
 //! Integration tests for LDBC SNB IC3-IC14 queries (SPA-111 phase 2).
 //!
 //! Uses the mini LDBC fixture data loaded via the sparrowdb-bench loader.
-//! Each test asserts non-empty results on the synthetic dataset.
+//!
+//! Most tests assert non-empty results on the synthetic dataset, but non-empty
+//! is not the goal — correctness is. IC6 asserts *empty*, because empty is the
+//! right answer there and asserting otherwise is what let #422 hide.
 
 use sparrowdb::GraphDb;
 use sparrowdb_bench::ic_queries;
@@ -136,19 +139,49 @@ fn ic5_forums_with_friends() {
 fn ic6_tag_co_occurrence() {
     let (_dir, db) = load_mini_db();
 
-    // Alice (1) knows Bob (2) and Carol (3).
-    // Bob created post 2 tagged with Rust.
-    // Carol created post 3 tagged with SocialNetworks.
-    // Exclude "Rust" — should find other tags on friend posts.
+    // IC6 asks which OTHER tags appear on the posts that carry the given tag and
+    // were created by the person's friends. It is not "every friend tag except
+    // this one" — that was #422, and this test used to assert it: it expected a
+    // non-empty result for "Rust" under the comment "should find other tags on
+    // friend posts", which is the bug written down as the expectation.
+    //
+    // Alice (1) knows Bob (2), Carol (3) and Frank (6).
+    // Bob created post 2, tagged {Rust}. Carol created post 3, tagged
+    // {SocialNetworks}. Frank created nothing.
+    //
+    // So post 2 is the only friend post carrying Rust, and it carries no other
+    // tag — nothing co-occurs. SocialNetworks is on post 3, which is not tagged
+    // Rust, so it must not appear.
     let results = ic_queries::ic6_tag_co_occurrence(&db, 1, "Rust").unwrap();
-
     assert!(
-        !results.is_empty(),
-        "IC6 should find co-occurring tags; got empty"
+        results.is_empty(),
+        "IC6: post 2 is the only friend post tagged Rust and carries no other tag; got {results:?}"
     );
-    for (name, _count) in &results {
-        assert_ne!(name, "Rust", "should not include the excluded tag");
-    }
+
+    // A tag no post carries must yield nothing. Before #422 this returned every
+    // friend tag, because the tag was only ever excluded from the output and
+    // never used to select posts.
+    let unknown = ic_queries::ic6_tag_co_occurrence(&db, 1, "ZZZ_nonexistent").unwrap();
+    assert!(
+        unknown.is_empty(),
+        "IC6: a tag absent from the graph must return empty; got {unknown:?}"
+    );
+
+    // Liveness guard. Every IC6 expectation this fixture can express is empty:
+    // the only multi-tag post is 1 ({Databases, GraphTheory}), it belongs to
+    // Alice, and nobody `knows` Alice (person 1 is never a knows target), so
+    // post 1 is never anyone's friend post. That makes both assertions above
+    // satisfiable by an ic6 that always returns empty. IC4 walks the same
+    // friend→post→tag pipeline without the tag restriction, so its non-emptiness
+    // proves the empties are the restriction at work, not a dead query.
+    // Tracked in #428 — a friend-owned multi-tag post would let IC6 be asserted
+    // positively and retire this guard.
+    let ic4 = ic_queries::ic4_top_tags(&db, 1, "2010-01-01", 365).unwrap();
+    assert!(
+        !ic4.is_empty(),
+        "IC6 liveness: IC4 shares IC6's friend→post→tag pipeline and must be non-empty, \
+         otherwise IC6's empty results prove nothing; got {ic4:?}"
+    );
 }
 
 // ── IC7 ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #422. Closes #423.

**Stacked on #424** (`fix/varlen-truncation-guard`, rebased onto head `2a6890c`) — that PR introduces the two `#[ignore]`d tests this one un-ignores. Retarget to `main` once #424 lands.

Related: **#427** (the engine bug behind #423, filed separately — not fixed here). **#428** (the fixture gap behind IC6's liveness guard, filed from this work).

## #422 — ic6 ignored its input tag filter

`ic6_tag_co_occurrence` never restricted to posts carrying the given tag. It collected every post created by the person's friends, counted every tag on them, and merely excluded the input tag from the output. `ic6(1, "Databases")` returned `[(Rust,1), (SocialNetworks,1)]` even though Databases sits only on Alice's own posts 1 and 4; `ic6(1, "ZZZ_nonexistent")` returned the same full set.

Fix: added the missing step — narrow the friends' posts to those actually carrying the tag, then count the other tags on exactly those posts.

**Issue #422's table is wrong on one row.** It marks `ic6(1, "Rust") → [(SocialNetworks,1)]` as correct. It is not. Post 2 is the only friend post tagged Rust and carries no other tag, so the correct LDBC answer is empty; SocialNetworks lives on post 3, which is not tagged Rust. Both "looks right" rows in #422 passed by coincidence — with one tag per friend post, "exclude the input tag" happens to coincide with the right answer.

## #423 — ic13 returned 1 instead of -1 — **root cause is in the engine**

Per the investigation instruction, I ran the raw Cypher before deciding where to fix:

```
MATCH (a:Person {ldbc_id: 10}), (b:Person {ldbc_id: 1}) RETURN shortestPath((a)-[:knows*]->(b))
  → Int64(1)      ← engine, wrong (no path exists)
MATCH (a:Person {ldbc_id: 2}),  (b:Person {ldbc_id: 1}) RETURN shortestPath((a)-[:knows*]->(b))
  → Int64(1)      ← engine, wrong (1 is never a knows target)
```

The engine is at fault, in two independent ways, both in `crates/sparrowdb-execution`:

1. **The relationship-type constraint is dropped.** `eval_shortest_path_expr` (`engine/expr.rs:526`) calls `bfs_shortest_path`, which calls `get_node_neighbors_by_slot(..., &[])` (`engine/path.rs:585`). The empty `rel_ids` slice means "no type filter", so the BFS for `[:knows*]` walks `isLocatedIn`, `likes`, `hasCreator` and every other edge type.
2. **Arrival is decided by slot, ignoring label.** `bfs_shortest_path` tests `nb_slot == dst_slot` (`engine/expr.rs:587`). Slot 0 of Place, Post, and Person are all `0`, so the slot-N node of *any* label terminates the BFS.

On the mini fixture the two combine exactly: person 10's only outgoing edge is `isLocatedIn` → Place id 1 → Place **slot 0**, and target person 1 is Person **slot 0**. Hence the reported 1-hop path between two unconnected persons. Same mechanism for `2→1`: person 2 `likes` post 1 → Post slot 0.

Engine files are outside this PR's scope, so **the engine bug is not fixed here** — it is filed as **#427**, which also notes that `visited.insert(nb_slot)` has the same slot/label conflation and can prune legitimate paths. What is fixed is the bench layer: IC13 now does its own level-synchronous BFS over `knows`, one Cypher query per hop, keyed on `ldbc_id` rather than storage slots. This follows the workaround pattern the module already documents for other engine limitations.

## Also — ic4/ic6 ordering determinism

CodeRabbit flagged on #424 that `ic4_top_tags` ordered by `cnt DESC` only, so tied counts could come back in any order and an exact-vector assertion was flaky. Added `tag.name ASC` as a deterministic tie-break in both IC4 and IC6.

## Tests

`ic6_co_occurring_tags` and `ic13_unreachable_returns_negative_one` un-ignored. Every expectation derived by hand from the fixture CSVs, none captured from program output.

Both were verified to **fail** against the unfixed `ic_queries.rs` with exactly the symptoms in the issues (`got 1`; `got [("SocialNetworks", 1)]`).

Assertions added beyond the un-ignore:

- **IC6**: `SocialNetworks` (symmetric single-tag case) and `Databases` (#422's headline case).
- **IC6 liveness guard.** Every IC6 expectation the mini fixture can express is empty: the only multi-tag post is 1 (`{Databases, GraphTheory}`), it belongs to Alice, and nobody `knows` Alice — person 1 is never a `knows` target — so post 1 is never anyone's friend post. That makes all four assertions satisfiable by an `ic6` that unconditionally returns empty. The test therefore also asserts IC4 (same friend→post→tag pipeline, minus the tag restriction) is non-empty, so the empties are provably the restriction at work rather than a dead query. Full derivation and a proposed fixture change are in **#428**.
- **IC13**: `2→1` unreachable (source *has* outgoing edges but 1 is never a `knows` target — separates "dead end" from "genuinely unreachable", and this is the case the pre-fix engine also got wrong), and absent persons in both directions.
- **New `ic13_directed_and_self_paths`**: `1→2 = 1`, `1→1 = 0`, `9999→9999 = -1`, `1→9 = 4` (`1→6→7→8→9`, vs 5 for `1→3→5→7→8→9` and 6 for `1→2→4→6→7→8→9`).

## Sibling test corrected

`crates/sparrowdb/tests/spa_111_ldbc_ic3_ic14.rs::ic6_tag_co_occurrence` asserted `ic6(1, "Rust")` is **non-empty**, under the comment *"Exclude 'Rust' — should find other tags on friend posts"* — a second copy of the #422 bug written down as the expectation. Corrected to assert empty, plus the unknown-tag case and the same liveness guard. Taken into this PR at the coordinator's request so the corrected assertion and the fix that makes it pass land together.

The file's module doc claimed *"Each test asserts non-empty results"*; updated, since non-empty was never the goal and treating it as one is what let #422 hide.

## Verification

Run with an isolated `CARGO_TARGET_DIR` — worktrees in this repo share one by default, which can silently produce a test binary built from another worktree's source.

```
CARGO_TARGET_DIR=/Volumes/Dev/target-425 cargo test -p sparrowdb-bench -p sparrowdb --no-fail-fast
CARGO_TARGET_DIR=/Volumes/Dev/target-425 cargo fmt --all -- --check
CARGO_TARGET_DIR=/Volumes/Dev/target-425 cargo clippy -p sparrowdb-bench --all-targets -- -D warnings
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag-count query results with deterministic alphabetical ordering for ties.
  * Corrected tag co-occurrence results for friend posts and unknown tags.
  * Improved shortest-path queries with directed traversal, bounded search, and proper handling of missing or unreachable endpoints.

* **Tests**
  * Re-enabled integration coverage for previously skipped queries.
  * Added validation for empty results, self-paths, missing people, unreachable paths, and pipeline behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->