### PR TITLE
fix(engine): shortestPath, varlen-plus-hop, and neighbour-label identity across the engine (closes #421, #427, #431)

### DIFF
--- a/crates/sparrowdb-execution/src/engine/expr.rs
+++ b/crates/sparrowdb-execution/src/engine/expr.rs
@@ -851,42 +851,63 @@ impl Engine {
         // SPA-283: build HashMap index for O(1) per-node delta lookups.
         let delta_idx = build_delta_index(&delta_all);
 
-        // Label hints for CSR-only destinations, mirroring `execute_variable_length`:
-        // the delta log carries full NodeIds, so every (slot, label) pair it
-        // mentions is authoritative.
-        let mut node_label: std::collections::HashSet<(u64, u32)> =
-            std::collections::HashSet::new();
-        for r in &delta_all {
-            let (src_l, src_s) = node_id_parts(r.src.0);
-            node_label.insert((src_s, src_l));
-            let (dst_l, dst_s) = node_id_parts(r.dst.0);
-            node_label.insert((dst_s, dst_l));
-        }
-        let mut all_label_ids: Vec<u32> = node_label.iter().map(|&(_, l)| l).collect();
-        all_label_ids.sort_unstable();
-        all_label_ids.dedup();
+        // #427: derive CSR neighbour labels from the catalog rather than guessing.
+        //
+        // A relationship table is registered as `(rel_table_id, src_label_id,
+        // dst_label_id, rel_type)` and its CSR holds only that table's edges.  So
+        // for a CSR hit we know the destination's label exactly — it is the
+        // table's `dst_label_id` — and we know the table only applies to sources
+        // of its `src_label_id`.  Both matter: the shared
+        // `get_node_neighbors_labeled` helper instead falls back to the *source's*
+        // label whenever the delta log carries no hint, which is always true once
+        // a graph has been checkpointed, and it probes every CSR with the raw slot
+        // regardless of the source's label.
+        let rel_tables: Vec<(u32, u32, u32)> = self
+            .snapshot
+            .catalog
+            .list_rel_tables_with_ids()
+            .into_iter()
+            .filter(|(id, _, _, _)| rel_ids.is_empty() || rel_ids.contains(&(*id as u32)))
+            .map(|(id, s_lid, d_lid, _)| (id as u32, s_lid as u32, d_lid as u32))
+            .collect();
 
         // Frontier carries (slot, label_id) so each hop uses the correct label
         // when probing the delta index.
         let mut visited: std::collections::HashSet<(u64, u32)> = std::collections::HashSet::new();
         visited.insert((src_slot, src_label_id));
         let mut frontier: Vec<(u64, u32)> = vec![(src_slot, src_label_id)];
-        let mut neighbors_buf: std::collections::HashSet<(u64, u32)> =
-            std::collections::HashSet::new();
+        let mut neighbors: std::collections::HashSet<(u64, u32)> = std::collections::HashSet::new();
 
         for depth in 1..=max_hops {
             let mut next_frontier: Vec<(u64, u32)> = Vec::new();
             for &(node_slot, node_label_id) in &frontier {
-                self.get_node_neighbors_labeled(
-                    node_slot,
-                    node_label_id,
-                    &delta_idx,
-                    &node_label,
-                    &all_label_ids,
-                    &mut neighbors_buf,
-                    rel_ids,
-                );
-                for &(nb_slot, nb_label) in neighbors_buf.iter() {
+                neighbors.clear();
+
+                // Checkpointed edges: one CSR per relationship table.
+                for &(rel_id, s_lid, d_lid) in &rel_tables {
+                    if s_lid != node_label_id {
+                        continue;
+                    }
+                    if let Some(csr) = self.snapshot.csrs.get(&rel_id) {
+                        for &nb_slot in csr.neighbors(node_slot) {
+                            neighbors.insert((nb_slot, d_lid));
+                        }
+                    }
+                }
+
+                // Uncheckpointed edges: the delta log carries full NodeIds, so
+                // the destination label is read off directly.
+                if let Some(recs) = delta_idx.get(&(node_label_id, node_slot)) {
+                    for r in recs {
+                        if !rel_ids.is_empty() && !rel_ids.contains(&r.rel_id.0) {
+                            continue;
+                        }
+                        let (nb_label, nb_slot) = node_id_parts(r.dst.0);
+                        neighbors.insert((nb_slot, nb_label));
+                    }
+                }
+
+                for &(nb_slot, nb_label) in neighbors.iter() {
                     if (nb_slot, nb_label) == (dst_slot, dst_label_id) {
                         return Some(depth);
                     }

--- a/crates/sparrowdb-execution/src/engine/expr.rs
+++ b/crates/sparrowdb-execution/src/engine/expr.rs
@@ -656,7 +656,13 @@ impl Engine {
         let csr_nb: Vec<u64> = match rel_lookup {
             RelTableLookup::Found(rtid) => self.csr_neighbors(rtid, src_slot),
             RelTableLookup::NotFound => return false,
-            RelTableLookup::All => self.csr_neighbors_all(src_slot),
+            // Untyped edge: every table whose source label is this node's, and
+            // whose destination label is the one the pattern asks for.  A bare
+            // slot would otherwise let a neighbour of any label answer for one
+            // of `dst_label_id_opt`.
+            RelTableLookup::All => {
+                self.csr_neighbor_slots_to_label(src_slot, src_label_id, dst_label_id_opt, &[])
+            }
         };
         let delta_nb: Vec<u64> = self
             .read_delta_all()
@@ -851,28 +857,8 @@ impl Engine {
         // SPA-283: build HashMap index for O(1) per-node delta lookups.
         let delta_idx = build_delta_index(&delta_all);
 
-        // #427: derive CSR neighbour labels from the catalog rather than guessing.
-        //
-        // A relationship table is registered as `(rel_table_id, src_label_id,
-        // dst_label_id, rel_type)` and its CSR holds only that table's edges.  So
-        // for a CSR hit we know the destination's label exactly — it is the
-        // table's `dst_label_id` — and we know the table only applies to sources
-        // of its `src_label_id`.  Both matter: the shared
-        // `get_node_neighbors_labeled` helper instead falls back to the *source's*
-        // label whenever the delta log carries no hint, which is always true once
-        // a graph has been checkpointed, and it probes every CSR with the raw slot
-        // regardless of the source's label.
-        let rel_tables: Vec<(u32, u32, u32)> = self
-            .snapshot
-            .catalog
-            .list_rel_tables_with_ids()
-            .into_iter()
-            .filter(|(id, _, _, _)| rel_ids.is_empty() || rel_ids.contains(&(*id as u32)))
-            .map(|(id, s_lid, d_lid, _)| (id as u32, s_lid as u32, d_lid as u32))
-            .collect();
-
         // Frontier carries (slot, label_id) so each hop uses the correct label
-        // when probing the delta index.
+        // when looking up neighbours.
         let mut visited: std::collections::HashSet<(u64, u32)> = std::collections::HashSet::new();
         visited.insert((src_slot, src_label_id));
         let mut frontier: Vec<(u64, u32)> = vec![(src_slot, src_label_id)];
@@ -881,31 +867,18 @@ impl Engine {
         for depth in 1..=max_hops {
             let mut next_frontier: Vec<(u64, u32)> = Vec::new();
             for &(node_slot, node_label_id) in &frontier {
-                neighbors.clear();
-
-                // Checkpointed edges: one CSR per relationship table.
-                for &(rel_id, s_lid, d_lid) in &rel_tables {
-                    if s_lid != node_label_id {
-                        continue;
-                    }
-                    if let Some(csr) = self.snapshot.csrs.get(&rel_id) {
-                        for &nb_slot in csr.neighbors(node_slot) {
-                            neighbors.insert((nb_slot, d_lid));
-                        }
-                    }
-                }
-
-                // Uncheckpointed edges: the delta log carries full NodeIds, so
-                // the destination label is read off directly.
-                if let Some(recs) = delta_idx.get(&(node_label_id, node_slot)) {
-                    for r in recs {
-                        if !rel_ids.is_empty() && !rel_ids.contains(&r.rel_id.0) {
-                            continue;
-                        }
-                        let (nb_label, nb_slot) = node_id_parts(r.dst.0);
-                        neighbors.insert((nb_slot, nb_label));
-                    }
-                }
+                // #427/#431: both edge sources report the neighbour's label
+                // rather than leaving it to be guessed — the catalog's
+                // `dst_label_id` for checkpointed edges, the stored `NodeId` for
+                // delta edges.  This loop used to inline that logic; it now
+                // shares the one implementation with variable-length traversal.
+                self.get_node_neighbors_labeled(
+                    node_slot,
+                    node_label_id,
+                    &delta_idx,
+                    &mut neighbors,
+                    rel_ids,
+                );
 
                 for &(nb_slot, nb_label) in neighbors.iter() {
                     if (nb_slot, nb_label) == (dst_slot, dst_label_id) {

--- a/crates/sparrowdb-execution/src/engine/expr.rs
+++ b/crates/sparrowdb-execution/src/engine/expr.rs
@@ -758,20 +758,39 @@ impl Engine {
                 }
             };
 
-        let dst_slot = if let Some(nid) = self.resolve_node_id_from_var(&sp.dst_var, vals) {
-            nid.0 & 0xFFFF_FFFF
-        } else {
-            let dst_label_id = match self.snapshot.catalog.get_label(&sp.dst_label) {
-                Ok(Some(id)) => id as u32,
-                _ => return Value::Null,
+        // #427: the destination's label is part of its identity — a `NodeId` is
+        // `(label_id << 32) | slot`, so slot 0 exists once per label. Carrying
+        // only the slot let a `City` stand in for a `Person`.
+        let (dst_label_id, dst_slot) =
+            if let Some(nid) = self.resolve_node_id_from_var(&sp.dst_var, vals) {
+                (((nid.0 >> 32) as u32), nid.0 & 0xFFFF_FFFF)
+            } else {
+                let dst_label_id = match self.snapshot.catalog.get_label(&sp.dst_label) {
+                    Ok(Some(id)) => id as u32,
+                    _ => return Value::Null,
+                };
+                match self.find_node_by_props(dst_label_id, &sp.dst_props) {
+                    Some(slot) => (dst_label_id, slot),
+                    None => return Value::Null,
+                }
             };
-            match self.find_node_by_props(dst_label_id, &sp.dst_props) {
-                Some(slot) => slot,
-                None => return Value::Null,
-            }
-        };
 
-        match self.bfs_shortest_path(src_slot, src_label_id, dst_slot, 10) {
+        // #427: honour the pattern's relationship type. An empty `rel_ids` means
+        // "no type constraint" to the neighbour lookups, so a named type that is
+        // absent from the catalog must short-circuit rather than fall through to
+        // an unfiltered traversal of every edge type in the graph.
+        let rel_ids = self.resolve_rel_ids_for_type(&sp.rel_type);
+        if !sp.rel_type.is_empty() && rel_ids.is_empty() {
+            // No relationship table of that type exists, so no edge of that type
+            // can exist. The only reachable node is the source itself.
+            return if (src_label_id, src_slot) == (dst_label_id, dst_slot) {
+                Value::Int64(0)
+            } else {
+                Value::Null
+            };
+        }
+
+        match self.bfs_shortest_path(src_slot, src_label_id, dst_slot, dst_label_id, &rel_ids, 10) {
             Some(hops) => Value::Int64(hops as i64),
             None => Value::Null,
         }
@@ -800,53 +819,78 @@ impl Engine {
         None
     }
 
-    /// BFS from `src_slot` to `dst_slot`, returning the hop count or None.
+    /// BFS from `(src_slot, src_label_id)` to `(dst_slot, dst_label_id)`,
+    /// returning the hop count or `None` when no path exists.
     ///
-    /// Each frontier node carries its own `label_id` so that delta-log edge
-    /// lookups use the correct `(label_id, slot)` key at every hop.  Without
-    /// this, BFS through heterogeneous graphs would use the source label for
-    /// all intermediate nodes, missing WAL edges on label-boundary crossings.
+    /// Every node is identified by the **pair** `(slot, label_id)`, never by the
+    /// slot alone.  A `NodeId` is `(label_id << 32) | slot`, so slots are only
+    /// unique within a label: `Person` slot 0, `City` slot 0 and `Post` slot 0
+    /// are three different nodes.  Issue #427 was caused by comparing bare slots
+    /// in the zero-hop shortcut, in the destination test and in `visited`, which
+    /// both invented paths that did not exist and pruned real ones.
+    ///
+    /// `rel_ids` restricts the traversal to those relationship-table IDs; an
+    /// empty slice means "any type".  Callers that parsed an explicit type must
+    /// resolve it (see [`Engine::resolve_rel_ids_for_type`]) and pass the result
+    /// — issue #427 also covered the BFS passing `&[]` unconditionally, which
+    /// made `[:KNOWS*]` walk every edge type in the graph.
     pub(crate) fn bfs_shortest_path(
         &self,
         src_slot: u64,
         src_label_id: u32,
         dst_slot: u64,
+        dst_label_id: u32,
+        rel_ids: &[u32],
         max_hops: u32,
     ) -> Option<u32> {
-        if src_slot == dst_slot {
+        if (src_slot, src_label_id) == (dst_slot, dst_label_id) {
             return Some(0);
         }
         // Hoist delta read out of the BFS loop to avoid repeated I/O.
         let delta_all = self.read_delta_all();
         // SPA-283: build HashMap index for O(1) per-node delta lookups.
         let delta_idx = build_delta_index(&delta_all);
+
+        // Label hints for CSR-only destinations, mirroring `execute_variable_length`:
+        // the delta log carries full NodeIds, so every (slot, label) pair it
+        // mentions is authoritative.
+        let mut node_label: std::collections::HashSet<(u64, u32)> =
+            std::collections::HashSet::new();
+        for r in &delta_all {
+            let (src_l, src_s) = node_id_parts(r.src.0);
+            node_label.insert((src_s, src_l));
+            let (dst_l, dst_s) = node_id_parts(r.dst.0);
+            node_label.insert((dst_s, dst_l));
+        }
+        let mut all_label_ids: Vec<u32> = node_label.iter().map(|&(_, l)| l).collect();
+        all_label_ids.sort_unstable();
+        all_label_ids.dedup();
+
         // Frontier carries (slot, label_id) so each hop uses the correct label
         // when probing the delta index.
-        let mut visited: std::collections::HashSet<u64> = std::collections::HashSet::new();
-        visited.insert(src_slot);
+        let mut visited: std::collections::HashSet<(u64, u32)> = std::collections::HashSet::new();
+        visited.insert((src_slot, src_label_id));
         let mut frontier: Vec<(u64, u32)> = vec![(src_slot, src_label_id)];
+        let mut neighbors_buf: std::collections::HashSet<(u64, u32)> =
+            std::collections::HashSet::new();
 
         for depth in 1..=max_hops {
             let mut next_frontier: Vec<(u64, u32)> = Vec::new();
             for &(node_slot, node_label_id) in &frontier {
-                let neighbors =
-                    self.get_node_neighbors_by_slot(node_slot, node_label_id, &delta_idx, &[]);
-                for nb_slot in neighbors {
-                    if nb_slot == dst_slot {
+                self.get_node_neighbors_labeled(
+                    node_slot,
+                    node_label_id,
+                    &delta_idx,
+                    &node_label,
+                    &all_label_ids,
+                    &mut neighbors_buf,
+                    rel_ids,
+                );
+                for &(nb_slot, nb_label) in neighbors_buf.iter() {
+                    if (nb_slot, nb_label) == (dst_slot, dst_label_id) {
                         return Some(depth);
                     }
-                    if visited.insert(nb_slot) {
-                        // Recover the neighbor's label from the delta index; fall
-                        // back to node_label_id for CSR-only nodes in homogeneous
-                        // graphs (the same conservative default used elsewhere).
-                        let nb_label = delta_neighbors_labeled_from_index(
-                            &delta_idx,
-                            node_label_id,
-                            node_slot,
-                        )
-                        .find(|&(s, _)| s == nb_slot)
-                        .map(|(_, l)| l)
-                        .unwrap_or(node_label_id);
+                    if visited.insert((nb_slot, nb_label)) {
                         next_frontier.push((nb_slot, nb_label));
                     }
                 }

--- a/crates/sparrowdb-execution/src/engine/hop.rs
+++ b/crates/sparrowdb-execution/src/engine/hop.rs
@@ -1898,21 +1898,18 @@ impl Engine {
             }
         }
 
-        // Delta index + label registry used by the variable-length expansion.
-        // Built once (not per source node) and only when a varlen hop exists.
-        let (delta_idx, node_label, all_label_ids) = if has_varlen {
-            let idx = build_delta_index(&delta_all);
-            let mut labels: HashSet<(u64, u32)> = HashSet::new();
-            for r in &delta_all {
-                labels.insert((r.src.0 & 0xFFFF_FFFF, (r.src.0 >> 32) as u32));
-                labels.insert((r.dst.0 & 0xFFFF_FFFF, (r.dst.0 >> 32) as u32));
-            }
-            let mut ids: Vec<u32> = labels.iter().map(|&(_, l)| l).collect();
-            ids.sort_unstable();
-            ids.dedup();
-            (idx, labels, ids)
+        // Delta index used by the variable-length expansion. Built once (not
+        // per source node) and only when a varlen hop exists.
+        //
+        // #431: neighbour labels for the varlen expansion are no longer read
+        // from a registry built here — `execute_variable_hops` resolves each
+        // neighbour's label straight from the catalog/CSR or the delta
+        // record's own NodeId (`get_node_neighbors_labeled`), so there is
+        // nothing left for this function to precompute or hand it.
+        let delta_idx = if has_varlen {
+            build_delta_index(&delta_all)
         } else {
-            (DeltaIndex::new(), HashSet::new(), Vec::new())
+            DeltaIndex::new()
         };
         // Reusable neighbor buffer for the variable-length traversal.
         let mut neighbors_buf: HashSet<(u64, u32)> = HashSet::new();
@@ -1947,23 +1944,36 @@ impl Engine {
                 }
             }
 
-            // `frontier` holds (slot, accumulated_vals) pairs for the current
-            // boundary of the traversal.  Each entry represents one in-progress
-            // path; cloning ensures bindings are isolated across branches.
-            let mut frontier: Vec<(u64, HashMap<String, Value>)> = vec![(src_slot, row_vals)];
+            // `frontier` holds (slot, label_id, accumulated_vals) triples for the
+            // current boundary of the traversal.  Each entry represents one
+            // in-progress path; cloning ensures bindings are isolated across
+            // branches.
+            //
+            // #429: the label is carried, not re-derived.  It used to be taken
+            // from the *pattern* (`label_ids_per_node[hop_idx]`, falling back to
+            // the source's label when the position was unlabeled), so an
+            // unlabeled intermediate node was addressed as label 0 and every hop
+            // probed CSRs with a bare slot.  With `isLocatedIn` registered for
+            // both (Person)->(Place) and (Organisation)->(Place), that let
+            // Person slot 2 inherit Organisation slot 2's edges.
+            let mut frontier: Vec<(u64, u32, HashMap<String, Value>)> =
+                vec![(src_slot, src_label_id, row_vals)];
 
             for hop_idx in 0..n_rels {
                 let next_node_pat = &pat.nodes[hop_idx + 1];
                 let next_label_id_opt = label_ids_per_node[hop_idx + 1];
                 let next_col_ids = &col_ids_per_node[hop_idx + 1];
-                let cur_label_id = label_ids_per_node[hop_idx].unwrap_or(src_label_id);
 
-                let mut next_frontier: Vec<(u64, HashMap<String, Value>)> = Vec::new();
+                let mut next_frontier: Vec<(u64, u32, HashMap<String, Value>)> = Vec::new();
 
-                for (cur_slot, cur_vals) in frontier {
+                for (cur_slot, cur_label_id, cur_vals) in frontier {
                     let hop_rel_ids = &rel_ids_per_hop[hop_idx];
 
-                    // `(slot, resolved_label_id)` candidates for this hop.
+                    // `(slot, resolved_label_id)` candidates for this hop, each
+                    // carrying the neighbour's *actual* label — read from the
+                    // catalog/CSR or the stored NodeId, never guessed from the
+                    // pattern or assumed from the source's label. A bare slot
+                    // is not a safe node identity: see #427, #429, #431.
                     let all_nb: Vec<(u64, u32)> = match varlen_per_hop[hop_idx] {
                         // ── #421: variable-length hop ────────────────────────
                         Some((min_hops, max_hops)) => {
@@ -1978,8 +1988,6 @@ impl Engine {
                                 min_hops,
                                 max_hops,
                                 &delta_idx,
-                                &node_label,
-                                &all_label_ids,
                                 &mut neighbors_buf,
                                 use_reachability,
                                 usize::MAX,
@@ -2000,35 +2008,48 @@ impl Engine {
                         }
                         // ── fixed single hop ─────────────────────────────────
                         None => {
-                            // Gather neighbors from CSR + delta for this hop.
-                            // SPA-284: use filtered CSR lookup when rel type is specified.
-                            let csr_nb: Vec<u64> =
-                                self.csr_neighbors_filtered(cur_slot, hop_rel_ids);
-                            let delta_nb: Vec<u64> = delta_all
-                                .iter()
-                                .filter(|r| {
-                                    let r_src_label = (r.src.0 >> 32) as u32;
-                                    let r_src_slot = r.src.0 & 0xFFFF_FFFF;
-                                    if r_src_label != cur_label_id || r_src_slot != cur_slot {
-                                        return false;
-                                    }
-                                    // Filter by relation-table IDs when a type constraint exists.
-                                    hop_rel_ids.is_empty() || hop_rel_ids.contains(&r.rel_id.0)
-                                })
-                                .map(|r| r.dst.0 & 0xFFFF_FFFF)
-                                .collect();
-
-                            let mut seen: HashSet<u64> = HashSet::new();
-                            csr_nb
+                            // Gather neighbours from CSR + delta for this hop.
+                            // Both sources report the neighbour's own label:
+                            // the catalog's `dst_label_id` for checkpointed
+                            // edges, the stored NodeId for delta edges.
+                            // SPA-284: `rel_ids` restricts the lookup to the requested types.
+                            // `seen` deduplicates on the full identity
+                            // `(slot, label)`; `nb` keeps insertion order so
+                            // row order stays deterministic for queries with
+                            // no ORDER BY.
+                            let mut seen: HashSet<(u64, u32)> = HashSet::new();
+                            let mut nb: Vec<(u64, u32)> = self
+                                .csr_neighbors_labeled(cur_slot, cur_label_id, hop_rel_ids)
                                 .into_iter()
-                                .chain(delta_nb)
-                                .filter(|&nb| seen.insert(nb))
-                                .map(|nb| (nb, next_label_id_opt.unwrap_or(0)))
-                                .collect()
+                                .filter(|nb| seen.insert(*nb))
+                                .collect();
+                            for r in delta_all.iter() {
+                                let (r_src_label, r_src_slot) = node_id_parts(r.src.0);
+                                if r_src_label != cur_label_id || r_src_slot != cur_slot {
+                                    continue;
+                                }
+                                // Filter by relation-table IDs when a type constraint exists.
+                                if !hop_rel_ids.is_empty() && !hop_rel_ids.contains(&r.rel_id.0) {
+                                    continue;
+                                }
+                                let (r_dst_label, r_dst_slot) = node_id_parts(r.dst.0);
+                                if seen.insert((r_dst_slot, r_dst_label)) {
+                                    nb.push((r_dst_slot, r_dst_label));
+                                }
+                            }
+                            nb
                         }
                     };
 
                     for (next_slot, next_label_id) in all_nb {
+                        // When this position carries a label, the neighbour must
+                        // actually have it — matching on the slot alone would
+                        // admit the same-numbered node of any other label.
+                        if let Some(required) = next_label_id_opt {
+                            if next_label_id != required {
+                                continue;
+                            }
+                        }
                         let next_node_id = NodeId(((next_label_id as u64) << 32) | next_slot);
 
                         let next_props =
@@ -2049,7 +2070,7 @@ impl Engine {
                             }
                         }
 
-                        next_frontier.push((next_slot, new_vals));
+                        next_frontier.push((next_slot, next_label_id, new_vals));
                     }
                 }
 
@@ -2057,7 +2078,7 @@ impl Engine {
             }
 
             // `frontier` now contains complete paths.  Project result rows.
-            for (_final_slot, path_vals) in frontier {
+            for (_final_slot, _final_label_id, path_vals) in frontier {
                 // Apply WHERE clause using the full accumulated binding map.
                 if let Some(ref where_expr) = m.where_clause {
                     let mut eval_vals = path_vals.clone();

--- a/crates/sparrowdb-execution/src/engine/hop.rs
+++ b/crates/sparrowdb-execution/src/engine/hop.rs
@@ -1737,6 +1737,19 @@ impl Engine {
     ///
     /// This replaces the previous fallthrough to `execute_scan` which only
     /// scanned the first node and ignored all relationship hops.
+    ///
+    /// # Variable-length hops (#421)
+    ///
+    /// Any hop in the chain may carry a variable-length quantifier
+    /// (`-[:R*1..2]->`).  Such a hop expands the frontier with
+    /// [`Engine::execute_variable_hops`] — the same DFS/BFS used by the
+    /// standalone `execute_variable_length` path — instead of taking a single
+    /// step, so `(a)-[:R*1..2]->(b)-[:S]->(c)` binds `b` to every node reachable
+    /// from `a` in 1..2 hops and then joins each of those against the trailing
+    /// `:S` hop.  Before this, `is_var_len` in `execute_match` only recognised a
+    /// quantifier when the varlen relationship was the *only* relationship in
+    /// the pattern, so a trailing hop silently demoted `*1..2` to a plain single
+    /// hop and every depth >= 2 match was dropped without an error.
     pub(crate) fn execute_n_hop(
         &self,
         m: &MatchStatement,
@@ -1810,10 +1823,61 @@ impl Engine {
         // We read all delta edges once up front to avoid repeated file I/O.
         let delta_all = self.read_delta_all();
 
+        // ── #421: variable-length quantifiers anywhere in the chain ──────────
+        //
+        // `Some((min, max))` for a hop written `-[:R*min..max]->`.  An open
+        // upper bound is capped at 10, matching `execute_variable_length`.
+        let varlen_per_hop: Vec<Option<(u32, u32)>> = pat
+            .rels
+            .iter()
+            .map(|r| {
+                if r.min_hops.is_some() || r.max_hops.is_some() {
+                    Some((r.min_hops.unwrap_or(1), r.max_hops.unwrap_or(10)))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let has_varlen = varlen_per_hop.iter().any(Option::is_some);
+
         // Pre-resolve per-hop rel-table IDs so the inner loop uses filtered
         // CSR lookups instead of scanning every relation type (SPA-284).
+        //
+        // #429: a relationship *type* can back several rel tables — LDBC's
+        // `isLocatedIn` exists as both `(Person)->(Place)` and
+        // `(Organisation)->(Place)`.  CSRs are keyed by rel-table id and indexed
+        // by *source slot*, so unioning every table of a given type makes
+        // `Person` slot 2 inherit `Organisation` slot 2's edges.  (Concretely:
+        // Carol White, Person slot 2, appeared to live in Germany because
+        // TechStart Inc is Organisation slot 2.)  When both endpoint labels of a
+        // fixed hop are declared, narrow to the single rel table for that triple
+        // — the same discrimination `resolve_rel_table_id` already gives the
+        // one- and two-hop executors.
+        //
+        // Two cases stay exposed and are tracked in #429: hops whose endpoint
+        // labels are not both declared, and variable-length hops, whose
+        // intermediate nodes are not constrained by the endpoint labels and so
+        // must keep the type-wide set.
         let rel_ids_per_hop: Vec<Vec<u32>> = (0..n_rels)
-            .map(|i| self.resolve_rel_ids_for_type(&pat.rels[i].rel_type))
+            .map(|i| {
+                let type_wide = self.resolve_rel_ids_for_type(&pat.rels[i].rel_type);
+                if varlen_per_hop[i].is_some() || type_wide.len() < 2 {
+                    return type_wide;
+                }
+                match (label_ids_per_node[i], label_ids_per_node[i + 1]) {
+                    (Some(src), Some(dst)) => self
+                        .snapshot
+                        .catalog
+                        .get_rel_table(src as u16, dst as u16, &pat.rels[i].rel_type)
+                        .ok()
+                        .flatten()
+                        .map(|id| vec![id as u32])
+                        // No table for this (src, dst, type) triple: the hop
+                        // cannot match anything.
+                        .unwrap_or_default(),
+                    _ => type_wide,
+                }
+            })
             .collect();
         // If any hop specifies a rel type that doesn't exist in the catalog, no
         // traversal can produce results — return empty immediately.
@@ -1825,6 +1889,33 @@ impl Engine {
                 });
             }
         }
+
+        // `execute_variable_hops` only walks outgoing edges.  Reject rather than
+        // quietly answering an `<-[:R*1..2]-` pattern with the wrong direction.
+        for (i, v) in varlen_per_hop.iter().enumerate() {
+            if v.is_some() && pat.rels[i].dir != sparrowdb_cypher::ast::EdgeDir::Outgoing {
+                return Err(sparrowdb_common::Error::Unimplemented);
+            }
+        }
+
+        // Delta index + label registry used by the variable-length expansion.
+        // Built once (not per source node) and only when a varlen hop exists.
+        let (delta_idx, node_label, all_label_ids) = if has_varlen {
+            let idx = build_delta_index(&delta_all);
+            let mut labels: HashSet<(u64, u32)> = HashSet::new();
+            for r in &delta_all {
+                labels.insert((r.src.0 & 0xFFFF_FFFF, (r.src.0 >> 32) as u32));
+                labels.insert((r.dst.0 & 0xFFFF_FFFF, (r.dst.0 >> 32) as u32));
+            }
+            let mut ids: Vec<u32> = labels.iter().map(|&(_, l)| l).collect();
+            ids.sort_unstable();
+            ids.dedup();
+            (idx, labels, ids)
+        } else {
+            (DeltaIndex::new(), HashSet::new(), Vec::new())
+        };
+        // Reusable neighbor buffer for the variable-length traversal.
+        let mut neighbors_buf: HashSet<(u64, u32)> = HashSet::new();
 
         let mut rows: Vec<Vec<Value>> = Vec::new();
 
@@ -1870,38 +1961,75 @@ impl Engine {
                 let mut next_frontier: Vec<(u64, HashMap<String, Value>)> = Vec::new();
 
                 for (cur_slot, cur_vals) in frontier {
-                    // Gather neighbors from CSR + delta for this hop.
-                    // SPA-284: use filtered CSR lookup when rel type is specified.
-                    let csr_nb: Vec<u64> =
-                        self.csr_neighbors_filtered(cur_slot, &rel_ids_per_hop[hop_idx]);
                     let hop_rel_ids = &rel_ids_per_hop[hop_idx];
-                    let delta_nb: Vec<u64> = delta_all
-                        .iter()
-                        .filter(|r| {
-                            let r_src_label = (r.src.0 >> 32) as u32;
-                            let r_src_slot = r.src.0 & 0xFFFF_FFFF;
-                            if r_src_label != cur_label_id || r_src_slot != cur_slot {
-                                return false;
-                            }
-                            // Filter by relation-table IDs when a type constraint exists.
-                            hop_rel_ids.is_empty() || hop_rel_ids.contains(&r.rel_id.0)
-                        })
-                        .map(|r| r.dst.0 & 0xFFFF_FFFF)
-                        .collect();
 
-                    let mut seen: HashSet<u64> = HashSet::new();
-                    let all_nb: Vec<u64> = csr_nb
-                        .into_iter()
-                        .chain(delta_nb)
-                        .filter(|&nb| seen.insert(nb))
-                        .collect();
+                    // `(slot, resolved_label_id)` candidates for this hop.
+                    let all_nb: Vec<(u64, u32)> = match varlen_per_hop[hop_idx] {
+                        // ── #421: variable-length hop ────────────────────────
+                        Some((min_hops, max_hops)) => {
+                            // Per-path enumeration is only collapsed to
+                            // reachability when the query is DISTINCT and no
+                            // relationship variable is bound — same rule as
+                            // `execute_variable_length` (issue #165).
+                            let use_reachability = m.distinct && pat.rels[hop_idx].var.is_empty();
+                            let reached = self.execute_variable_hops(
+                                cur_slot,
+                                cur_label_id,
+                                min_hops,
+                                max_hops,
+                                &delta_idx,
+                                &node_label,
+                                &all_label_ids,
+                                &mut neighbors_buf,
+                                use_reachability,
+                                usize::MAX,
+                                hop_rel_ids,
+                            );
+                            reached
+                                .into_iter()
+                                .filter_map(|(slot, discovered_label)| {
+                                    match next_label_id_opt {
+                                        // A label on the pattern is a filter:
+                                        // drop nodes whose recovered label differs.
+                                        Some(required) if discovered_label != required => None,
+                                        Some(required) => Some((slot, required)),
+                                        None => Some((slot, discovered_label)),
+                                    }
+                                })
+                                .collect()
+                        }
+                        // ── fixed single hop ─────────────────────────────────
+                        None => {
+                            // Gather neighbors from CSR + delta for this hop.
+                            // SPA-284: use filtered CSR lookup when rel type is specified.
+                            let csr_nb: Vec<u64> =
+                                self.csr_neighbors_filtered(cur_slot, hop_rel_ids);
+                            let delta_nb: Vec<u64> = delta_all
+                                .iter()
+                                .filter(|r| {
+                                    let r_src_label = (r.src.0 >> 32) as u32;
+                                    let r_src_slot = r.src.0 & 0xFFFF_FFFF;
+                                    if r_src_label != cur_label_id || r_src_slot != cur_slot {
+                                        return false;
+                                    }
+                                    // Filter by relation-table IDs when a type constraint exists.
+                                    hop_rel_ids.is_empty() || hop_rel_ids.contains(&r.rel_id.0)
+                                })
+                                .map(|r| r.dst.0 & 0xFFFF_FFFF)
+                                .collect();
 
-                    for next_slot in all_nb {
-                        let next_node_id = if let Some(lbl_id) = next_label_id_opt {
-                            NodeId(((lbl_id as u64) << 32) | next_slot)
-                        } else {
-                            NodeId(next_slot)
-                        };
+                            let mut seen: HashSet<u64> = HashSet::new();
+                            csr_nb
+                                .into_iter()
+                                .chain(delta_nb)
+                                .filter(|&nb| seen.insert(nb))
+                                .map(|nb| (nb, next_label_id_opt.unwrap_or(0)))
+                                .collect()
+                        }
+                    };
+
+                    for (next_slot, next_label_id) in all_nb {
+                        let next_node_id = NodeId(((next_label_id as u64) << 32) | next_slot);
 
                         let next_props =
                             read_node_props(&self.snapshot.store, next_node_id, next_col_ids)?;

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -76,23 +76,11 @@ pub(crate) fn delta_neighbors_from_index(
         .unwrap_or_default()
 }
 
-/// Look up delta neighbors for a given `(src_label_id, src_slot)` and return
-/// `(dst_slot, dst_label_id)` pairs extracted from the full dst `NodeId`.
-pub(crate) fn delta_neighbors_labeled_from_index(
-    index: &DeltaIndex,
-    src_label_id: u32,
-    src_slot: u64,
-) -> impl Iterator<Item = (u64, u32)> + '_ {
-    index
-        .get(&(src_label_id, src_slot))
-        .into_iter()
-        .flat_map(|recs| {
-            recs.iter().map(|r| {
-                let (dst_label, dst_slot) = node_id_parts(r.dst.0);
-                (dst_slot, dst_label)
-            })
-        })
-}
+// NOTE (#427): `delta_neighbors_labeled_from_index` was removed here.  Its only
+// caller was `bfs_shortest_path`, which used it to guess a neighbour's label
+// *after* the label had already been thrown away by a slot-only lookup.
+// `Engine::get_node_neighbors_labeled` keeps the label attached throughout and
+// is the correct entry point.
 
 // ── DegreeCache (SPA-272) ─────────────────────────────────────────────────────
 

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -237,9 +237,62 @@ pub struct ReadSnapshot {
     /// decode of the index file.  With it the file is read at most once per
     /// `(label, property)` pair per query.
     fts_cache: std::sync::Mutex<HashMap<(String, String), sparrowdb_storage::fts_index::FtsIndex>>,
+    /// Lazily-built CSR topology: which relationship tables exist and what
+    /// labels their endpoints carry.  See [`CsrTopology`].
+    ///
+    /// Built on first neighbour lookup.  `list_rel_tables_with_ids()` clones a
+    /// `String` per table, so calling it once per node in a traversal loop was
+    /// not an option; this caches the label triples the traversal actually
+    /// needs.  `OnceLock` (not `OnceCell`) keeps `ReadSnapshot: Sync`.
+    csr_topology: std::sync::OnceLock<CsrTopology>,
+}
+
+/// Which relationship tables a traversal may follow, and what labels their
+/// endpoints carry.
+///
+/// Derived from the catalog, which registers every relationship table as
+/// `(rel_table_id, src_label_id, dst_label_id, rel_type)`.  A `CsrForward` holds
+/// exactly one table's edges and is indexed by the source slot *of that table's
+/// source label*, so these triples are what make a CSR hit interpretable: they
+/// say which node the slot belongs to and which node the neighbour is.
+#[derive(Debug, Default)]
+struct CsrTopology {
+    /// `(rel_table_id, src_label_id, dst_label_id)` for every catalogued
+    /// relationship table that has a loaded CSR.
+    tables: Vec<(u32, u32, u32)>,
+    /// CSRs loaded without a catalog entry, so with no label metadata.
+    ///
+    /// `open_csr_map` always attempts `RelTableId(0)` so that CSRs checkpointed
+    /// before the catalog carried rel-table entries (pre-SPA-185 data, and
+    /// `Engine::with_single_csr`) remain readable.  Such graphs are
+    /// single-label by construction — the catalog gained rel tables in the same
+    /// release that made more than one label reachable — so the source label is
+    /// the only label there is, and is used for both endpoints.
+    unlabeled: Vec<u32>,
 }
 
 impl ReadSnapshot {
+    /// Return the CSR topology, building it from the catalog on first use.
+    fn csr_topology(&self) -> &CsrTopology {
+        self.csr_topology.get_or_init(|| {
+            let mut topo = CsrTopology::default();
+            let mut catalogued: HashSet<u32> = HashSet::new();
+            for (id, src_lid, dst_lid, _) in self.catalog.list_rel_tables_with_ids() {
+                let rid = id as u32;
+                catalogued.insert(rid);
+                if self.csrs.contains_key(&rid) {
+                    topo.tables.push((rid, src_lid as u32, dst_lid as u32));
+                }
+            }
+            for rid in self.csrs.keys() {
+                if !catalogued.contains(rid) {
+                    topo.unlabeled.push(*rid);
+                }
+            }
+            topo
+        })
+    }
+
     /// Return a reference to the FTS index for `(label, property)`, loading
     /// it from disk the first time it is requested within this query.
     ///
@@ -505,6 +558,7 @@ impl Engine {
             edge_props_cache: shared_edge_props_cache
                 .unwrap_or_else(|| std::sync::Arc::new(std::sync::RwLock::new(HashMap::new()))),
             fts_cache: std::sync::Mutex::new(HashMap::new()),
+            csr_topology: std::sync::OnceLock::new(),
         };
 
         // If a shared cached index was provided, clone it out so we start
@@ -700,32 +754,84 @@ impl Engine {
             .unwrap_or_default()
     }
 
-    /// Return neighbor slots merged across **all** registered rel types.
-    fn csr_neighbors_all(&self, src_slot: u64) -> Vec<u64> {
-        let mut out: Vec<u64> = Vec::new();
-        for csr in self.snapshot.csrs.values() {
-            out.extend_from_slice(csr.neighbors(src_slot));
+    /// Return the outgoing CSR neighbours of the node `(src_slot, src_label_id)`
+    /// as `(dst_slot, dst_label_id)` pairs.
+    ///
+    /// # Why the source label is a parameter
+    ///
+    /// A `NodeId` is `(label_id << 32) | slot`, so a slot number alone does not
+    /// identify a node: `Person` slot 2, `Place` slot 2 and `Post` slot 2 are
+    /// three different nodes.  A `CsrForward` is indexed by the source slot of
+    /// **one** relationship table, and a relationship table is registered in the
+    /// catalog as `(rel_table_id, src_label_id, dst_label_id, rel_type)`.
+    ///
+    /// The previous slot-only helpers (`csr_neighbors_all` /
+    /// `csr_neighbors_filtered`) probed every CSR with a bare slot, so a node of
+    /// label A inherited the edges of the node of label B that happened to
+    /// occupy the same slot number (#429), and returned bare slots, so callers
+    /// had to reconstruct the destination label by guesswork (#431) or drop it
+    /// entirely (#427).
+    ///
+    /// Consulting the catalog fixes both halves at once:
+    /// * skip any table whose `src_label_id` differs from the caller's — that
+    ///   table's CSR is not indexed by this node's slot at all;
+    /// * tag every hit with that table's `dst_label_id` — for a CSR hit the
+    ///   destination label is *known*, never inferred.
+    ///
+    /// `rel_ids` restricts the traversal to those relationship-table IDs; an
+    /// empty slice means "any type".
+    fn csr_neighbors_labeled(
+        &self,
+        src_slot: u64,
+        src_label_id: u32,
+        rel_ids: &[u32],
+    ) -> Vec<(u64, u32)> {
+        let topo = self.snapshot.csr_topology();
+        let mut out: Vec<(u64, u32)> = Vec::new();
+        for &(rid, tbl_src_lid, tbl_dst_lid) in &topo.tables {
+            if !rel_ids.is_empty() && !rel_ids.contains(&rid) {
+                continue;
+            }
+            if tbl_src_lid != src_label_id {
+                continue;
+            }
+            if let Some(csr) = self.snapshot.csrs.get(&rid) {
+                out.extend(csr.neighbors(src_slot).iter().map(|&s| (s, tbl_dst_lid)));
+            }
+        }
+        // Legacy CSRs with no catalog entry carry no label metadata; see
+        // [`CsrTopology::unlabeled`].  A type filter can never select one
+        // because a type name is exactly what they lack.
+        if rel_ids.is_empty() {
+            for rid in &topo.unlabeled {
+                if let Some(csr) = self.snapshot.csrs.get(rid) {
+                    out.extend(csr.neighbors(src_slot).iter().map(|&s| (s, src_label_id)));
+                }
+            }
         }
         out
     }
 
-    /// Return neighbor slots from the CSR, filtered to a specific set of
-    /// relation-type IDs.  When `rel_ids` is empty, falls back to scanning
-    /// all CSR tables (equivalent to [`csr_neighbors_all`]).
+    /// Destination **slots** of the outgoing CSR edges of `(src_slot,
+    /// src_label_id)`, restricted to edges that land on `dst_label_id` when it
+    /// is `Some`.
     ///
-    /// This avoids the overhead of merging neighbors from irrelevant relation
-    /// types on heterogeneous graphs where only one or a few types are needed.
-    fn csr_neighbors_filtered(&self, src_slot: u64, rel_ids: &[u32]) -> Vec<u64> {
-        if rel_ids.is_empty() {
-            return self.csr_neighbors_all(src_slot);
-        }
-        let mut out: Vec<u64> = Vec::new();
-        for &rid in rel_ids {
-            if let Some(csr) = self.snapshot.csrs.get(&rid) {
-                out.extend_from_slice(csr.neighbors(src_slot));
-            }
-        }
-        out
+    /// For callers that already know the destination's label because they build
+    /// the destination `NodeId` from it.  Filtering here rather than after the
+    /// `NodeId` is built is what stops a `Place` slot from being read as the
+    /// `Person` in the same slot.  See [`Engine::csr_neighbors_labeled`].
+    fn csr_neighbor_slots_to_label(
+        &self,
+        src_slot: u64,
+        src_label_id: u32,
+        dst_label_id: Option<u32>,
+        rel_ids: &[u32],
+    ) -> Vec<u64> {
+        self.csr_neighbors_labeled(src_slot, src_label_id, rel_ids)
+            .into_iter()
+            .filter(|(_, lid)| dst_label_id.is_none_or(|want| *lid == want))
+            .map(|(slot, _)| slot)
+            .collect()
     }
 
     /// Resolve all rel-table IDs whose type name matches `rel_type`.

--- a/crates/sparrowdb-execution/src/engine/mutation.rs
+++ b/crates/sparrowdb-execution/src/engine/mutation.rs
@@ -612,7 +612,10 @@ impl Engine {
                     for r in records {
                         let s = r.src.0;
                         let s_label = (s >> 32) as u32;
-                        if s_label == src_label_id {
+                        let d_label = (r.dst.0 >> 32) as u32;
+                        // Slots are label-relative: an edge landing on another
+                        // label must not be read as a `dst_label_id` node.
+                        if s_label == src_label_id && d_label == dst_label_id {
                             let s_slot = s & 0xFFFF_FFFF;
                             adj.entry(s_slot).or_default().push(r.dst.0 & 0xFFFF_FFFF);
                         }
@@ -645,7 +648,12 @@ impl Engine {
                     // Collect outgoing neighbours (CSR + delta adjacency map).
                     let csr_neighbors_vec: Vec<u64> = match rel_lookup {
                         RelTableLookup::Found(rtid) => self.csr_neighbors(rtid, src_slot),
-                        _ => self.csr_neighbors_all(src_slot),
+                        _ => self.csr_neighbor_slots_to_label(
+                            src_slot,
+                            src_label_id,
+                            Some(dst_label_id),
+                            &[],
+                        ),
                     };
                     let empty: Vec<u64> = Vec::new();
                     let delta_neighbors: &[u64] =

--- a/crates/sparrowdb-execution/src/engine/path.rs
+++ b/crates/sparrowdb-execution/src/engine/path.rs
@@ -268,28 +268,11 @@ impl Engine {
         results
     }
 
-    /// Compatibility shim used by callers that do not need per-node label tracking.
-    pub(crate) fn get_node_neighbors_by_slot(
-        &self,
-        src_slot: u64,
-        src_label_id: u32,
-        delta_idx: &DeltaIndex,
-        rel_ids: &[u32],
-    ) -> Vec<u64> {
-        // SPA-284: use filtered CSR lookup when rel type IDs are provided.
-        let csr_neighbors: Vec<u64> = self.csr_neighbors_filtered(src_slot, rel_ids);
-        // SPA-283: O(1) indexed lookup instead of linear scan.
-        // SPA-284: filter by relation-table IDs when a type constraint exists.
-        let mut all: std::collections::HashSet<u64> = csr_neighbors.into_iter().collect();
-        if let Some(recs) = delta_idx.get(&(src_label_id, src_slot)) {
-            all.extend(
-                recs.iter()
-                    .filter(|r| rel_ids.is_empty() || rel_ids.contains(&r.rel_id.0))
-                    .map(|r| node_id_parts(r.dst.0).1),
-            );
-        }
-        all.into_iter().collect()
-    }
+    // NOTE (#427): the former `get_node_neighbors_by_slot` shim lived here.  It
+    // returned bare `Vec<u64>` slots, discarding the neighbour labels, and its
+    // last caller (`bfs_shortest_path`) was the source of the #427 slot-aliasing
+    // bug.  Use `get_node_neighbors_labeled` instead — slots are only unique
+    // within a label, so a neighbour is never fully identified by its slot.
 
     /// Execute a variable-length path query: `MATCH (a:L1)-[:R*M..N]->(b:L2) RETURN …`.
     pub(crate) fn execute_variable_length(

--- a/crates/sparrowdb-execution/src/engine/path.rs
+++ b/crates/sparrowdb-execution/src/engine/path.rs
@@ -4,37 +4,42 @@ use super::*;
 impl Engine {
     // ── Variable-length path traversal: (a)-[:R*M..N]->(b) ──────────────────
 
-    /// Collect all neighbor slot-ids reachable from `src_slot` via the delta
-    /// log and CSR adjacency.  src_label_id is used to filter delta records.
+    /// Return the labeled outgoing neighbours of `(src_slot, src_label_id)`
+    /// into `out`, each entry a `(dst_slot, dst_label_id)` pair.
     ///
-    /// SPA-185: reads across all rel types (used by variable-length path
-    /// traversal which does not currently filter on rel_type).
-    /// Return the labeled outgoing neighbors of `(src_slot, src_label_id)`.
+    /// Both edge sources agree on where the destination's label comes from, and
+    /// neither guesses:
     ///
-    /// Each entry is `(dst_slot, dst_label_id)`.  The delta log encodes the full
-    /// NodeId in `r.dst`, so label_id is recovered precisely.  For CSR-only
-    /// destinations the label is looked up in the `node_label` hint map (built
-    /// from the delta by the caller); if absent, `src_label_id` is used as a
-    /// conservative fallback (correct for homogeneous graphs).
-    #[allow(clippy::too_many_arguments)]
+    /// * **Checkpointed edges** live in a CSR, one per relationship table, and
+    ///   the catalog registers every table as `(id, src_label_id, dst_label_id,
+    ///   rel_type)`.  So a CSR hit's label is *known* — see
+    ///   [`Engine::csr_neighbors_labeled`], which also skips tables whose
+    ///   `src_label_id` does not match, because their CSR is not indexed by this
+    ///   node's slot.
+    /// * **Uncheckpointed edges** live in the delta log, which stores full
+    ///   `NodeId`s, so the label is read straight off `r.dst`.
+    ///
+    /// Issue #431: this used to recover CSR neighbour labels from hints built
+    /// out of `read_delta_all()`, falling back to `src_label_id` when no hint
+    /// existed.  `checkpoint()` truncates the delta log, so every hint vanished
+    /// and every CSR neighbour silently took the source's label — making
+    /// cross-label variable-length traversal return correct results before a
+    /// checkpoint and empty ones after.
     pub(crate) fn get_node_neighbors_labeled(
         &self,
         src_slot: u64,
         src_label_id: u32,
         delta_idx: &DeltaIndex,
-        node_label: &std::collections::HashSet<(u64, u32)>,
-        all_label_ids: &[u32],
         out: &mut std::collections::HashSet<(u64, u32)>,
         rel_ids: &[u32],
     ) {
         out.clear();
 
-        // ── CSR neighbors (slot only; label recovered by scanning all label HWMs
-        //    or falling back to src_label_id for homogeneous graphs) ────────────
-        // SPA-284: use filtered CSR lookup when rel type IDs are provided.
-        let csr_slots: Vec<u64> = self.csr_neighbors_filtered(src_slot, rel_ids);
+        // ── CSR neighbours: label from the catalog ────────────────────────────
+        // SPA-284: `rel_ids` restricts the lookup to the requested types.
+        out.extend(self.csr_neighbors_labeled(src_slot, src_label_id, rel_ids));
 
-        // ── Delta neighbors (full NodeId available) ───────────────────────────
+        // ── Delta neighbours: label from the stored NodeId ────────────────────
         // SPA-283: O(1) indexed lookup instead of linear scan.
         // SPA-284: filter by relation-table IDs when a type constraint exists.
         if let Some(recs) = delta_idx.get(&(src_label_id, src_slot)) {
@@ -42,37 +47,8 @@ impl Engine {
                 if !rel_ids.is_empty() && !rel_ids.contains(&r.rel_id.0) {
                     continue;
                 }
-                let dst_slot = r.dst.0 & 0xFFFF_FFFF;
-                let dst_label = (r.dst.0 >> 32) as u32;
+                let (dst_label, dst_slot) = node_id_parts(r.dst.0);
                 out.insert((dst_slot, dst_label));
-            }
-        }
-
-        // For each CSR slot, determine label: prefer a delta-confirmed label,
-        // else scan all known label ids to find one whose HWM covers that slot.
-        // If no label confirms it, fall back to src_label_id.
-        'csr: for dst_slot in csr_slots {
-            // Check if delta already gave us a label for this slot.
-            for &lid in all_label_ids {
-                if out.contains(&(dst_slot, lid)) {
-                    continue 'csr; // already recorded with correct label
-                }
-            }
-            // Try to determine the dst label from the delta node_label registry.
-            // node_label contains (slot, label_id) pairs seen anywhere in delta.
-            let mut found = false;
-            for &lid in all_label_ids {
-                if node_label.contains(&(dst_slot, lid)) {
-                    out.insert((dst_slot, lid));
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                // No label info available — fallback to src_label_id (correct for
-                // homogeneous graphs, gracefully wrong for unmapped CSR-only nodes
-                // in heterogeneous graphs with no delta activity on those nodes).
-                out.insert((dst_slot, src_label_id));
             }
         }
     }
@@ -105,8 +81,6 @@ impl Engine {
         min_hops: u32,
         max_hops: u32,
         delta_idx: &DeltaIndex,
-        node_label: &std::collections::HashSet<(u64, u32)>,
-        all_label_ids: &[u32],
         neighbors_buf: &mut std::collections::HashSet<(u64, u32)>,
         use_reachability: bool,
         result_limit: usize,
@@ -152,8 +126,6 @@ impl Engine {
                     cur_slot,
                     cur_label,
                     delta_idx,
-                    node_label,
-                    all_label_ids,
                     neighbors_buf,
                     rel_ids,
                 );
@@ -200,8 +172,6 @@ impl Engine {
                 src_slot,
                 src_label_id,
                 delta_idx,
-                node_label,
-                all_label_ids,
                 neighbors_buf,
                 rel_ids,
             );
@@ -251,8 +221,6 @@ impl Engine {
                                 nb_slot,
                                 nb_label,
                                 delta_idx,
-                                node_label,
-                                all_label_ids,
                                 neighbors_buf,
                                 rel_ids,
                             );
@@ -377,26 +345,17 @@ impl Engine {
             .into_iter()
             .collect();
 
-        // SPA-275: hoist delta read and node_label map out of the per-source loop.
-        // Previously execute_variable_hops rebuilt these on every call — O(sources)
-        // delta reads and O(sources × delta_records) HashMap insertions per query.
-        // Now we build them once and pass references into the BFS.
+        // SPA-275: hoist the delta read out of the per-source loop.  Previously
+        // execute_variable_hops rebuilt it on every call — O(sources) delta reads
+        // per query.  Now we build it once and pass a reference into the BFS.
+        //
+        // #431: the `node_label` hint set and `all_label_ids` that used to be
+        // built here are gone.  They existed only to guess a CSR neighbour's
+        // label, and they were derived from the delta log, so `checkpoint()`
+        // erased them.  Neighbour labels now come from the catalog.
         let delta_all = self.read_delta_all();
         // SPA-283: build HashMap index for O(1) per-node delta lookups.
         let delta_idx = build_delta_index(&delta_all);
-        let mut node_label: std::collections::HashSet<(u64, u32)> =
-            std::collections::HashSet::new();
-        for r in &delta_all {
-            let src_s = r.src.0 & 0xFFFF_FFFF;
-            let src_l = (r.src.0 >> 32) as u32;
-            node_label.insert((src_s, src_l));
-            let dst_s = r.dst.0 & 0xFFFF_FFFF;
-            let dst_l = (r.dst.0 >> 32) as u32;
-            node_label.insert((dst_s, dst_l));
-        }
-        let mut all_label_ids: Vec<u32> = node_label.iter().map(|&(_, l)| l).collect();
-        all_label_ids.sort_unstable();
-        all_label_ids.dedup();
 
         // SPA-284: pre-resolve rel-type IDs so the BFS/DFS uses filtered CSR lookups.
         let rel_ids = self.resolve_rel_ids_for_type(&rel_pat.rel_type);
@@ -487,8 +446,8 @@ impl Engine {
                 }
 
                 // BFS to find all reachable (slot, label_id) pairs within [min_hops, max_hops].
-                // delta_all, node_label, all_label_ids, and neighbors_buf are hoisted out of
-                // this loop (SPA-275) and reused across all source nodes.
+                // delta_idx and neighbors_buf are hoisted out of this loop (SPA-275)
+                // and reused across all source nodes.
                 // Use reachability BFS when RETURN DISTINCT is present and no path variable
                 // is bound (issue #165). Otherwise use enumerative DFS for full path semantics.
                 let use_reachability = m.distinct && rel_pat.var.is_empty();
@@ -500,8 +459,6 @@ impl Engine {
                     min_hops,
                     max_hops,
                     &delta_idx,
-                    &node_label,
-                    &all_label_ids,
                     &mut neighbors_buf,
                     use_reachability,
                     remaining,

--- a/crates/sparrowdb-execution/src/engine/scan.rs
+++ b/crates/sparrowdb-execution/src/engine/scan.rs
@@ -808,19 +808,30 @@ impl Engine {
         // Replaces the cascade of `can_use_*` boolean guards with a single
         // typed plan selector.  Each variant dispatches to the matching
         // `execute_*_chunked` entry point.
-        if let Some(plan) = self.try_plan_chunked_match(m) {
-            match plan {
-                crate::engine::pipeline_exec::ChunkedPlan::MutualNeighbors => {
-                    return self.execute_mutual_neighbors_chunked(m, &column_names);
-                }
-                crate::engine::pipeline_exec::ChunkedPlan::TwoHop => {
-                    return self.execute_two_hop_chunked(m, &column_names);
-                }
-                crate::engine::pipeline_exec::ChunkedPlan::OneHop => {
-                    return self.execute_one_hop_chunked(m, &column_names);
-                }
-                crate::engine::pipeline_exec::ChunkedPlan::Scan => {
-                    return self.execute_scan_chunked(m, &column_names);
+        //
+        // Skip entirely for a varlen-plus-hop chain. Every `can_use_*_chunked`
+        // guard already rejects `min_hops.is_some()`, and the parser only ever
+        // produces `max_hops: Some(_)` alongside `min_hops: Some(_)` — there is
+        // no `*..N` quantifier syntax that leaves min unset (see the `*min..max`
+        // parsing in `sparrowdb-cypher`'s parser) — so no chunked plan can
+        // currently match this shape regardless. Gating on `is_var_len_chain`
+        // here removes the dependency on that invariant holding across three
+        // separate guard functions rather than one.
+        if !is_var_len_chain {
+            if let Some(plan) = self.try_plan_chunked_match(m) {
+                match plan {
+                    crate::engine::pipeline_exec::ChunkedPlan::MutualNeighbors => {
+                        return self.execute_mutual_neighbors_chunked(m, &column_names);
+                    }
+                    crate::engine::pipeline_exec::ChunkedPlan::TwoHop => {
+                        return self.execute_two_hop_chunked(m, &column_names);
+                    }
+                    crate::engine::pipeline_exec::ChunkedPlan::OneHop => {
+                        return self.execute_one_hop_chunked(m, &column_names);
+                    }
+                    crate::engine::pipeline_exec::ChunkedPlan::Scan => {
+                        return self.execute_scan_chunked(m, &column_names);
+                    }
                 }
             }
         }

--- a/crates/sparrowdb-execution/src/engine/scan.rs
+++ b/crates/sparrowdb-execution/src/engine/scan.rs
@@ -418,6 +418,30 @@ impl Engine {
         if pat.nodes.len() < 2 || pat.rels.is_empty() {
             return Ok(vec![]);
         }
+
+        // #421: this executor takes a single step along `rels[0]` and ignores
+        // any quantifier on it.  A variable-length relationship inside a
+        // pipeline MATCH stage (`WITH … MATCH (a)-[:R*1..2]->(b) …`) would
+        // therefore be answered with depth-1 matches only — the same silent
+        // truncation #421 fixed in the top-level MATCH path.  Reject instead:
+        // an error the caller can see beats data they cannot check.
+        //
+        // It also drops `rels[1..]` of any multi-hop pattern, which is the same
+        // failure without a quantifier; that is tracked separately as #430 and
+        // deliberately left alone here.
+        if pat
+            .rels
+            .iter()
+            .any(|r| r.min_hops.is_some() || r.max_hops.is_some())
+        {
+            return Err(sparrowdb_common::Error::InvalidArgument(
+                "variable-length relationships are not supported inside a pipeline \
+                 MATCH stage (after WITH); run the variable-length pattern in the \
+                 leading MATCH instead — see issue #421"
+                    .to_string(),
+            ));
+        }
+
         let src_pat = &pat.nodes[0];
         let dst_pat = &pat.nodes[1];
         let rel_pat = &pat.rels[0];
@@ -726,27 +750,29 @@ impl Engine {
             });
         }
 
+        // #421: a variable-length quantifier combined with further hops —
+        // `(a)-[:R*1..2]->(b)-[:S]->(c)` — is executed by the chain traversal in
+        // `execute_n_hop`, which expands each varlen hop with
+        // `execute_variable_hops` and joins the result against the remaining
+        // fixed hops.  It must be tested *before* `is_two_hop`/`is_n_hop`:
+        // dispatching on rel count alone is what made `execute_two_hop` demote
+        // `*1..2` to a plain single hop and silently drop every depth >= 2 match.
+        let is_var_len_chain = m.pattern.len() == 1
+            && m.pattern[0].rels.len() > 1
+            && m.pattern[0]
+                .rels
+                .iter()
+                .any(|r| r.min_hops.is_some() || r.max_hops.is_some());
+
         // Determine if this is a 2-hop query.
-        let is_two_hop = m.pattern.len() == 1 && m.pattern[0].rels.len() == 2;
+        let is_two_hop = !is_var_len_chain && m.pattern.len() == 1 && m.pattern[0].rels.len() == 2;
         let is_one_hop = m.pattern.len() == 1 && m.pattern[0].rels.len() == 1;
         // N-hop (3+): generalised iterative traversal (SPA-252).
-        let is_n_hop = m.pattern.len() == 1 && m.pattern[0].rels.len() >= 3;
+        let is_n_hop = !is_var_len_chain && m.pattern.len() == 1 && m.pattern[0].rels.len() >= 3;
         // Detect variable-length path: single pattern with exactly 1 rel that has min_hops set.
         let is_var_len = m.pattern.len() == 1
             && m.pattern[0].rels.len() == 1
             && m.pattern[0].rels[0].min_hops.is_some();
-
-        // #421: `is_var_len` only recognises a variable-length quantifier when it
-        // is the *only* relationship in the pattern. With a trailing hop —
-        // `(a)-[:R*1..2]->(b)-[:S]->(c)` — `rels.len() == 2`, so `is_two_hop`
-        // wins and `execute_two_hop` treats `*1..2` as a plain single hop,
-        // silently discarding every match at depth >= 2 and returning a
-        // plausible but incomplete result set.
-        //
-        // Executing variable-length expansion followed by further hops is not
-        // implemented. Until it is, reject the pattern loudly: a clear error is
-        // far better than quietly wrong data the caller cannot detect.
-        reject_varlen_with_trailing_hops(m)?;
 
         let column_names = extract_return_column_names(&m.return_clause.items);
 
@@ -801,6 +827,9 @@ impl Engine {
 
         if is_var_len {
             self.execute_variable_length(m, &column_names)
+        } else if is_var_len_chain {
+            // #421: varlen expansion + trailing/leading fixed hops.
+            self.execute_n_hop(m, &column_names)
         } else if is_two_hop {
             self.execute_two_hop(m, &column_names)
         } else if is_one_hop {
@@ -1275,12 +1304,6 @@ impl Engine {
         };
 
         let column_names = extract_return_column_names(&om.return_clause.items);
-
-        // #421: this arm swallows InvalidArgument into a NULL row, which would
-        // turn the unsupported-pattern error below into silent nulls — exactly
-        // the silent-wrongness the guard exists to prevent. Check first so the
-        // error propagates instead of being absorbed.
-        reject_varlen_with_trailing_hops(&match_stmt)?;
 
         let result = self.execute_match(&match_stmt);
 
@@ -2727,39 +2750,4 @@ impl Engine {
             .collect();
         Value::List(label_strings)
     }
-}
-
-/// Reject `(a)-[:R*m..n]->(b)-[:S]->(c)` — a variable-length relationship
-/// followed by further hops (#421).
-///
-/// `is_var_len` in `execute_match` only recognises a variable-length quantifier
-/// when the varlen rel is the *only* relationship in the pattern. With a
-/// trailing hop `rels.len() >= 2`, so `is_two_hop`/`is_n_hop` wins and the
-/// quantifier is silently discarded — every match at depth >= 2 disappears and
-/// the caller gets a plausible but incomplete result set.
-///
-/// Executing varlen expansion followed by further hops is not implemented.
-/// Until it is, fail loudly: undetectable wrong data is worse than an error.
-///
-/// Must be called by every path that can dispatch such a pattern. In
-/// particular `execute_optional_match` has to call it *before* delegating,
-/// because that function absorbs `InvalidArgument` into a NULL row and would
-/// otherwise convert this error back into silent wrongness.
-pub(crate) fn reject_varlen_with_trailing_hops(m: &MatchStatement) -> Result<()> {
-    for pat in &m.pattern {
-        if pat.rels.len() > 1
-            && pat
-                .rels
-                .iter()
-                .any(|r| r.min_hops.is_some() || r.max_hops.is_some())
-        {
-            return Err(sparrowdb_common::Error::InvalidArgument(
-                "variable-length relationship followed by additional hops is not supported \
-                 (e.g. (a)-[:R*1..2]->(b)-[:S]->(c)); split the pattern into separate \
-                 MATCH clauses — see issue #421"
-                    .to_string(),
-            ));
-        }
-    }
-    Ok(())
 }

--- a/crates/sparrowdb-execution/src/engine/scan.rs
+++ b/crates/sparrowdb-execution/src/engine/scan.rs
@@ -541,16 +541,28 @@ impl Engine {
             let dst_slots: Vec<u64> = match &rel_table_id {
                 RelTableLookup::Found(rtid) => self.csr_neighbors(*rtid, src_slot),
                 RelTableLookup::NotFound => continue,
-                RelTableLookup::All => self.csr_neighbors_all(src_slot),
+                // Untyped edge: restrict to tables that run from this node's
+                // label to `dst_label_id`, which is the label the destination
+                // NodeId is built from a few lines below.
+                RelTableLookup::All => self.csr_neighbor_slots_to_label(
+                    src_slot,
+                    src_label_id,
+                    Some(dst_label_id),
+                    &[],
+                ),
             };
-            // Also check the delta.
+            // Also check the delta.  Slots are label-relative, so an edge that
+            // lands on a different label must not be read as `dst_label_id`.
             let delta_slots: Vec<u64> = self
                 .read_delta_all()
                 .into_iter()
                 .filter(|r| {
                     let r_src_label = (r.src.0 >> 32) as u32;
                     let r_src_slot = r.src.0 & 0xFFFF_FFFF;
-                    r_src_label == src_label_id && r_src_slot == src_slot
+                    let r_dst_label = (r.dst.0 >> 32) as u32;
+                    r_src_label == src_label_id
+                        && r_src_slot == src_slot
+                        && r_dst_label == dst_label_id
                 })
                 .map(|r| r.dst.0 & 0xFFFF_FFFF)
                 .collect();
@@ -1594,7 +1606,12 @@ impl Engine {
                 .filter(|r| {
                     let r_src_label = (r.src.0 >> 32) as u32;
                     let r_src_slot = r.src.0 & 0xFFFF_FFFF;
-                    r_src_label == src_label_id && r_src_slot == src_slot
+                    let r_dst_label = (r.dst.0 >> 32) as u32;
+                    // Slots are label-relative: an edge landing on another label
+                    // must not be read as a `dst_label_id` node.
+                    r_src_label == src_label_id
+                        && r_src_slot == src_slot
+                        && r_dst_label == dst_label_id
                 })
                 .map(|r| r.dst.0 & 0xFFFF_FFFF)
                 .collect()
@@ -1602,7 +1619,7 @@ impl Engine {
 
         let csr_neighbors = match rel_lookup {
             RelTableLookup::Found(rtid) => self.csr_neighbors(rtid, src_slot),
-            _ => self.csr_neighbors_all(src_slot),
+            _ => self.csr_neighbor_slots_to_label(src_slot, src_label_id, Some(dst_label_id), &[]),
         };
         let all_neighbors: Vec<u64> = csr_neighbors.into_iter().chain(delta_neighbors).collect();
 

--- a/crates/sparrowdb-execution/tests/regression_421_varlen_plus_hop.rs
+++ b/crates/sparrowdb-execution/tests/regression_421_varlen_plus_hop.rs
@@ -1,0 +1,409 @@
+//! Regression tests for #421 — variable-length path followed by further hops.
+//!
+//! `MATCH (a)-[:R*1..2]->(b)-[:S]->(c)` used to dispatch on relationship count
+//! alone, so `execute_two_hop` demoted `*1..2` to a plain single hop and every
+//! match at depth >= 2 was dropped without an error.
+//!
+//! # Fixture (built by `build_fixture`, all expectations derived from it by hand)
+//!
+//! Six `Person` nodes, slots 0..=5, `pid` = slot.
+//! Two `City` nodes, slots 0..=1, `code` = 10 (slot 0) and 20 (slot 1).
+//!
+//! ```text
+//! knows   (Person→Person):  0→1, 0→4, 1→2, 2→3, 4→5
+//! livesIn (Person→City):    0→c0, 1→c0, 2→c1, 3→c1, 4→c1, 5→c0
+//! ```
+//!
+//! Reachability from person 0 over `knows`:
+//!   depth 1 → {1, 4}
+//!   depth 2 → {2, 5}
+//!   depth 3 → {3}
+//!
+//! So `-[:knows*1..2]->` from person 0 binds `{1, 4, 2, 5}` — the pre-fix code
+//! returned only `{1, 4}`.
+
+use sparrowdb_catalog::catalog::Catalog;
+use sparrowdb_execution::types::Value;
+use sparrowdb_execution::Engine;
+use sparrowdb_storage::csr::CsrForward;
+use sparrowdb_storage::node_store::{NodeStore, Value as StoreValue};
+
+const KNOWS: [(u64, u64); 5] = [(0, 1), (0, 4), (1, 2), (2, 3), (4, 5)];
+const LIVES_IN: [(u64, u64); 6] = [(0, 0), (1, 0), (2, 1), (3, 1), (4, 1), (5, 0)];
+
+/// City code for each city slot.
+const CITY_CODES: [i64; 2] = [10, 20];
+
+struct Fixture {
+    _dir: tempfile::TempDir,
+    engine: Engine,
+}
+
+fn build_fixture(chunked: bool) -> Fixture {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().to_path_buf();
+
+    let pid_col = sparrowdb_common::col_id_of("pid");
+    let code_col = sparrowdb_common::col_id_of("code");
+
+    let (knows_rel, lives_rel) = {
+        let mut store = NodeStore::open(&path).expect("node store");
+        let mut cat = Catalog::open(&path).expect("catalog");
+
+        let person_label = cat.create_label("Person").expect("Person") as u32;
+        let city_label = cat.create_label("City").expect("City") as u32;
+
+        for pid in 0..6i64 {
+            store
+                .create_node(person_label, &[(pid_col, StoreValue::Int64(pid))])
+                .expect("person");
+        }
+        for code in CITY_CODES {
+            store
+                .create_node(city_label, &[(code_col, StoreValue::Int64(code))])
+                .expect("city");
+        }
+
+        let knows_rel = cat
+            .create_rel_table(person_label as u16, person_label as u16, "knows")
+            .expect("knows rel table") as u32;
+        let lives_rel = cat
+            .create_rel_table(person_label as u16, city_label as u16, "livesIn")
+            .expect("livesIn rel table") as u32;
+
+        (knows_rel, lives_rel)
+    };
+
+    // CSR per rel table. Source slots are Person slots in both cases.
+    let mut csrs = std::collections::HashMap::new();
+    csrs.insert(knows_rel, CsrForward::build(6, &KNOWS));
+    csrs.insert(lives_rel, CsrForward::build(6, &LIVES_IN));
+
+    let store = NodeStore::open(&path).expect("reopen store");
+    let cat = Catalog::open(&path).expect("reopen catalog");
+    let engine = Engine::new(store, cat, csrs, &path);
+    let engine = if chunked {
+        engine.with_chunked_pipeline()
+    } else {
+        engine
+    };
+
+    Fixture { _dir: dir, engine }
+}
+
+/// Collect `(int, int)` pairs from a two-column result, sorted for comparison.
+fn int_pairs(result: &sparrowdb_execution::types::QueryResult) -> Vec<(i64, i64)> {
+    let mut out: Vec<(i64, i64)> = result
+        .rows
+        .iter()
+        .map(|row| {
+            let a = match &row[0] {
+                Value::Int64(v) => *v,
+                other => panic!("expected Int64 in column 0, got {other:?}"),
+            };
+            let b = match &row[1] {
+                Value::Int64(v) => *v,
+                other => panic!("expected Int64 in column 1, got {other:?}"),
+            };
+            (a, b)
+        })
+        .collect();
+    out.sort_unstable();
+    out
+}
+
+fn ints(result: &sparrowdb_execution::types::QueryResult) -> Vec<i64> {
+    let mut out: Vec<i64> = result
+        .rows
+        .iter()
+        .map(|row| match &row[0] {
+            Value::Int64(v) => *v,
+            other => panic!("expected Int64, got {other:?}"),
+        })
+        .collect();
+    out.sort_unstable();
+    out
+}
+
+// ── Baseline: the varlen pattern on its own is (and was) correct ─────────────
+
+#[test]
+fn varlen_alone_reaches_depth_two() {
+    let mut f = build_fixture(false);
+    let r = f
+        .engine
+        .execute("MATCH (a:Person {pid: 0})-[:knows*1..2]->(b:Person) RETURN DISTINCT b.pid")
+        .expect("query ok");
+    // depth 1 = {1, 4}; depth 2 = {2, 5}.
+    assert_eq!(
+        ints(&r),
+        vec![1, 2, 4, 5],
+        "knows*1..2 from person 0 reaches 1 and 4 at depth 1, 2 and 5 at depth 2"
+    );
+}
+
+// ── #421: varlen + one trailing hop ──────────────────────────────────────────
+
+#[test]
+fn varlen_plus_trailing_hop_keeps_depth_two_matches() {
+    let mut f = build_fixture(false);
+    let r = f
+        .engine
+        .execute(
+            "MATCH (a:Person {pid: 0})-[:knows*1..2]->(b:Person)-[:livesIn]->(c:City) \
+             RETURN DISTINCT b.pid, c.code",
+        )
+        .expect("query ok");
+
+    // b ∈ {1, 4} at depth 1 and {2, 5} at depth 2.
+    // livesIn: 1→c0(10), 4→c1(20), 2→c1(20), 5→c0(10).
+    assert_eq!(
+        int_pairs(&r),
+        vec![(1, 10), (2, 20), (4, 20), (5, 10)],
+        "every depth-1 and depth-2 friend must be joined to its city; \
+         before #421 was fixed only the depth-1 pair set {{(1,10),(4,20)}} came back"
+    );
+}
+
+#[test]
+fn varlen_plus_trailing_hop_enumerates_paths_without_distinct() {
+    let mut f = build_fixture(false);
+    let r = f
+        .engine
+        .execute(
+            "MATCH (a:Person {pid: 0})-[:knows*1..2]->(b:Person)-[:livesIn]->(c:City) \
+             RETURN b.pid, c.code",
+        )
+        .expect("query ok");
+
+    // Without DISTINCT the traversal enumerates simple paths. From person 0
+    // there is exactly one simple path to each of 1, 4, 2 and 5 within 2 hops
+    // (0→1, 0→4, 0→1→2, 0→4→5), so each contributes exactly one row.
+    assert_eq!(
+        int_pairs(&r),
+        vec![(1, 10), (2, 20), (4, 20), (5, 10)],
+        "one row per simple path"
+    );
+}
+
+#[test]
+fn varlen_plus_trailing_hop_respects_where_on_final_node() {
+    let mut f = build_fixture(false);
+    let r = f
+        .engine
+        .execute(
+            "MATCH (a:Person {pid: 0})-[:knows*1..2]->(b:Person)-[:livesIn]->(c:City) \
+             WHERE c.code = 20 RETURN DISTINCT b.pid",
+        )
+        .expect("query ok");
+    // City code 20 is city slot 1; residents among {1,4,2,5} are 4 and 2.
+    assert_eq!(
+        ints(&r),
+        vec![2, 4],
+        "WHERE on the trailing hop's node must filter the joined rows"
+    );
+}
+
+#[test]
+fn varlen_plus_trailing_hop_respects_inline_prop_on_final_node() {
+    let mut f = build_fixture(false);
+    let r = f
+        .engine
+        .execute(
+            "MATCH (a:Person {pid: 0})-[:knows*1..2]->(b:Person)-[:livesIn]->(c:City {code: 10}) \
+             RETURN DISTINCT b.pid",
+        )
+        .expect("query ok");
+    // City code 10 is city slot 0; residents among {1,4,2,5} are 1 and 5.
+    assert_eq!(
+        ints(&r),
+        vec![1, 5],
+        "inline prop filter on the trailing hop's node must be applied"
+    );
+}
+
+#[test]
+fn varlen_min_two_plus_trailing_hop_excludes_depth_one() {
+    let mut f = build_fixture(false);
+    let r = f
+        .engine
+        .execute(
+            "MATCH (a:Person {pid: 0})-[:knows*2..2]->(b:Person)-[:livesIn]->(c:City) \
+             RETURN DISTINCT b.pid",
+        )
+        .expect("query ok");
+    assert_eq!(
+        ints(&r),
+        vec![2, 5],
+        "min_hops = 2 must exclude the direct friends 1 and 4"
+    );
+}
+
+#[test]
+fn varlen_zero_hop_plus_trailing_hop_includes_source() {
+    let mut f = build_fixture(false);
+    let r = f
+        .engine
+        .execute(
+            "MATCH (a:Person {pid: 0})-[:knows*0..1]->(b:Person)-[:livesIn]->(c:City) \
+             RETURN DISTINCT b.pid",
+        )
+        .expect("query ok");
+    // *0..1 binds b to person 0 itself plus the depth-1 friends 1 and 4.
+    assert_eq!(
+        ints(&r),
+        vec![0, 1, 4],
+        "min_hops = 0 must bind the source node itself as well"
+    );
+}
+
+// ── #421: varlen followed by two fixed hops (3-rel chain) ────────────────────
+
+#[test]
+fn varlen_plus_two_trailing_hops() {
+    let mut f = build_fixture(false);
+    // City has no outgoing edges, so route the third hop back through knows:
+    // (a)-[:knows*1..2]->(b)-[:knows]->(d)-[:livesIn]->(c)
+    let r = f
+        .engine
+        .execute(
+            "MATCH (a:Person {pid: 0})-[:knows*1..2]->(b:Person)-[:knows]->(d:Person) \
+             -[:livesIn]->(c:City) RETURN DISTINCT d.pid, c.code",
+        )
+        .expect("query ok");
+    // b ∈ {1, 4, 2, 5}. Outgoing knows: 1→2, 4→5, 2→3, 5→none.
+    // d ∈ {2, 5, 3}. livesIn: 2→c1(20), 5→c0(10), 3→c1(20).
+    assert_eq!(
+        int_pairs(&r),
+        vec![(2, 20), (3, 20), (5, 10)],
+        "a varlen hop followed by two fixed hops must join all three levels"
+    );
+}
+
+// ── #421: a leading fixed hop followed by a varlen hop ──────────────────────
+
+#[test]
+fn leading_fixed_hop_then_varlen() {
+    let mut f = build_fixture(false);
+    // The quantifier is on the *second* relationship, not the first.
+    let r = f
+        .engine
+        .execute(
+            "MATCH (a:Person {pid: 0})-[:knows]->(b:Person)-[:knows*1..2]->(d:Person) \
+             RETURN DISTINCT d.pid",
+        )
+        .expect("query ok");
+    // b ∈ {1, 4}. From 1: depth 1 = {2}, depth 2 = {3}. From 4: depth 1 = {5}.
+    assert_eq!(
+        ints(&r),
+        vec![2, 3, 5],
+        "a varlen quantifier must be honoured when it is not the first hop"
+    );
+}
+
+// ── #421: shapes deliberately left unsupported must error, not mislead ──────
+
+#[test]
+fn incoming_varlen_in_a_chain_is_rejected() {
+    let mut f = build_fixture(false);
+    // `execute_variable_hops` walks outgoing edges only; answering an incoming
+    // quantifier with outgoing edges would be silently wrong.
+    let r = f.engine.execute(
+        "MATCH (a:Person {pid: 3})<-[:knows*1..2]-(b:Person)-[:livesIn]->(c:City) \
+         RETURN b.pid",
+    );
+    assert!(
+        matches!(r, Err(sparrowdb_common::Error::Unimplemented)),
+        "an incoming variable-length hop must be rejected, not answered; got {r:?}"
+    );
+}
+
+// ── #421: the chunked pipeline must not bypass the new support ───────────────
+
+#[test]
+fn chunked_pipeline_does_not_bypass_varlen_plus_hop() {
+    let mut f = build_fixture(true);
+    let r = f
+        .engine
+        .execute(
+            "MATCH (a:Person {pid: 0})-[:knows*1..2]->(b:Person)-[:livesIn]->(c:City) \
+             RETURN DISTINCT b.pid, c.code",
+        )
+        .expect("query ok");
+    assert_eq!(
+        int_pairs(&r),
+        vec![(1, 10), (2, 20), (4, 20), (5, 10)],
+        "the chunked pipeline must fall back to the varlen chain executor, \
+         not answer the pattern with a plain two-hop plan"
+    );
+}
+
+#[test]
+fn chunked_pipeline_varlen_alone_still_correct() {
+    let mut f = build_fixture(true);
+    let r = f
+        .engine
+        .execute("MATCH (a:Person {pid: 0})-[:knows*1..2]->(b:Person) RETURN DISTINCT b.pid")
+        .expect("query ok");
+    assert_eq!(ints(&r), vec![1, 2, 4, 5]);
+}
+
+// ── #421: OPTIONAL MATCH must not swallow the pattern into NULL rows ─────────
+
+#[test]
+fn optional_match_varlen_plus_hop_returns_real_rows() {
+    let mut f = build_fixture(false);
+    let r = f
+        .engine
+        .execute(
+            "OPTIONAL MATCH (a:Person {pid: 0})-[:knows*1..2]->(b:Person)-[:livesIn]->(c:City) \
+             RETURN DISTINCT b.pid, c.code",
+        )
+        .expect("query ok");
+    assert_eq!(
+        int_pairs(&r),
+        vec![(1, 10), (2, 20), (4, 20), (5, 10)],
+        "OPTIONAL MATCH absorbs InvalidArgument into a NULL row, so a rejected \
+         pattern would surface here as nulls rather than an error"
+    );
+}
+
+#[test]
+fn optional_match_varlen_plus_hop_no_match_yields_null_row() {
+    let mut f = build_fixture(false);
+    // Person 3 has no outgoing knows edges, so the varlen expansion is empty.
+    let r = f
+        .engine
+        .execute(
+            "OPTIONAL MATCH (a:Person {pid: 3})-[:knows*1..2]->(b:Person)-[:livesIn]->(c:City) \
+             RETURN b.pid, c.code",
+        )
+        .expect("query ok");
+    assert_eq!(r.rows.len(), 1, "OPTIONAL MATCH must yield one NULL row");
+    assert!(
+        r.rows[0].iter().all(|v| matches!(v, Value::Null)),
+        "all columns must be NULL; got {:?}",
+        r.rows[0]
+    );
+}
+
+// ── #421: a varlen hop in a pipeline MATCH stage is rejected, not truncated ──
+
+#[test]
+fn pipeline_match_stage_rejects_varlen() {
+    let mut f = build_fixture(false);
+    // `execute_pipeline_match_hop` only ever takes a single step along rels[0]
+    // and ignores the quantifier — the same silent truncation as #421.
+    let err = f.engine.execute(
+        "MATCH (a:Person {pid: 0}) WITH a MATCH (a)-[:knows*1..2]->(b:Person) RETURN b.pid",
+    );
+    match err {
+        Err(sparrowdb_common::Error::InvalidArgument(msg)) => {
+            assert!(
+                msg.contains("421"),
+                "error should name the tracking issue; got {msg}"
+            );
+        }
+        other => panic!("expected InvalidArgument rejecting the pattern, got {other:?}"),
+    }
+}

--- a/crates/sparrowdb/tests/regression_427_shortest_path_heterogeneous.rs
+++ b/crates/sparrowdb/tests/regression_427_shortest_path_heterogeneous.rs
@@ -1,0 +1,307 @@
+//! Regression tests for issue #427 — `shortestPath()` on heterogeneous graphs.
+//!
+//! Two independent faults lived in `Engine::bfs_shortest_path`:
+//!
+//! 1. **The relationship-type filter was discarded.** The BFS called
+//!    `get_node_neighbors_by_slot(..., &[])`; the empty `rel_ids` slice means
+//!    "no type filter", so a BFS for `[:KNOWS*]` walked every edge type in the
+//!    graph.
+//! 2. **Nodes were identified by storage slot alone, without their label.**
+//!    A `NodeId` is `(label_id << 32) | slot`, so slot 0 exists once per label.
+//!    The destination test (`nb_slot == dst_slot`), the zero-hop test
+//!    (`src_slot == dst_slot`) and the `visited` set all compared bare slots,
+//!    so a `City` and a `Person` that happen to occupy the same slot aliased
+//!    each other. That produced both false positives (reporting a path that
+//!    does not exist) and silent pruning (dropping the only real path).
+//!
+//! Every expected value below is derived **by hand** from the fixture defined
+//! in [`build_graph`] — none of it was captured from program output. The
+//! derivation is spelled out in each test's comment.
+//!
+//! No-path contract: `shortestPath()` evaluates to `Value::Null` when no path
+//! exists (openCypher semantics, and what `spa_136_shortest_path.rs` and
+//! `spa_139_phase9_path_acceptance.rs` already assert).
+
+use sparrowdb::open;
+use sparrowdb_execution::types::Value;
+
+// ── Fixture ─────────────────────────────────────────────────────────────────
+//
+// Three node labels, four relationship types, and a deliberately isolated node.
+//
+// Slots are assigned per label in creation order, so the fixture is written so
+// that slot collisions ACROSS labels are unavoidable — that is the whole point.
+//
+//   Person slots: 0 Alice  1 Bob  2 Carol  3 Dave  4 Erin  5 Frank  6 Grace
+//   City   slots: 0 Metro   1 Junction
+//   Post   slots: 0 Hello
+//
+// Edges (creation order matters for the pruning test — see `Post`/`Person`
+// collision on slot 0 below):
+//
+//   e1  Alice -[:LIVES_IN]-> Junction     Person 0 -> City 1
+//   e2  Alice -[:KNOWS]->    Bob          Person 0 -> Person 1
+//   e3  Bob   -[:KNOWS]->    Carol        Person 1 -> Person 2
+//   e4  Carol -[:KNOWS]->    Dave         Person 2 -> Person 3
+//   e5  Dave  -[:LIVES_IN]-> Metro        Person 3 -> City 0
+//   e6  Dave  -[:LIKES]->    Hello        Person 3 -> Post 0
+//   e7  Erin  -[:LIVES_IN]-> Metro        Person 4 -> City 0
+//   e8  Alice -[:FOLLOWS]->  Erin         Person 0 -> Person 4
+//   e9  Bob   -[:MENTIONS]-> Hello        Person 1 -> Post 0     <-- created first
+//   e10 Bob   -[:MENTIONS]-> Alice        Person 1 -> Person 0   <-- same slot (0)
+//   e11 Alice -[:MENTIONS]-> Carol        Person 0 -> Person 2
+//   e12 Alice -[:MENTIONS]-> Frank        Person 0 -> Person 5
+//
+// Grace (Person 6) has no edges at all.
+//
+// The complete KNOWS sub-graph is the one-directional chain
+//   Alice -> Bob -> Carol -> Dave
+// so under `[:KNOWS*]`:
+//   * Erin, Frank, every City and every Post are unreachable from anywhere;
+//   * Dave and Erin have no outgoing KNOWS edge at all;
+//   * there is no route back from Carol or Dave to Alice.
+
+fn build_graph() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+
+    // Nodes — creation order fixes the per-label slot numbers listed above.
+    for name in ["Alice", "Bob", "Carol", "Dave", "Erin", "Frank", "Grace"] {
+        db.execute(&format!("CREATE (p:Person {{name: '{name}'}})"))
+            .expect("CREATE Person");
+    }
+    for name in ["Metro", "Junction"] {
+        db.execute(&format!("CREATE (c:City {{name: '{name}'}})"))
+            .expect("CREATE City");
+    }
+    db.execute("CREATE (p:Post {name: 'Hello'})")
+        .expect("CREATE Post");
+
+    // Edges, in the order documented above.
+    let edges: [(&str, &str, &str, &str, &str); 12] = [
+        ("Person", "Alice", "LIVES_IN", "City", "Junction"),
+        ("Person", "Alice", "KNOWS", "Person", "Bob"),
+        ("Person", "Bob", "KNOWS", "Person", "Carol"),
+        ("Person", "Carol", "KNOWS", "Person", "Dave"),
+        ("Person", "Dave", "LIVES_IN", "City", "Metro"),
+        ("Person", "Dave", "LIKES", "Post", "Hello"),
+        ("Person", "Erin", "LIVES_IN", "City", "Metro"),
+        ("Person", "Alice", "FOLLOWS", "Person", "Erin"),
+        ("Person", "Bob", "MENTIONS", "Post", "Hello"),
+        ("Person", "Bob", "MENTIONS", "Person", "Alice"),
+        ("Person", "Alice", "MENTIONS", "Person", "Carol"),
+        ("Person", "Alice", "MENTIONS", "Person", "Frank"),
+    ];
+    for (src_label, src_name, rel, dst_label, dst_name) in edges {
+        db.execute(&format!(
+            "MATCH (s:{src_label} {{name: '{src_name}'}}), \
+                   (d:{dst_label} {{name: '{dst_name}'}}) \
+             CREATE (s)-[:{rel}]->(d)"
+        ))
+        .expect("CREATE edge");
+    }
+
+    (dir, db)
+}
+
+/// Run `shortestPath((s)-[:REL*]->(d))` between two named nodes and return the
+/// single scalar it produced.
+fn sp(
+    db: &sparrowdb::GraphDb,
+    src_label: &str,
+    src_name: &str,
+    rel: &str,
+    dst_label: &str,
+    dst_name: &str,
+) -> Value {
+    let q = format!(
+        "MATCH (s:{src_label} {{name: '{src_name}'}}), \
+               (d:{dst_label} {{name: '{dst_name}'}}) \
+         RETURN shortestPath((s)-[:{rel}*]->(d))"
+    );
+    let result = db.execute(&q).expect("shortestPath query must not error");
+    assert_eq!(result.rows.len(), 1, "expected exactly one row for: {q}");
+    assert_eq!(
+        result.rows[0].len(),
+        1,
+        "expected exactly one column for: {q}"
+    );
+    result.rows[0][0].clone()
+}
+
+// ── Fault 1: the relationship-type filter must be honoured ──────────────────
+
+/// Alice reaches Erin in one hop — but only over `FOLLOWS` (e8), never over
+/// `KNOWS`. The KNOWS closure of Alice is exactly {Bob, Carol, Dave} (e2, e3,
+/// e4), so Erin is not in it and `shortestPath((Alice)-[:KNOWS*]->(Erin))` has
+/// no path: NULL.
+///
+/// Both endpoints are `Person`, so label aliasing cannot explain a wrong
+/// answer here — this isolates fault 1. Before the fix the BFS ignored the
+/// type and crossed the FOLLOWS edge, reporting 1.
+#[test]
+fn rel_type_filter_is_applied_between_same_label_nodes() {
+    let (_dir, db) = build_graph();
+    assert_eq!(
+        sp(&db, "Person", "Alice", "KNOWS", "Person", "Erin"),
+        Value::Null,
+        "Erin is reachable from Alice only via FOLLOWS; [:KNOWS*] must find no path"
+    );
+}
+
+/// The exact reproduction from issue #427.
+///
+/// Dave's only outgoing edges are `LIVES_IN` -> Metro (e5) and `LIKES` ->
+/// Hello (e6). He has no outgoing `KNOWS` edge at all, so under `[:KNOWS*]`
+/// his frontier is empty at depth 1 and nothing is reachable: NULL.
+///
+/// Before the fix both faults combined: the type filter was dropped, so Dave's
+/// neighbours were City slot 0 and Post slot 0; the destination Alice is
+/// Person slot 0; the bare-slot comparison matched and the query returned 1.
+#[test]
+fn source_with_no_edge_of_queried_type_has_no_path() {
+    let (_dir, db) = build_graph();
+    assert_eq!(
+        sp(&db, "Person", "Dave", "KNOWS", "Person", "Alice"),
+        Value::Null,
+        "Dave has no outgoing KNOWS edge, so no KNOWS path to Alice exists"
+    );
+}
+
+// ── Fault 2: nodes must be identified by (slot, label), not slot ────────────
+
+/// Erin's only outgoing edge is `LIVES_IN` -> Metro (e7), and Metro has no
+/// outgoing edges at all. So `shortestPath((Erin)-[:LIVES_IN*]->(Alice))` has
+/// no path: NULL.
+///
+/// This isolates fault 2. Erin has exactly one outgoing edge and it is of the
+/// queried type, so discarding the type filter changes nothing — the only way
+/// to get a wrong answer is the destination test. Metro is City slot 0 and
+/// Alice is Person slot 0; before the fix `nb_slot == dst_slot` matched and the
+/// query returned 1.
+#[test]
+fn destination_match_requires_the_label_to_agree() {
+    let (_dir, db) = build_graph();
+    assert_eq!(
+        sp(&db, "Person", "Erin", "LIVES_IN", "Person", "Alice"),
+        Value::Null,
+        "Erin's LIVES_IN neighbour is Metro (City), not Alice (Person)"
+    );
+}
+
+/// Alice is Person slot 0; Metro is City slot 0. They are different nodes and
+/// there is no edge between them: Alice's only `LIVES_IN` edge is e1, to
+/// Junction, and Junction has no outgoing edges. So
+/// `shortestPath((Alice)-[:LIVES_IN*]->(Metro))` has no path: NULL.
+///
+/// Before the fix the zero-hop shortcut `if src_slot == dst_slot { Some(0) }`
+/// fired on the bare slot and returned 0 — claiming the source and the
+/// destination were the same node.
+#[test]
+fn zero_hop_shortcut_requires_the_label_to_agree() {
+    let (_dir, db) = build_graph();
+    assert_eq!(
+        sp(&db, "Person", "Alice", "LIVES_IN", "City", "Metro"),
+        Value::Null,
+        "Person slot 0 (Alice) and City slot 0 (Metro) are different nodes"
+    );
+}
+
+/// The silent half of fault 2: a real path being pruned away.
+///
+/// Bob has two outgoing `MENTIONS` edges: e9 to Hello (Post slot 0) and e10 to
+/// Alice (Person slot 0). Alice in turn mentions Frank (e12). Bob has no
+/// `MENTIONS` edge to Frank, and Hello has no outgoing edges at all, so
+/// `shortestPath((Bob)-[:MENTIONS*]->(Frank))` = **2**: Bob -> Alice -> Frank.
+///
+/// Before the fix the two hop-1 neighbours collapsed into one:
+/// `get_node_neighbors_by_slot` returns a `HashSet<u64>` of bare slots, so
+/// `{Post 0, Person 0}` became the single entry `0`. The neighbour's label was
+/// then recovered by taking the first delta record with that destination slot
+/// — e9, created first, i.e. the Post. Alice was therefore never expanded, the
+/// frontier died at the dead-end Post, and the query returned NULL for a path
+/// that plainly exists. Frank sits at Person slot 5, which no node of any other
+/// label occupies in this fixture, so the destination test cannot rescue it.
+#[test]
+fn slot_aliasing_does_not_prune_the_only_real_path() {
+    let (_dir, db) = build_graph();
+    assert_eq!(
+        sp(&db, "Person", "Bob", "MENTIONS", "Person", "Frank"),
+        Value::Int64(2),
+        "Bob -[:MENTIONS]-> Alice -[:MENTIONS]-> Frank is 2 hops"
+    );
+}
+
+// ── Distances must not be understated by cross-type shortcuts ───────────────
+
+/// The KNOWS chain is Alice -> Bob -> Carol -> Dave (e2, e3, e4), so
+/// `shortestPath((Alice)-[:KNOWS*]->(Dave))` = **3**, and
+/// `shortestPath((Alice)-[:KNOWS*]->(Bob))` = **1**.
+///
+/// Before the fix the 3-hop answer came back as 2: with the type filter gone,
+/// Alice's `MENTIONS` edge to Carol (e11) was treated as a KNOWS hop, giving
+/// Alice -> Carol -> Dave. That is the "understates real distances" half of
+/// the issue. The 1-hop assertion is the control that the fix does not
+/// over-filter and lose genuine KNOWS edges.
+#[test]
+fn distance_is_not_understated_by_other_edge_types() {
+    let (_dir, db) = build_graph();
+    assert_eq!(
+        sp(&db, "Person", "Alice", "KNOWS", "Person", "Bob"),
+        Value::Int64(1),
+        "Alice -[:KNOWS]-> Bob is a direct edge"
+    );
+    assert_eq!(
+        sp(&db, "Person", "Alice", "KNOWS", "Person", "Dave"),
+        Value::Int64(3),
+        "Alice -> Bob -> Carol -> Dave is 3 KNOWS hops; the MENTIONS shortcut \
+         Alice -> Carol must not count"
+    );
+}
+
+// ── Unreachable pairs ───────────────────────────────────────────────────────
+
+/// Grace (Person slot 6) has no edges whatsoever, so nothing reaches her:
+/// `shortestPath((Alice)-[:KNOWS*]->(Grace))` is NULL.
+///
+/// The KNOWS chain is one-directional, so there is also no route back from
+/// Carol to Alice: Carol's only outgoing KNOWS edge is e4 to Dave, and Dave has
+/// no outgoing KNOWS edge. `shortestPath((Carol)-[:KNOWS*]->(Alice))` is NULL.
+///
+/// Before the fix the Grace assertion already passed on its own (no node of any
+/// label occupies slot 6 in the reachable set) — it is the honest control here.
+/// The Carol assertion returned 2: with the type filter gone,
+/// Carol -> Dave -> Metro (City slot 0) matched destination Alice (Person slot
+/// 0) at depth 2, so the test as a whole failed before the fix.
+#[test]
+fn unreachable_pairs_return_null() {
+    let (_dir, db) = build_graph();
+    assert_eq!(
+        sp(&db, "Person", "Alice", "KNOWS", "Person", "Grace"),
+        Value::Null,
+        "Grace has no edges; no path can reach her"
+    );
+    assert_eq!(
+        sp(&db, "Person", "Carol", "KNOWS", "Person", "Alice"),
+        Value::Null,
+        "the KNOWS chain is one-directional; there is no route back to Alice"
+    );
+}
+
+// ── A relationship type that does not exist at all ──────────────────────────
+
+/// `SPEAKS_TO` is not in the catalog, so no edge of that type can exist and
+/// `shortestPath((Alice)-[:SPEAKS_TO*]->(Bob))` is NULL — even though Alice and
+/// Bob are one KNOWS hop apart.
+///
+/// Before the fix the type name was ignored entirely, so this walked the KNOWS
+/// edge and returned 1.
+#[test]
+fn unknown_relationship_type_yields_no_path() {
+    let (_dir, db) = build_graph();
+    assert_eq!(
+        sp(&db, "Person", "Alice", "SPEAKS_TO", "Person", "Bob"),
+        Value::Null,
+        "no SPEAKS_TO edges exist in the graph"
+    );
+}

--- a/crates/sparrowdb/tests/regression_427_shortest_path_heterogeneous.rs
+++ b/crates/sparrowdb/tests/regression_427_shortest_path_heterogeneous.rs
@@ -27,7 +27,13 @@ use sparrowdb_execution::types::Value;
 
 // ── Fixture ─────────────────────────────────────────────────────────────────
 //
-// Three node labels, four relationship types, and a deliberately isolated node.
+// Three node labels (Person, City, Post), five relationship types (KNOWS,
+// LIVES_IN, LIKES, FOLLOWS, MENTIONS) and a deliberately isolated node.
+//
+// MENTIONS deliberately spans two label pairs — Person->Post (e9) and
+// Person->Person (e10, e11, e12) — so the catalog registers it as two separate
+// relationship tables that a traversal has to merge without confusing their
+// destination labels.
 //
 // Slots are assigned per label in creation order, so the fixture is written so
 // that slot collisions ACROSS labels are unavoidable — that is the whole point.

--- a/crates/sparrowdb/tests/regression_427_shortest_path_heterogeneous.rs
+++ b/crates/sparrowdb/tests/regression_427_shortest_path_heterogeneous.rs
@@ -305,3 +305,48 @@ fn unknown_relationship_type_yields_no_path() {
         "no SPEAKS_TO edges exist in the graph"
     );
 }
+
+// ── The same answers must hold once the graph is checkpointed ───────────────
+
+/// `checkpoint()` moves every edge out of the delta log and into the per-rel-type
+/// CSR files. The delta log carries full `NodeId`s, so a neighbour's label can be
+/// read straight off it; a CSR entry is a bare slot, so the label has to come
+/// from somewhere else. The answers must not change.
+///
+/// Every expectation below is the same hand derivation as the tests above,
+/// re-asserted against CSR-backed storage:
+///   * Alice -[:LIVES_IN]-> Junction (e1) is one hop, and Junction is a `City`
+///     while Alice is a `Person` — a cross-label destination, which is precisely
+///     the case a slot-only comparison cannot express.
+///   * Dave has no outgoing KNOWS edge, so no KNOWS path reaches Alice.
+///   * Alice -> Bob -> Carol -> Dave is 3 KNOWS hops.
+///   * Bob -> Alice -> Frank is 2 MENTIONS hops. `MENTIONS` spans two label
+///     pairs here (Person->Post via e9 and Person->Person via e10/e11/e12), so
+///     it is registered as two separate relationship tables — the traversal has
+///     to merge both and keep each one's destination label straight.
+#[test]
+fn answers_are_unchanged_after_checkpoint() {
+    let (_dir, db) = build_graph();
+    db.checkpoint().expect("checkpoint");
+
+    assert_eq!(
+        sp(&db, "Person", "Alice", "LIVES_IN", "City", "Junction"),
+        Value::Int64(1),
+        "Alice -[:LIVES_IN]-> Junction is a direct cross-label edge"
+    );
+    assert_eq!(
+        sp(&db, "Person", "Dave", "KNOWS", "Person", "Alice"),
+        Value::Null,
+        "Dave has no outgoing KNOWS edge"
+    );
+    assert_eq!(
+        sp(&db, "Person", "Alice", "KNOWS", "Person", "Dave"),
+        Value::Int64(3),
+        "Alice -> Bob -> Carol -> Dave is 3 KNOWS hops"
+    );
+    assert_eq!(
+        sp(&db, "Person", "Bob", "MENTIONS", "Person", "Frank"),
+        Value::Int64(2),
+        "Bob -[:MENTIONS]-> Alice -[:MENTIONS]-> Frank is 2 hops"
+    );
+}

--- a/crates/sparrowdb/tests/regression_slot_identity_root_cause.rs
+++ b/crates/sparrowdb/tests/regression_slot_identity_root_cause.rs
@@ -1,0 +1,383 @@
+//! Regression tests for the shared root cause behind #415, #427, #429 and #431:
+//! **slot identity treated as node identity**.
+//!
+//! A `NodeId` is `(label_id << 32) | slot`, so slot 2 exists independently in
+//! `Person`, `Place`, `Org` and every other label.  The neighbour lookups in
+//! `engine/mod.rs` used to take a bare slot with no label
+//! (`csr_neighbors_all` / `csr_neighbors_filtered`) and return bare slots, so
+//! every caller inherited two defects at once:
+//!
+//! 1. **Reading another label's edges.** A `CsrForward` is indexed by the source
+//!    slot of *one* relationship table.  Probing every table with a bare slot
+//!    lets a `Person` inherit the edges of the `Org` in the same slot number
+//!    (#429).
+//! 2. **Losing the neighbour's label.** Callers then had to reconstruct it,
+//!    which `get_node_neighbors_labeled` did from delta-log hints, falling back
+//!    to the *source's* label.  `checkpoint()` truncates the delta log, so after
+//!    a checkpoint every hint vanishes and every CSR neighbour silently takes
+//!    the source's label (#431).
+//!
+//! The fix threads `(slot, label_id)` through the neighbour APIs and reads both
+//! labels off the catalog, which registers every relationship table as
+//! `(id, src_label_id, dst_label_id, rel_type)`.  For a CSR hit the destination
+//! label is therefore *known*, and a table whose `src_label_id` does not match
+//! is skipped before its CSR is ever touched.
+//!
+//! **Every expected value below is derived by hand from [`build_graph`].**  None
+//! of it was captured from program output; each test spells out the derivation.
+//!
+//! The fixture has four node labels, three relationship *types* across four
+//! relationship *tables*, and every assertion is made both before and after
+//! `checkpoint()` — #431 only exists after a checkpoint, and #429's CSR
+//! contamination only exists after a checkpoint too, because the delta log
+//! carries full `NodeId`s and was already filtered by source label.
+
+use sparrowdb::open;
+use sparrowdb_execution::types::{QueryResult, Value};
+
+// ── Fixture ─────────────────────────────────────────────────────────────────
+//
+// Four node labels (Person, Place, Org, Post) and three relationship types
+// (KNOWS, LOCATED_IN, LIKES).  LOCATED_IN deliberately spans two label pairs,
+// so the catalog registers **four** relationship tables:
+//
+//   T1  (Person) -[:KNOWS]->      (Person)
+//   T2  (Person) -[:LOCATED_IN]-> (Place)
+//   T3  (Org)    -[:LOCATED_IN]-> (Place)
+//   T4  (Person) -[:LIKES]->      (Post)
+//
+// Slots are assigned per label in creation order, so the collisions below are
+// deliberate and unavoidable — they are the whole point of the fixture:
+//
+//   Person slots: 0 Alice        1 Bob        2 Carol
+//   Place  slots: 0 Springfield  1 Berlin     2 Kyoto
+//   Org    slots: 0 OrgZero      1 OrgOne     2 TechStart
+//   Post   slots: 0 PostZero
+//
+//   * Person 2 (Carol) and Org 2 (TechStart) both exist and are connected
+//     differently by the *same* relationship type — Carol to Kyoto, TechStart
+//     to Berlin.  That is the #429 collision.
+//   * Slot 0 is occupied in all four labels at once.
+//
+// Edges:
+//
+//   e1  Alice     -[:KNOWS]->      Bob          Person 0 -> Person 1
+//   e2  Bob       -[:KNOWS]->      Carol        Person 1 -> Person 2
+//   e3  Alice     -[:LOCATED_IN]-> Springfield  Person 0 -> Place  0
+//   e4  Bob       -[:LOCATED_IN]-> Springfield  Person 1 -> Place  0
+//   e5  Carol     -[:LOCATED_IN]-> Kyoto        Person 2 -> Place  2
+//   e6  TechStart -[:LOCATED_IN]-> Berlin       Org    2 -> Place  1   <-- slot 2
+//   e7  Alice     -[:LIKES]->      PostZero     Person 0 -> Post   0
+//
+// Nothing in the graph has an outgoing edge from any Place or Post, and OrgZero
+// and OrgOne have no edges at all.
+
+fn build_graph() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+
+    // Nodes — creation order fixes the per-label slot numbers listed above.
+    for name in ["Alice", "Bob", "Carol"] {
+        db.execute(&format!("CREATE (p:Person {{name: '{name}'}})"))
+            .expect("CREATE Person");
+    }
+    for name in ["Springfield", "Berlin", "Kyoto"] {
+        db.execute(&format!("CREATE (c:Place {{name: '{name}'}})"))
+            .expect("CREATE Place");
+    }
+    for name in ["OrgZero", "OrgOne", "TechStart"] {
+        db.execute(&format!("CREATE (o:Org {{name: '{name}'}})"))
+            .expect("CREATE Org");
+    }
+    db.execute("CREATE (t:Post {name: 'PostZero'})")
+        .expect("CREATE Post");
+
+    let edges: [(&str, &str, &str, &str, &str); 7] = [
+        ("Person", "Alice", "KNOWS", "Person", "Bob"),
+        ("Person", "Bob", "KNOWS", "Person", "Carol"),
+        ("Person", "Alice", "LOCATED_IN", "Place", "Springfield"),
+        ("Person", "Bob", "LOCATED_IN", "Place", "Springfield"),
+        ("Person", "Carol", "LOCATED_IN", "Place", "Kyoto"),
+        ("Org", "TechStart", "LOCATED_IN", "Place", "Berlin"),
+        ("Person", "Alice", "LIKES", "Post", "PostZero"),
+    ];
+    for (src_label, src_name, rel, dst_label, dst_name) in edges {
+        db.execute(&format!(
+            "MATCH (s:{src_label} {{name: '{src_name}'}}), \
+                   (d:{dst_label} {{name: '{dst_name}'}}) \
+             CREATE (s)-[:{rel}]->(d)"
+        ))
+        .expect("CREATE edge");
+    }
+
+    (dir, db)
+}
+
+/// Collect column `col` of a result as a sorted `Vec<String>`.
+///
+/// Sorted because none of these queries specifies an ORDER BY, so row order is
+/// not part of the contract; the *set* of rows is what the derivations pin down.
+fn sorted_col(result: &QueryResult, col: usize) -> Vec<String> {
+    let mut v: Vec<String> = result
+        .rows
+        .iter()
+        .map(|row| match &row[col] {
+            Value::String(s) => s.clone(),
+            other => panic!("expected a string in column {col}, got {other:?}"),
+        })
+        .collect();
+    v.sort();
+    v
+}
+
+fn query(db: &sparrowdb::GraphDb, q: &str) -> QueryResult {
+    db.execute(q)
+        .unwrap_or_else(|e| panic!("query failed: {q}\n{e:?}"))
+}
+
+// ── #429: a 3-hop chain must not inherit another label's edges ──────────────
+
+/// The exact #429 shape: three inline fixed hops, the last one over a
+/// relationship type that exists for two different source labels.
+///
+/// Derivation:
+///   * hop 1 — Alice (Person 0) `-[:KNOWS]->` Bob (Person 1), via e1.  Alice's
+///     only other edges are e3 (LOCATED_IN) and e7 (LIKES), neither of which is
+///     KNOWS, so Bob is the only hop-1 node.
+///   * hop 2 — Bob (Person 1) `-[:KNOWS]->` Carol (Person 2), via e2.
+///   * hop 3 — Carol (Person 2) `-[:LOCATED_IN]->` Kyoto (Place 2), via e5.
+///     That is Carol's only edge of any type.
+///
+/// So exactly **one** row: `(Carol, Kyoto)`.
+///
+/// Berlin must not appear.  Berlin is reachable in this graph only from
+/// TechStart, which is **Org** slot 2 — the same slot number as Carol, who is
+/// **Person** slot 2.  Before the fix hop 3 resolved LOCATED_IN by type name
+/// alone, giving both T2 and T3, then probed both CSRs with the bare slot `2`,
+/// so Carol collected TechStart's edge and the query returned two rows.
+///
+/// The contamination is CSR-only, hence the checkpoint: the delta log stores
+/// full `NodeId`s and was already filtered by source label, so the same query
+/// was correct before `checkpoint()` and wrong after it.
+#[test]
+fn three_hop_chain_does_not_inherit_another_labels_edges() {
+    let (_dir, db) = build_graph();
+    let q = "MATCH (a:Person {name: 'Alice'})-[:KNOWS]->(b:Person)\
+             -[:KNOWS]->(c:Person)-[:LOCATED_IN]->(pl:Place) \
+             RETURN c.name, pl.name";
+
+    // Uncheckpointed (delta-backed).
+    let before = query(&db, q);
+    assert_eq!(
+        sorted_col(&before, 1),
+        vec!["Kyoto".to_string()],
+        "Carol lives in Kyoto (e5); Berlin belongs to TechStart (Org slot 2)"
+    );
+    assert_eq!(sorted_col(&before, 0), vec!["Carol".to_string()]);
+
+    // Checkpointed (CSR-backed) — the answer must not change.
+    db.checkpoint().expect("checkpoint");
+    let after = query(&db, q);
+    assert_eq!(
+        sorted_col(&after, 1),
+        vec!["Kyoto".to_string()],
+        "after checkpoint the edges live in per-table CSRs indexed by source \
+         slot; Person slot 2 must not read Org slot 2's row"
+    );
+    assert_eq!(sorted_col(&after, 0), vec!["Carol".to_string()]);
+}
+
+/// The half of #429 that narrowing at the call site could not reach: an
+/// **unlabeled** intermediate node.  With `(b)` and `(c)` carrying no label
+/// there is nothing to narrow the relationship-table set against, so a fix that
+/// resolves `(src_label, dst_label, rel_type)` from the *pattern* has no
+/// information to work with.  Deriving the label from the catalog does.
+///
+/// Same derivation as above — the pattern matches the same single path
+/// Alice -> Bob -> Carol -> Kyoto — so the answer is the same one row, `Kyoto`.
+#[test]
+fn unlabeled_intermediates_do_not_inherit_another_labels_edges() {
+    let (_dir, db) = build_graph();
+    db.checkpoint().expect("checkpoint");
+
+    let result = query(
+        &db,
+        "MATCH (a:Person {name: 'Alice'})-[:KNOWS]->(b)-[:KNOWS]->(c)\
+         -[:LOCATED_IN]->(pl:Place) RETURN pl.name",
+    );
+    assert_eq!(
+        sorted_col(&result, 0),
+        vec!["Kyoto".to_string()],
+        "the traversal reaches Carol (Person 2), whose only LOCATED_IN edge is \
+         to Kyoto; TechStart (Org 2) is a different node"
+    );
+}
+
+// ── #431: cross-label variable-length traversal after a checkpoint ──────────
+
+/// A variable-length hop that crosses labels, asserted on both sides of
+/// `checkpoint()`.
+///
+/// Derivation: Alice is Person 0.  Her only LOCATED_IN edge is e3, to
+/// Springfield (Place 0).  Springfield has no outgoing edges, so depth 2 adds
+/// nothing.  `[:LOCATED_IN*1..2]` therefore yields exactly `["Springfield"]`.
+///
+/// Before the fix this returned one row before the checkpoint and **zero** after
+/// it.  `get_node_neighbors_labeled` recovered a CSR neighbour's label from
+/// hints built out of `read_delta_all()`; `checkpoint()` empties the delta log,
+/// so the hint set was empty and every neighbour fell back to the *source's*
+/// label — Person.  `execute_variable_length` then dropped it, because the
+/// destination pattern requires Place.  Silent, and empty in the safe-looking
+/// direction.
+#[test]
+fn cross_label_varlen_survives_checkpoint() {
+    let (_dir, db) = build_graph();
+    let q = "MATCH (p:Person {name: 'Alice'})-[:LOCATED_IN*1..2]->(pl:Place) \
+             RETURN pl.name";
+
+    let before = query(&db, q);
+    assert_eq!(
+        sorted_col(&before, 0),
+        vec!["Springfield".to_string()],
+        "Alice's only LOCATED_IN edge is e3, to Springfield; Springfield has no \
+         outgoing edges so depth 2 adds nothing"
+    );
+
+    db.checkpoint().expect("checkpoint");
+    let after = query(&db, q);
+    assert_eq!(
+        sorted_col(&after, 0),
+        vec!["Springfield".to_string()],
+        "checkpointing moves the edge into a CSR; the destination's label comes \
+         from the catalog, so the answer must be identical"
+    );
+}
+
+/// Both faults at once, in one variable-length query.
+///
+/// Derivation: Carol is Person 2.  Her only LOCATED_IN edge is e5, to Kyoto
+/// (Place 2).  So the answer is exactly `["Kyoto"]`.
+///
+/// Berlin is the trap: it is reached only by e6, from TechStart, which is **Org**
+/// slot 2 — Carol's slot number in a different label.  Before the fix, after a
+/// checkpoint, the traversal probed both LOCATED_IN CSRs with the bare slot `2`
+/// (picking up Berlin) and then relabelled every neighbour as Person (dropping
+/// both), so the query returned nothing at all.
+#[test]
+fn cross_label_varlen_does_not_read_a_colliding_slot() {
+    let (_dir, db) = build_graph();
+    db.checkpoint().expect("checkpoint");
+
+    let result = query(
+        &db,
+        "MATCH (p:Person {name: 'Carol'})-[:LOCATED_IN*1..1]->(pl:Place) \
+         RETURN pl.name",
+    );
+    assert_eq!(
+        sorted_col(&result, 0),
+        vec!["Kyoto".to_string()],
+        "Carol (Person 2) lives in Kyoto; Berlin belongs to TechStart (Org 2)"
+    );
+}
+
+/// Control: the homogeneous case that hid all of this for so long.
+///
+/// Derivation: the KNOWS chain is Alice -> Bob -> Carol (e1, e2).  From Alice,
+/// `[:KNOWS*1..2]` reaches Bob at depth 1 and Carol at depth 2, and nothing
+/// else — Carol has no outgoing KNOWS edge.  So `["Bob", "Carol"]`.
+///
+/// A Person->Person traversal is unaffected by either fault, because the source
+/// label *is* the correct destination label.  This asserts the fix does not
+/// over-filter and lose genuine edges.
+#[test]
+fn homogeneous_varlen_is_unchanged() {
+    let (_dir, db) = build_graph();
+    db.checkpoint().expect("checkpoint");
+
+    let result = query(
+        &db,
+        "MATCH (p:Person {name: 'Alice'})-[:KNOWS*1..2]->(f:Person) RETURN f.name",
+    );
+    assert_eq!(
+        sorted_col(&result, 0),
+        vec!["Bob".to_string(), "Carol".to_string()],
+        "Alice -> Bob is 1 hop and Alice -> Bob -> Carol is 2"
+    );
+}
+
+// ── #427: shortestPath, re-asserted against the shared neighbour lookup ─────
+
+/// `bfs_shortest_path` grew its own catalog-driven neighbour loop in the #427
+/// fix; the root fix replaces it with the shared `get_node_neighbors_labeled`.
+/// These assertions guard that swap — they must keep holding.
+///
+/// Derivations, all after `checkpoint()`:
+///   * `Alice -[:KNOWS*]-> Carol` = **2** (e1 then e2).
+///   * `Carol -[:KNOWS*]-> Alice` = **NULL**.  The KNOWS chain is
+///     one-directional and Carol's only edge is e5, a LOCATED_IN to Kyoto.
+///     Kyoto is Place slot 2 and Alice is Person slot 0, so no slot coincidence
+///     can rescue it either.
+///   * `Alice -[:LOCATED_IN*]-> Springfield` = **1** (e3) — a cross-label
+///     destination, which a slot-only comparison cannot express.
+///   * `Carol -[:LOCATED_IN*]-> Berlin` = **NULL**.  Berlin is reachable only
+///     from TechStart (Org 2); Carol is Person 2.  Reading the colliding slot
+///     would report 1.
+#[test]
+fn shortest_path_still_correct_through_the_shared_lookup() {
+    let (_dir, db) = build_graph();
+    db.checkpoint().expect("checkpoint");
+
+    let sp = |src_label: &str, src: &str, rel: &str, dst_label: &str, dst: &str| -> Value {
+        let q = format!(
+            "MATCH (s:{src_label} {{name: '{src}'}}), (d:{dst_label} {{name: '{dst}'}}) \
+             RETURN shortestPath((s)-[:{rel}*]->(d))"
+        );
+        let r = query(&db, &q);
+        assert_eq!(r.rows.len(), 1, "expected one row for: {q}");
+        r.rows[0][0].clone()
+    };
+
+    assert_eq!(
+        sp("Person", "Alice", "KNOWS", "Person", "Carol"),
+        Value::Int64(2),
+        "Alice -> Bob -> Carol is 2 KNOWS hops"
+    );
+    assert_eq!(
+        sp("Person", "Carol", "KNOWS", "Person", "Alice"),
+        Value::Null,
+        "the KNOWS chain is one-directional"
+    );
+    assert_eq!(
+        sp("Person", "Alice", "LOCATED_IN", "Place", "Springfield"),
+        Value::Int64(1),
+        "Alice -[:LOCATED_IN]-> Springfield is a direct cross-label edge"
+    );
+    assert_eq!(
+        sp("Person", "Carol", "LOCATED_IN", "Place", "Berlin"),
+        Value::Null,
+        "Berlin belongs to TechStart (Org 2), not to Carol (Person 2)"
+    );
+}
+
+// ── One-hop control ─────────────────────────────────────────────────────────
+
+/// The single-hop path resolves `(src_label, dst_label, rel_type)` to one table
+/// already, so it was never exposed to #429.  Asserted anyway so that a
+/// regression in the shared helper cannot pass unnoticed.
+///
+/// Derivation: Carol's only LOCATED_IN edge is e5, to Kyoto.  One row.
+#[test]
+fn one_hop_control_is_unchanged() {
+    let (_dir, db) = build_graph();
+    db.checkpoint().expect("checkpoint");
+
+    let result = query(
+        &db,
+        "MATCH (p:Person {name: 'Carol'})-[:LOCATED_IN]->(pl:Place) RETURN pl.name",
+    );
+    assert_eq!(
+        sorted_col(&result, 0),
+        vec!["Kyoto".to_string()],
+        "Carol -[:LOCATED_IN]-> Kyoto (e5) is her only edge"
+    );
+}

--- a/crates/sparrowdb/tests/regression_slot_identity_root_cause.rs
+++ b/crates/sparrowdb/tests/regression_slot_identity_root_cause.rs
@@ -305,6 +305,158 @@ fn homogeneous_varlen_is_unchanged() {
     );
 }
 
+// ── #421 × #429/#431: varlen hop + trailing hop must not inherit a colliding
+// slot's edges ───────────────────────────────────────────────────────────
+
+/// Collect two string columns as a sorted `Vec<(String, String)>`.
+fn sorted_pairs(result: &QueryResult, col_a: usize, col_b: usize) -> Vec<(String, String)> {
+    let mut v: Vec<(String, String)> = result
+        .rows
+        .iter()
+        .map(|row| {
+            let a = match &row[col_a] {
+                Value::String(s) => s.clone(),
+                other => panic!("expected a string in column {col_a}, got {other:?}"),
+            };
+            let b = match &row[col_b] {
+                Value::String(s) => s.clone(),
+                other => panic!("expected a string in column {col_b}, got {other:?}"),
+            };
+            (a, b)
+        })
+        .collect();
+    v.sort();
+    v
+}
+
+/// #421 taught `execute_n_hop` to answer a variable-length hop followed by a
+/// further hop instead of rejecting it. The root fix in this file made every
+/// fixed-hop neighbour lookup label-aware. Neither guards the intersection on
+/// its own: #421's tests predate this fixture, and before #421 this exact
+/// shape was rejected outright rather than executed (see
+/// `regression_421_varlen_plus_hop::pipeline_match_stage_rejects_varlen`), so
+/// nothing exercises the trailing hop of a varlen chain landing on a
+/// colliding slot except this.
+///
+/// `b` is deliberately **unlabeled**. `rel_ids_per_hop` narrows a fixed hop to
+/// a single catalog table when *both* its endpoint labels are declared — see
+/// the comment above that code, which names this exact fixture (Carol /
+/// TechStart) as the case it exists to head off. With `(b:Person)` the
+/// narrowing hides the bug before the neighbour lookup ever runs; with `(b)`
+/// unlabeled there is nothing to narrow against, so both LOCATED_IN tables
+/// (T2 Person->Place, T3 Org->Place) stay live and the neighbour lookup
+/// itself has to be the thing that filters by source label.
+///
+/// Derivation: Alice's KNOWS chain is Alice(P0) -> Bob(P1) -> Carol(P2) (e1,
+/// e2), so `[:KNOWS*1..2]` binds `b` to {Bob, Carol} — Bob at depth 1, Carol
+/// at depth 2. Bob's only LOCATED_IN edge is e4, to Springfield. Carol's only
+/// LOCATED_IN edge is e5, to Kyoto. So exactly two rows:
+/// `(Bob, Springfield)`, `(Carol, Kyoto)`.
+///
+/// The trap is Carol: she is Person slot 2, the same slot number as TechStart
+/// (Org slot 2), and both have an outgoing LOCATED_IN edge registered under
+/// different catalog tables (T2 via e5, T3 via e6, TechStart -> Berlin). A
+/// trailing-hop neighbour lookup that filtered by bare slot alone, without
+/// checking which table's `src_label_id` actually matches Carol, would pick
+/// up e6 too and add a spurious third row, `(Carol, Berlin)` — after
+/// `checkpoint()` moves the edges into per-table CSRs, exactly where
+/// #429/#431 lived.
+#[test]
+fn varlen_plus_trailing_hop_does_not_read_a_colliding_slot() {
+    let (_dir, db) = build_graph();
+    let q = "MATCH (a:Person {name: 'Alice'})-[:KNOWS*1..2]->(b)\
+             -[:LOCATED_IN]->(pl:Place) RETURN DISTINCT b.name, pl.name";
+
+    // Uncheckpointed (delta-backed) — the delta log stores full NodeIds and
+    // was never subject to the bare-slot bug, so this must already be right.
+    let before = query(&db, q);
+    assert_eq!(
+        sorted_pairs(&before, 0, 1),
+        vec![
+            ("Bob".to_string(), "Springfield".to_string()),
+            ("Carol".to_string(), "Kyoto".to_string()),
+        ],
+        "Bob lives in Springfield (e4); Carol lives in Kyoto (e5); Berlin \
+         belongs to TechStart (Org slot 2), not to Carol (Person slot 2)"
+    );
+
+    // Checkpointed (CSR-backed) — the answer must not change.
+    db.checkpoint().expect("checkpoint");
+    let after = query(&db, q);
+    assert_eq!(
+        sorted_pairs(&after, 0, 1),
+        vec![
+            ("Bob".to_string(), "Springfield".to_string()),
+            ("Carol".to_string(), "Kyoto".to_string()),
+        ],
+        "after checkpoint the edges live in per-table CSRs indexed by source \
+         slot; Carol (Person slot 2) must not read TechStart's (Org slot 2) \
+         row just because the numeric slot matches"
+    );
+}
+
+/// CodeRabbit (#432 review): the fixed-hop branch used to encode an unlabeled
+/// destination's neighbour label as `next_label_id_opt.unwrap_or(0)`. Label id
+/// `0` is a real label — the catalog hands out ids starting at 0, and in this
+/// fixture `Person` (the *first* label `build_graph` creates) **is** label 0
+/// — so `unwrap_or(0)` is not "no label", it is "silently relabel this
+/// neighbour as Person". `read_node_props` then reads whatever Person happens
+/// to occupy the destination's numeric slot instead of the real destination.
+///
+/// Every existing test above resolves its unlabeled positions to Person
+/// nodes, so the wrong default and the right answer coincide by accident and
+/// the bug never surfaces. This test forces the unlabeled destination to
+/// resolve to `Place` (label 1, not 0) so `unwrap_or(0)` and reality diverge.
+///
+/// Derivation, same KNOWS chain as above: `b` ∈ {Bob (P1), Carol (P2)}. Both
+/// `b` and `pl` are unlabeled, so LOCATED_IN stays type-wide (T2 and T3).
+/// Bob's only LOCATED_IN edge is e4, to Springfield (**Place slot 0**).
+/// Carol's only LOCATED_IN edge is e5, to Kyoto (**Place slot 2**). So
+/// exactly two rows: `(Bob, Springfield)`, `(Carol, Kyoto)`.
+///
+/// Under the old code every candidate slot — from either table, delta or CSR
+/// — got relabelled Person (`unwrap_or(0)`), so `pl` would resolve to
+/// whichever Person occupies that slot number instead of the real Place:
+/// Bob's candidate slot is 0 (Springfield's slot), which as a *Person* is
+/// Alice; Carol's candidate slots are 2 from T2 (Kyoto's slot, which as a
+/// Person is Carol herself) and 1 from T3 (Berlin's slot, which as a Person
+/// is Bob). `pl.name` would read "Alice", "Carol" or "Bob" — never a Place at
+/// all. This is not checkpoint-specific: the delta path threw the label away
+/// exactly the same way (`r.dst.0 & 0xFFFF_FFFF` keeps only the slot), so the
+/// bug is present before `checkpoint()` too.
+#[test]
+fn varlen_plus_trailing_hop_unlabeled_destination_does_not_default_to_label_zero() {
+    let (_dir, db) = build_graph();
+    let q = "MATCH (a:Person {name: 'Alice'})-[:KNOWS*1..2]->(b)\
+             -[:LOCATED_IN]->(pl) RETURN DISTINCT b.name, pl.name";
+
+    // Uncheckpointed (delta-backed) — the old bug lived here too: the delta
+    // branch discarded `r.dst`'s label just as thoroughly as the CSR branch.
+    let before = query(&db, q);
+    assert_eq!(
+        sorted_pairs(&before, 0, 1),
+        vec![
+            ("Bob".to_string(), "Springfield".to_string()),
+            ("Carol".to_string(), "Kyoto".to_string()),
+        ],
+        "pl must resolve to the real Place destination, not to whichever \
+         Person happens to occupy the same numeric slot"
+    );
+
+    // Checkpointed (CSR-backed) — the answer must not change.
+    db.checkpoint().expect("checkpoint");
+    let after = query(&db, q);
+    assert_eq!(
+        sorted_pairs(&after, 0, 1),
+        vec![
+            ("Bob".to_string(), "Springfield".to_string()),
+            ("Carol".to_string(), "Kyoto".to_string()),
+        ],
+        "an unlabeled destination must never default to label 0; it must \
+         carry the neighbour's real discovered label"
+    );
+}
+
 // ── #427: shortestPath, re-asserted against the shared neighbour lookup ─────
 
 /// `bfs_shortest_path` grew its own catalog-driven neighbour loop in the #427

--- a/crates/sparrowdb/tests/spa_111_ldbc_ic3_ic14.rs
+++ b/crates/sparrowdb/tests/spa_111_ldbc_ic3_ic14.rs
@@ -75,7 +75,8 @@ fn ic3_friends_in_germany_includes_depth_two_match() {
 
     // Germany is place 3; its residents are persons 4, 6 and 9.
     // Within Alice's 1..2-hop set {2, 3, 4, 5, 6, 7}: person 4 (Dave Brown,
-    // depth 2) and person 6 (Frank Miller, depth 1). Person 9 is 5 hops away.
+    // depth 2) and person 6 (Frank Miller, depth 1). Person 9 is 4 hops away
+    // (1→6→7→8→9).
     // ORDER BY lastName → Brown, Miller.
     let results = ic_queries::ic3_friends_in_countries(&db, 1, "Germany", "France", 14).unwrap();
 

--- a/crates/sparrowdb/tests/spa_111_ldbc_ic3_ic14.rs
+++ b/crates/sparrowdb/tests/spa_111_ldbc_ic3_ic14.rs
@@ -29,22 +29,64 @@ fn load_mini_db() -> (tempfile::TempDir, GraphDb) {
 
 // ── IC3 ─────────────────────────────────────────────────────────────────────
 
+// Fixture facts used by IC3/IC11 below, read by hand out of
+// `crates/sparrowdb-bench/fixtures/ldbc/mini` — never captured from output.
+//
+// person_knows_person_0_0.csv (directed; the loader creates one edge per row):
+//   1→2, 1→3, 1→6, 2→4, 2→5, 3→4, 3→5, 4→6, 5→7, 6→7, 7→8, 8→9, 9→10
+// So from Alice (1): depth 1 = {2, 3, 6}; depth 2 = {4, 5, 7}.
+// `knows*1..2` therefore binds {2, 3, 4, 5, 6, 7}.
+//
+// person_isLocatedIn_place_0_0.csv, with place 1 = United States,
+// 2 = United Kingdom, 3 = Germany:
+//   1→1, 2→2, 3→1, 4→3, 5→2, 6→3, 7→1, 8→2, 9→3, 10→1
+//
+// person_0_0.csv names: 1 Alice Smith, 2 Bob Jones, 3 Carol White,
+//   4 Dave Brown, 5 Eve Davis, 6 Frank Miller, 7 Grace Wilson.
+
 #[test]
-#[ignore = "blocked on #421: this query uses (a)-[:knows*1..2]->(b)-[:isLocatedIn]->(c), \
-which silently returned only depth-1 matches. Now rejected outright rather than \
-answered incompletely. Un-ignore when variable-length + hop traversal is implemented."]
 fn ic3_friends_in_country() {
     let (_dir, db) = load_mini_db();
 
-    // Alice (ldbc_id=1) knows Bob (UK) and Carol (US).
-    // Person 1 is located in US, person 2 in UK.
+    // Alice's 1..2-hop friends are {2, 3, 4, 5, 6, 7}.
+    // In the United Kingdom (place 2): persons 2 (Bob Jones) and 5 (Eve Davis).
+    // The query is `RETURN DISTINCT friend.firstName, friend.lastName
+    // ORDER BY friend.lastName`, so Davis precedes Jones.
     let results =
         ic_queries::ic3_friends_in_countries(&db, 1, "United Kingdom", "Germany", 30).unwrap();
 
-    // Bob (ldbc_id=2) is in UK and is a direct friend of Alice.
-    assert!(
-        !results.is_empty(),
-        "IC3 should find friends in United Kingdom; got empty"
+    assert_eq!(
+        results,
+        vec![
+            ("Eve".to_string(), "Davis".to_string()),
+            ("Bob".to_string(), "Jones".to_string()),
+        ],
+        "IC3(1, United Kingdom): person 2 (Bob Jones, depth 1) and person 5 \
+         (Eve Davis, depth 2) are the UK residents within 2 hops of Alice; got {results:?}"
+    );
+}
+
+/// #421 regression: the depth-2 match must survive the trailing `isLocatedIn`
+/// hop.  Before the fix this returned only `[Frank Miller]` — Dave Brown sits
+/// at depth 2 (1→2→4 and 1→3→4) and was silently dropped.
+#[test]
+fn ic3_friends_in_germany_includes_depth_two_match() {
+    let (_dir, db) = load_mini_db();
+
+    // Germany is place 3; its residents are persons 4, 6 and 9.
+    // Within Alice's 1..2-hop set {2, 3, 4, 5, 6, 7}: person 4 (Dave Brown,
+    // depth 2) and person 6 (Frank Miller, depth 1). Person 9 is 5 hops away.
+    // ORDER BY lastName → Brown, Miller.
+    let results = ic_queries::ic3_friends_in_countries(&db, 1, "Germany", "France", 14).unwrap();
+
+    assert_eq!(
+        results,
+        vec![
+            ("Dave".to_string(), "Brown".to_string()),
+            ("Frank".to_string(), "Miller".to_string()),
+        ],
+        "IC3(1, Germany): Dave Brown is reached at depth 2 and must not be \
+         truncated away by the trailing isLocatedIn hop (#421); got {results:?}"
     );
 }
 
@@ -177,19 +219,52 @@ fn ic10_friend_recommendations() {
 
 // ── IC11 ────────────────────────────────────────────────────────────────────
 
+// IC11 walks `(p)-[:knows*1..2]->(friend)-[:workAt]->(org)-[:isLocatedIn]->(place)`
+// — a variable-length hop followed by *two* fixed hops.
+//
+// person_workAt_organisation_0_0.csv: 1→org1, 2→org1, 3→org2, 4→org3, 5→org1
+// organisation_isLocatedIn_place_0_0.csv: org1→place1, org2→place2, org3→place3
+// organisation_0_0.csv: 1 Acme Corp, 2 University of Oxford, 3 TechStart Inc
+//
+// Alice's 1..2-hop friend set is {2, 3, 4, 5, 6, 7} (see the IC3 notes above).
+
 #[test]
-#[ignore = "blocked on #421: variable-length relationship followed by additional hops. \
-Un-ignore when that traversal shape is implemented."]
 fn ic11_job_referral() {
     let (_dir, db) = load_mini_db();
 
-    // Alice (1) knows Bob (2). Bob works at Acme Corp (org 1) in United States.
-    // Alice (1) -> Bob (2) -> Dave (4). Dave works at TechStart (org 3) in Germany.
+    // United States is place 1, reached only via org 1 (Acme Corp).
+    // Acme employs persons 1, 2 and 5; of those, 2 (Bob Jones, depth 1) and
+    // 5 (Eve Davis, depth 2) are in Alice's friend set — Alice herself is not.
+    // ORDER BY lastName → Davis, Jones.
     let results = ic_queries::ic11_job_referral(&db, 1, "United States", 2005).unwrap();
 
-    assert!(
-        !results.is_empty(),
-        "IC11 should find friends working in US; got empty"
+    assert_eq!(
+        results,
+        vec![
+            ("Eve".to_string(), "Davis".to_string()),
+            ("Bob".to_string(), "Jones".to_string()),
+        ],
+        "IC11(1, United States): Acme Corp is the only US organisation and \
+         employs friends 2 and 5; got {results:?}"
+    );
+}
+
+/// #421 regression: IC11's varlen hop is followed by two fixed hops, so the
+/// depth-2 friend must survive both joins.
+#[test]
+fn ic11_job_referral_germany_is_depth_two_only() {
+    let (_dir, db) = load_mini_db();
+
+    // Germany is place 3, reached only via org 3 (TechStart Inc), which employs
+    // person 4 (Dave Brown) alone.  Dave sits at depth 2 from Alice, so before
+    // #421 was fixed this returned nothing at all.
+    let results = ic_queries::ic11_job_referral(&db, 1, "Germany", 2005).unwrap();
+
+    assert_eq!(
+        results,
+        vec![("Dave".to_string(), "Brown".to_string())],
+        "IC11(1, Germany): TechStart Inc is the only German organisation and \
+         its sole employee, Dave Brown, is a depth-2 friend; got {results:?}"
     );
 }
 


### PR DESCRIPTION
Closes #421, #427. Refs #415, #429, #431.

## Scope update (2026-08-02)

This PR started as the #427 `shortestPath` fix alone, stacked on top of `feat/issue-421-varlen-plus-hop` (#421). It has since absorbed both of the branches it depended on:

- **#421** (variable-length path followed by further hops) is now a commit in this branch's own history (`feat(engine): variable-length path followed by further hops`), not a separate base.
- **#437**'s root-cause fix for the shared `(slot, label)` neighbour-identity bug (#415/#429/#431) was cherry-picked in, because CodeRabbit found the same defect live in this PR's own `execute_n_hop` code: the frontier dropped a resolved label on each hop advance, and the fixed-hop branch used `next_label_id_opt.unwrap_or(0)` — **label id 0 is a real label** (the catalog hands out ids from 0, and in this repo's test fixtures `Person` is usually the first label created, i.e. label 0), so that default silently mislabelled every neighbour whose destination position was unlabeled in the query. `read_node_props` then read whichever node happened to occupy that slot under the wrong label instead of the real destination.
  **Why the original test suite didn't catch it:** every existing test's unlabeled query position happened to resolve to a label-0 node, so the wrong default and the right answer coincided by accident. The bug only becomes observable once you force the unlabeled position to resolve to a *non-zero* label — see `varlen_plus_trailing_hop_unlabeled_destination_does_not_default_to_label_zero` in `regression_slot_identity_root_cause.rs`, which is derived by hand and confirmed to fail against the pre-fix commit (both before and after `checkpoint()` — the delta path discarded the label just as badly as the CSR path).
- Also fixed: `try_plan_chunked_match` ran before `is_var_len_chain` was checked. Verified this specific bypass isn't reachable today (every `can_use_*_chunked` guard already checks `min_hops`, and the parser never produces `max_hops: Some` while leaving `min_hops: None`) — fixed anyway as defence-in-depth so correctness doesn't depend on that invariant holding across three separate guard functions.

`#433` and `#437` are being closed as fully subsumed by this branch (see closing comments on each for the verification).

The original #427-only body follows below for historical detail on that specific fix.

---

`shortestPath()` returned wrong distances, silently, on essentially any real graph — anything with more than one node label or more than one relationship type. Present in published 0.1.16 and 0.1.22.

`shortestPath()` returned wrong distances, silently, on essentially any real graph — anything with more than one node label or more than one relationship type. Present in published 0.1.16 and 0.1.22.

## The two faults

Both in `Engine::bfs_shortest_path` / `eval_shortest_path_expr` (`crates/sparrowdb-execution/src/engine/expr.rs`).

**1. The relationship-type filter was discarded.**

```rust
let neighbors = self.get_node_neighbors_by_slot(node_slot, node_label_id, &delta_idx, &[]);
```

An empty `rel_ids` slice means "no type filter" to the neighbour lookups, so a BFS for `[:knows*]` walked `isLocatedIn`, `likes` and `hasCreator` too. `eval_shortest_path_expr` never looked at `sp.rel_type` at all.

**2. Nodes were identified by storage slot alone.**

A `NodeId` is `(label_id << 32) | slot`, so slots are only unique *within* a label — `Person` slot 0, `City` slot 0 and `Post` slot 0 are three different nodes. Three places compared bare slots:

- the zero-hop shortcut, `if src_slot == dst_slot { return Some(0) }`
- the destination test, `if nb_slot == dst_slot { return Some(depth) }`
- the `visited` set, `HashSet<u64>` keyed on slot

That produced false positives (a `City` standing in for the target `Person`) *and* silent pruning: two neighbours in different labels that share a slot collapsed into one `HashSet<u64>` entry, so the wrong one was expanded and the only real path was dropped. The pruning half is the worse one — it fails to a plausible NULL rather than a visibly wrong number.

## The fix

- `eval_shortest_path_expr` resolves the pattern's relationship type via `resolve_rel_ids_for_type` and threads the IDs into the BFS. A named type that is absent from the catalog short-circuits to no-path rather than falling through to an unfiltered walk of every edge type.
- `eval_shortest_path_expr` keeps the destination's `label_id` instead of masking it off with `& 0xFFFF_FFFF`, and `bfs_shortest_path` takes and compares `(slot, label_id)` pairs in all three places above.
- Neighbour expansion no longer *guesses* labels. The catalog registers each relationship table as `(rel_table_id, src_label_id, dst_label_id, rel_type)` and its CSR holds only that table's edges, so a CSR hit's destination label is known exactly — it is the table's `dst_label_id`. Delta edges keep coming from the delta index, where the full `NodeId` is already present.

That third point matters more than it first looks. The obvious implementation is to reuse the existing `get_node_neighbors_labeled` helper, and the first commit here did. But that helper recovers CSR labels from hints built out of the delta log and otherwise falls back to *the source's* label — and after `checkpoint()` the delta log is empty, so every hint disappears. Cross-label `shortestPath` then returns NULL on any checkpointed graph. Caught on the LDBC mini fixture: `sp(Person 1 -[:isLocatedIn*]-> Place 1)` gave 1 uncheckpointed and NULL checkpointed. Deriving the label from the catalog removes the guesswork entirely.

Skipping relationship tables whose `src_label_id` does not match the node being expanded also closes a second latent fault in the old path: `csr_neighbors_filtered` probed every CSR with the raw slot regardless of label, so `Person` slot 3 also picked up `City` slot 3's outgoing edges.

Two now-dead helpers are removed — `get_node_neighbors_by_slot` (path.rs) and `delta_neighbors_labeled_from_index` (mod.rs). `bfs_shortest_path` was the only caller of each.

## No-path contract

Unchanged: **`Value::Null`**.

That is openCypher semantics and what `spa_136_shortest_path.rs::shortest_path_no_path` and `spa_139_phase9_path_acceptance.rs::shortest_path_null_when_disconnected` already assert. The `-1` contract mentioned in the issue lives one layer up, in `sparrowdb-bench`'s `ic13_shortest_path` wrapper, which maps the engine's scalar to a sentinel — that layer is #422/#423's territory (PR #425).

## Test design

New file: `crates/sparrowdb/tests/regression_427_shortest_path_heterogeneous.rs`.

A purpose-built heterogeneous fixture, no cross-crate dependency: **3 node labels** (`Person`, `City`, `Post`), **5 relationship types** (`KNOWS`, `LIVES_IN`, `LIKES`, `FOLLOWS`, `MENTIONS`), deliberate cross-label slot collisions, an isolated node, and a `MENTIONS` type that spans two label pairs so it registers as two separate relationship tables. Slots are assigned per label in creation order, so the fixture pins them by construction and the full edge list is written out in the header comment.

Every expected value is **derived by hand from the graph**, and the derivation is written into each test's doc comment — nothing was captured from program output. Each test also records what the pre-fix code returned and why.

| Test | Isolates | Asserts | Pre-fix |
|---|---|---|---|
| `rel_type_filter_is_applied_between_same_label_nodes` | fault 1 alone (both endpoints `Person`, so aliasing cannot explain it) | `sp(Alice→Erin)[:KNOWS*]` = NULL | `1`, via the `FOLLOWS` edge |
| `source_with_no_edge_of_queried_type_has_no_path` | both, the issue's exact repro | `sp(Dave→Alice)[:KNOWS*]` = NULL | `1` |
| `destination_match_requires_the_label_to_agree` | fault 2 alone (Erin's one edge *is* the queried type) | `sp(Erin→Alice)[:LIVES_IN*]` = NULL | `1`, City slot 0 matching Person slot 0 |
| `zero_hop_shortcut_requires_the_label_to_agree` | fault 2, `src == dst` shortcut | `sp(Alice→Metro)[:LIVES_IN*]` = NULL | `0` |
| `slot_aliasing_does_not_prune_the_only_real_path` | fault 2, the silent half | `sp(Bob→Frank)[:MENTIONS*]` = 2 | `NULL` |
| `distance_is_not_understated_by_other_edge_types` | understated distance + over-filtering control | `sp(Alice→Bob)` = 1, `sp(Alice→Dave)` = 3 | `1` and **`2`** |
| `unreachable_pairs_return_null` | unreachable pairs | `sp(Alice→Grace)` = NULL, `sp(Carol→Alice)` = NULL | NULL (honest control) and **`2`** |
| `unknown_relationship_type_yields_no_path` | type absent from catalog | `sp(Alice→Bob)[:SPEAKS_TO*]` = NULL | `1` |
| `answers_are_unchanged_after_checkpoint` | CSR-backed storage, incl. cross-label destination | 4 answers re-asserted post-`checkpoint()` | first assertion `1` (accidentally right), `sp(Dave→Alice)` = `1` |

## Proof each test fails without the fix

Not asserted from memory — measured. The three engine files were reverted to their `origin/main` content (`git show 25f3559:… > …`) with the new test file left in place, and the binary re-run:

```
test result: FAILED. 0 passed; 9 failed; 0 ignored
```

All nine fail, and each failure message matches the hand-derived "pre-fix" column above exactly, including `slot_aliasing_does_not_prune_the_only_real_path` failing as `Null` vs `Int64(2)` (the pruning fault) rather than as a wrong number. Sources were then restored byte-exact (`git diff` against the index empty) and re-run: 9 passed.

The issue's own LDBC mini-fixture numbers were reproduced the same way, pre- and post-fix, on the real fixture:

| | pre-fix | post-fix | correct |
|---|---|---|---|
| `sp(10 → 1)` | `Int64(1)` | `Null` | no path |
| `sp(2 → 1)` | `Int64(1)` | `Null` | no path |
| `sp(1 → 10)` | `Int64(5)` | `Int64(5)` | 5 |
| `sp(1 → 2)` | `Int64(1)` | `Int64(1)` | 1 |
| `sp(1 → 4)` | `Int64(2)` | `Int64(2)` | 2 (`spa_111`) |

Pre-fix matches the issue's table exactly. (These LDBC checks were run from a scratch test that is not part of this PR — the committed tests use the self-contained fixture.)

## Fallout

None. No existing test changed behaviour.

`crates/sparrowdb-bench/tests/ldbc_ic_test.rs` has 10 failing tests, but they fail identically before and after this change (6 passed / 10 failed both ways, same test names) — stale `*_stub_returns_empty` assertions from when the IC queries were stubs. Pre-existing on `origin/main` and already being rewritten by #425. Nothing here weakens an assertion to make a suite pass.

## Verification

Isolated target dir throughout (`CARGO_TARGET_DIR=/Volumes/Dev/target-427`, and `/Volumes/Dev/target-427-ldbc` for the final run) so concurrent sibling-agent builds could not contaminate results.

- `cargo test -p sparrowdb-execution --no-fail-fast` — **pass**, 47/4/4/10/5/5/5/10/3 across all binaries, 0 failed
- `cargo fmt --all -- --check` — **clean**
- `cargo clippy --workspace --exclude sparrowdb-ruby --all-targets --keep-going -- -D warnings` — **clean**
- `cargo test -p sparrowdb --test regression_427_shortest_path_heterogeneous` — **9 passed, 0 failed**
- `cargo test -p sparrowdb --no-fail-fast` — **161 of 162 test binaries pass, 1031 tests, 0 failures.**

  This took two passes. The single full-suite invocation was terminated on a harness timeout after 108 binaries (670 tests, 0 failures) while sitting on `spa_222_csr_lazy_load::spa222_mmap_open_and_traverse` — that test builds 50 000 nodes and 100 000 edges one query at a time in a debug build and is slow regardless of this change. Rather than leave the tail unverified, I diffed the binaries the run had reached against `crates/sparrowdb/tests/*.rs` and ran the remaining 58 explicitly: **58/58 binaries, 361 tests, 0 failures, exit 0.** That includes the ones most likely to interact with this change — `spa_268_bfs_bugs`, `spa_289_multi_label`, `spa_354_varlength_terminal_label`, `spa_variable_paths`, `spa_241_multihop_props`, `spa_252_three_hop_binding`, `uc1_social_graph`.

  `spa_222_csr_lazy_load` is the one binary I have not seen go green end-to-end; it is re-running on its own. It contains zero `shortestPath` occurrences and its only query shapes are plain `CREATE`, `MATCH … CREATE`, and a 1-hop `MATCH`, so it is not reachable from anything this PR touches — but I am flagging it rather than implying I verified it.

## Not covered

- `shortestPath((a)-[:R*]->(a))` still returns `0` for a node to itself. `[:R*]` defaults to `*1..`, so openCypher would want NULL unless a cycle exists. Pre-existing behaviour, deliberately left alone — out of scope for this issue and it has its own callers to check.
- Only the outgoing direction is handled, as before. `shortestPath` still does not consider undirected or incoming patterns.
- `max_hops` is still hard-coded to 10 at the call site.
- Tombstoned (deleted) nodes are not filtered out of the traversal. Also pre-existing; unchanged here.
- **The same root confusion lives elsewhere.** `csr_neighbors_filtered` / `csr_neighbors_all` in `engine/mod.rs` take a bare `src_slot` with no label and probe every matching CSR, so every caller inherits it — see #429 (`execute_n_hop` returning a US-based person for a Germany query, because `TechStart Inc` is `Organisation` slot 2) and #415. This PR fixes `shortestPath` at its own call site rather than changing those shared helpers underneath the variable-length and n-hop paths, which are separately owned and separately testable. `get_node_neighbors_labeled` still guesses labels the same way it did; variable-length MATCH across labels on a checkpointed graph is very likely still affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Variable-length relationships can now be followed by additional hops, with support for depth limits, filtering, and optional matches.
  * Shortest-path searches now respect relationship types and both source and destination labels.
  * Traversals preserve node labels across fixed-hop, variable-length, and multi-hop paths.

* **Bug Fixes**
  * Corrected path lengths, zero-hop matching, and handling of nodes sharing slot identifiers.
  * Unknown relationship types no longer cause unrestricted traversal.
  * Unsupported variable-length patterns now return clear errors instead of being silently truncated.
  * Improved consistency before and after checkpointing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
