### PR TITLE
test(node): real regression guard for #406 anonymous relationship patterns

### DIFF
--- a/npm/sparrowdb/test/integration.test.js
+++ b/npm/sparrowdb/test/integration.test.js
@@ -495,3 +495,125 @@ describe('DISTINCT aggregation — SPA-172 regression', () => {
     assert.equal(r.rows.length, 2, 'should return 2 distinct names (red, blue)')
   })
 })
+
+describe('anonymous relationship patterns — issue #406 regression', () => {
+  // Issue #406: `MATCH ()-[r]->() RETURN count(r)` threw "not found"
+  // (napi code GenericFailure) through the Node binding on the KMS production
+  // database, while node-only patterns kept working.
+  //
+  // Root cause (fixed in #408, crates/sparrowdb-storage/src/node_store.rs):
+  // `NodeStore::read_col_slot` returned `Err(Error::NotFound)` when the
+  // requested slot fell beyond the end of a column file.  A one-hop traversal
+  // reads source-node columns for every slot up to the label HWM, so any
+  // database whose HWM exceeds the length of one of its column files failed the
+  // whole query.  The correct sentinel for an absent non-nullable read is `0`,
+  // matching the already-existing behaviour for a completely missing file.
+  //
+  // Seed below is fixed and small so every expected value is derived by hand,
+  // never captured from program output:
+  //   nodes  : a, b, c, d                       → 4 :Knowledge nodes
+  //   edges  : (a)-[:RELATED_TO]->(b)
+  //            (b)-[:ABOUT]->(c)                → 2 directed edges
+  //   so     : count(n)          = 4
+  //            directed count(r) = 2
+  //            undirected        = 4  (each edge is walked from both endpoints)
+
+  const EXPECTED_NODES = 4
+  const EXPECTED_DIRECTED_EDGES = 2
+  const EXPECTED_UNDIRECTED_EDGES = EXPECTED_DIRECTED_EDGES * 2
+
+  let db
+  let dir
+  let dbPath
+
+  before(() => {
+    dir = makeTempDir()
+    dbPath = path.join(dir, 'graph.db')
+
+    // 1. Seed the graph and flush to disk.
+    const seed = SparrowDB.open(dbPath)
+    for (const name of ['a', 'b', 'c', 'd']) {
+      seed.execute(`CREATE (n:Knowledge {name: '${name}'})`)
+    }
+    seed.execute(
+      "MATCH (a:Knowledge {name: 'a'}), (b:Knowledge {name: 'b'}) CREATE (a)-[:RELATED_TO]->(b)"
+    )
+    seed.execute(
+      "MATCH (b:Knowledge {name: 'b'}), (c:Knowledge {name: 'c'}) CREATE (b)-[:ABOUT]->(c)"
+    )
+    seed.checkpoint()
+
+    // 2. Recreate the on-disk shape that triggered #406: a column file that
+    //    EXISTS but is shorter than the label's high-water mark.  On the KMS
+    //    production DB this was col_0.bin with 1064 slots against an HWM of
+    //    1065 — legacy data written before columns were zero-padded on CREATE.
+    //    A fresh DB never produces that state on its own, which is why the
+    //    original synthetic Rust regression test did not actually reproduce the
+    //    bug; planting the short column here makes this a real guard.
+    const nodesDir = path.join(dbPath, 'nodes')
+    const labelDirs = fs
+      .readdirSync(nodesDir, { withFileTypes: true })
+      .filter(e => e.isDirectory())
+      .map(e => path.join(nodesDir, e.name))
+    assert.ok(labelDirs.length > 0, 'expected at least one label directory under nodes/')
+
+    let planted = 0
+    for (const labelDir of labelDirs) {
+      const col0 = path.join(labelDir, 'col_0.bin')
+      if (!fs.existsSync(col0)) {
+        // 8 bytes = 1 slot, while the label HWM is 4 → slots 1..3 are past EOF.
+        fs.writeFileSync(col0, Buffer.alloc(8))
+        planted++
+      }
+    }
+    assert.ok(planted > 0, 'expected to plant at least one short col_0.bin fixture')
+
+    // 3. Reopen so the engine reads the planted on-disk state.
+    db = SparrowDB.open(dbPath)
+  })
+
+  after(() => {
+    removeDir(dir)
+  })
+
+  it('node-only count still works (control)', () => {
+    const r = db.execute('MATCH (n:Knowledge) RETURN count(n) AS cnt')
+    assert.equal(r.rows.length, 1)
+    assert.equal(r.rows[0]['cnt'], EXPECTED_NODES)
+  })
+
+  it('MATCH ()-[r]->() RETURN count(r) does not throw "not found"', () => {
+    // The exact query from issue #406.
+    const r = db.execute('MATCH ()-[r]->() RETURN count(r) AS cnt')
+    assert.equal(r.rows.length, 1, 'must return one aggregated row')
+    assert.equal(r.rows[0]['cnt'], EXPECTED_DIRECTED_EDGES)
+  })
+
+  it('MATCH ()-[r]-() RETURN count(r) (undirected) does not throw', () => {
+    const r = db.execute('MATCH ()-[r]-() RETURN count(r) AS cnt')
+    assert.equal(r.rows.length, 1)
+    assert.equal(r.rows[0]['cnt'], EXPECTED_UNDIRECTED_EDGES)
+  })
+
+  it('MATCH (a)-[r]->(b) with named endpoints does not throw', () => {
+    const r = db.execute('MATCH (a)-[r]->(b) RETURN count(r) AS cnt')
+    assert.equal(r.rows.length, 1)
+    assert.equal(r.rows[0]['cnt'], EXPECTED_DIRECTED_EDGES)
+  })
+
+  it('typed anonymous pattern counts only that rel type', () => {
+    // Exactly one (a)-[:RELATED_TO]->(b) edge was seeded.
+    const r = db.execute('MATCH ()-[r:RELATED_TO]->() RETURN count(r) AS cnt')
+    assert.equal(r.rows.length, 1)
+    assert.equal(r.rows[0]['cnt'], 1)
+  })
+
+  it('MATCH ()-[r]->() RETURN r enumerates every edge', () => {
+    // KMSmcp's _getRelationships traversal — must yield one row per directed edge.
+    const r = db.execute('MATCH ()-[r]->() RETURN r')
+    assert.equal(r.rows.length, EXPECTED_DIRECTED_EDGES)
+    for (const row of r.rows) {
+      assert.equal(row['r'].$type, 'edge', 'each row must carry an edge handle')
+    }
+  })
+})

--- a/npm/sparrowdb/test/integration.test.js
+++ b/npm/sparrowdb/test/integration.test.js
@@ -557,14 +557,17 @@ describe('anonymous relationship patterns — issue #406 regression', () => {
       .map(e => path.join(nodesDir, e.name))
     assert.ok(labelDirs.length > 0, 'expected at least one label directory under nodes/')
 
+    //    Plant unconditionally. A fresh DB names columns by FNV hash of the
+    //    property (col_2369371622, …), so col_0.bin does not normally exist and
+    //    a conditional write happens to fire — but making the fixture depend on
+    //    that is fragile: if col_0.bin ever did exist, a conditional write would
+    //    skip it and this guard would silently stop guarding.
     let planted = 0
     for (const labelDir of labelDirs) {
       const col0 = path.join(labelDir, 'col_0.bin')
-      if (!fs.existsSync(col0)) {
-        // 8 bytes = 1 slot, while the label HWM is 4 → slots 1..3 are past EOF.
-        fs.writeFileSync(col0, Buffer.alloc(8))
-        planted++
-      }
+      // 8 bytes = 1 slot, while the label HWM is 4 → slots 1..3 are past EOF.
+      fs.writeFileSync(col0, Buffer.alloc(8))
+      planted++
     }
     assert.ok(planted > 0, 'expected to plant at least one short col_0.bin fixture')
 


### PR DESCRIPTION
Closes #406.

## TL;DR

The reported bug is **not a binding bug**, and it is **already fixed on `main`** by #408 (SPA-406). What was missing is coverage: the Rust regression test that shipped with that fix **passes against the pre-fix code**, so it never guarded the regression. This PR adds a Node-layer test that actually fails before the fix and passes after.

No production code is changed — test-only.

## Root cause

`MATCH ()-[r]->() RETURN count(r)` runs a one-hop traversal, which reads source-node columns for **every slot up to the label high-water mark**. `NodeStore::read_col_slot` returned `Err(Error::NotFound)` when the requested slot fell past the end of a column file, and `sparrowdb_common::Error::NotFound` renders as the string `not found` — which the binding surfaces verbatim as a `GenericFailure` napi error. That is the exact message and error code in the issue.

The failing state is a column file that **exists but is shorter than the label HWM**. On the KMS production DB that was `nodes/0/col_0.bin` at 1064 slots against an HWM of 1065 — legacy data written before columns were zero-padded on CREATE. Node-only queries (`MATCH (n:Knowledge) RETURN count(n)`) never read that column and kept working, which is exactly the asymmetry reported.

#408 changed `read_col_slot` to return `Ok(0)` for an out-of-range slot, matching the sentinel already used for a completely missing column file and the `Ok(None)` behaviour of its sibling `read_col_slot_nullable`.

## Layer isolation (binding vs core)

`SparrowDB::execute` in `crates/sparrowdb-node/src/lib.rs` does nothing but forward to `GraphDb::execute` and reshape rows. Running the same Cypher through the Rust API on a copy of the reporter's DB at `49246b3^` failed identically:

```
OK   MATCH (n:Knowledge) RETURN count(n)      -> Some([Int64(2583)])
ERR  MATCH ()-[r]->() RETURN count(r) AS cnt  -> not found
ERR  MATCH (a)-[r]->(b) RETURN count(r) AS cnt -> not found
```

A `panic!` planted in the pre-fix `read_col_slot` gave the call chain: `GraphDb::execute` → `execute_match` → `execute_one_hop` (`hop.rs:225`) → `get_node_raw` → `read_col_slot(label=0, col=0, slot=1064, len=8512)`. Storage layer, not the binding.

## Why a new test was needed

`crates/sparrowdb/tests/regression_406.rs` was copied onto the pre-fix tree and run there — all 3 tests **pass**, because a fresh DB zero-pads columns on CREATE (SPA-187) and so can never reach the failing state on its own. It is a false guard: it would not catch a reintroduction of this bug.

The new test plants the legacy on-disk shape explicitly (an 8-byte `col_0.bin` against an HWM of 4), then reopens the DB and runs the reported queries through the binding.

## Verified

| Command | Result |
|---|---|
| `cargo build --release -p sparrowdb-node` | pass |
| `node --test npm/sparrowdb/test/integration.test.js` | 40/40 pass (6 new) |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p sparrowdb-node --all-targets -- -D warnings` | clean |
| New tests vs binding built at `49246b3^` | **5 of 6 fail with `not found`** (the node-only control passes) — the guard is real |
| Reporter's DB copy, pre-fix binding | reproduced `not found` / `GenericFailure` verbatim |
| Reporter's DB copy, `main` binding | `count(r)` = 2661, no error |

Expected values in the test are derived by hand from the fixed 4-node / 2-edge seed (4 nodes; 2 directed edges; 4 undirected traversals; 1 `RELATED_TO`), never captured from program output.

## Notes for the reporter

The fix has been on `main` since #408 (2026-05-06) — a rebuilt binding from current `main` resolves this. KMSmcp can revert the PR #59 try/catch workaround and use the real relationship count again.

## Not addressed here (out of scope, separate issues warranted)

- `crates/sparrowdb/tests/regression_406.rs` is a false guard and should either be strengthened with the same short-column fixture or deleted. It lives outside this PR's file scope.
- Separately observed while probing: `MATCH ()-[r]->() RETURN r LIMIT 3` returned more than 3 rows on both pre-fix and current `main`. Unrelated to #406, not investigated, filed here only as a pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for anonymous relationship patterns.
  * Expanded validation of directed, undirected, named, and typed relationships.
  * Added checks for relationship enumeration and accurate node and relationship counts.
  * Added database reopen scenarios to verify data remains accessible after reopening.
  * Added fixture-based regression coverage for improved graph relationship handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->