### PR TITLE
feat(engine): variable-length path followed by further hops (closes #421)

### DIFF
--- a/crates/sparrowdb-execution/src/engine/hop.rs
+++ b/crates/sparrowdb-execution/src/engine/hop.rs
@@ -1737,6 +1737,19 @@ impl Engine {
     ///
     /// This replaces the previous fallthrough to `execute_scan` which only
     /// scanned the first node and ignored all relationship hops.
+    ///
+    /// # Variable-length hops (#421)
+    ///
+    /// Any hop in the chain may carry a variable-length quantifier
+    /// (`-[:R*1..2]->`).  Such a hop expands the frontier with
+    /// [`Engine::execute_variable_hops`] — the same DFS/BFS used by the
+    /// standalone `execute_variable_length` path — instead of taking a single
+    /// step, so `(a)-[:R*1..2]->(b)-[:S]->(c)` binds `b` to every node reachable
+    /// from `a` in 1..2 hops and then joins each of those against the trailing
+    /// `:S` hop.  Before this, `is_var_len` in `execute_match` only recognised a
+    /// quantifier when the varlen relationship was the *only* relationship in
+    /// the pattern, so a trailing hop silently demoted `*1..2` to a plain single
+    /// hop and every depth >= 2 match was dropped without an error.
     pub(crate) fn execute_n_hop(
         &self,
         m: &MatchStatement,
@@ -1810,10 +1823,61 @@ impl Engine {
         // We read all delta edges once up front to avoid repeated file I/O.
         let delta_all = self.read_delta_all();
 
+        // ── #421: variable-length quantifiers anywhere in the chain ──────────
+        //
+        // `Some((min, max))` for a hop written `-[:R*min..max]->`.  An open
+        // upper bound is capped at 10, matching `execute_variable_length`.
+        let varlen_per_hop: Vec<Option<(u32, u32)>> = pat
+            .rels
+            .iter()
+            .map(|r| {
+                if r.min_hops.is_some() || r.max_hops.is_some() {
+                    Some((r.min_hops.unwrap_or(1), r.max_hops.unwrap_or(10)))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let has_varlen = varlen_per_hop.iter().any(Option::is_some);
+
         // Pre-resolve per-hop rel-table IDs so the inner loop uses filtered
         // CSR lookups instead of scanning every relation type (SPA-284).
+        //
+        // #429: a relationship *type* can back several rel tables — LDBC's
+        // `isLocatedIn` exists as both `(Person)->(Place)` and
+        // `(Organisation)->(Place)`.  CSRs are keyed by rel-table id and indexed
+        // by *source slot*, so unioning every table of a given type makes
+        // `Person` slot 2 inherit `Organisation` slot 2's edges.  (Concretely:
+        // Carol White, Person slot 2, appeared to live in Germany because
+        // TechStart Inc is Organisation slot 2.)  When both endpoint labels of a
+        // fixed hop are declared, narrow to the single rel table for that triple
+        // — the same discrimination `resolve_rel_table_id` already gives the
+        // one- and two-hop executors.
+        //
+        // Two cases stay exposed and are tracked in #429: hops whose endpoint
+        // labels are not both declared, and variable-length hops, whose
+        // intermediate nodes are not constrained by the endpoint labels and so
+        // must keep the type-wide set.
         let rel_ids_per_hop: Vec<Vec<u32>> = (0..n_rels)
-            .map(|i| self.resolve_rel_ids_for_type(&pat.rels[i].rel_type))
+            .map(|i| {
+                let type_wide = self.resolve_rel_ids_for_type(&pat.rels[i].rel_type);
+                if varlen_per_hop[i].is_some() || type_wide.len() < 2 {
+                    return type_wide;
+                }
+                match (label_ids_per_node[i], label_ids_per_node[i + 1]) {
+                    (Some(src), Some(dst)) => self
+                        .snapshot
+                        .catalog
+                        .get_rel_table(src as u16, dst as u16, &pat.rels[i].rel_type)
+                        .ok()
+                        .flatten()
+                        .map(|id| vec![id as u32])
+                        // No table for this (src, dst, type) triple: the hop
+                        // cannot match anything.
+                        .unwrap_or_default(),
+                    _ => type_wide,
+                }
+            })
             .collect();
         // If any hop specifies a rel type that doesn't exist in the catalog, no
         // traversal can produce results — return empty immediately.
@@ -1825,6 +1889,33 @@ impl Engine {
                 });
             }
         }
+
+        // `execute_variable_hops` only walks outgoing edges.  Reject rather than
+        // quietly answering an `<-[:R*1..2]-` pattern with the wrong direction.
+        for (i, v) in varlen_per_hop.iter().enumerate() {
+            if v.is_some() && pat.rels[i].dir != sparrowdb_cypher::ast::EdgeDir::Outgoing {
+                return Err(sparrowdb_common::Error::Unimplemented);
+            }
+        }
+
+        // Delta index + label registry used by the variable-length expansion.
+        // Built once (not per source node) and only when a varlen hop exists.
+        let (delta_idx, node_label, all_label_ids) = if has_varlen {
+            let idx = build_delta_index(&delta_all);
+            let mut labels: HashSet<(u64, u32)> = HashSet::new();
+            for r in &delta_all {
+                labels.insert((r.src.0 & 0xFFFF_FFFF, (r.src.0 >> 32) as u32));
+                labels.insert((r.dst.0 & 0xFFFF_FFFF, (r.dst.0 >> 32) as u32));
+            }
+            let mut ids: Vec<u32> = labels.iter().map(|&(_, l)| l).collect();
+            ids.sort_unstable();
+            ids.dedup();
+            (idx, labels, ids)
+        } else {
+            (DeltaIndex::new(), HashSet::new(), Vec::new())
+        };
+        // Reusable neighbor buffer for the variable-length traversal.
+        let mut neighbors_buf: HashSet<(u64, u32)> = HashSet::new();
 
         let mut rows: Vec<Vec<Value>> = Vec::new();
 
@@ -1870,38 +1961,75 @@ impl Engine {
                 let mut next_frontier: Vec<(u64, HashMap<String, Value>)> = Vec::new();
 
                 for (cur_slot, cur_vals) in frontier {
-                    // Gather neighbors from CSR + delta for this hop.
-                    // SPA-284: use filtered CSR lookup when rel type is specified.
-                    let csr_nb: Vec<u64> =
-                        self.csr_neighbors_filtered(cur_slot, &rel_ids_per_hop[hop_idx]);
                     let hop_rel_ids = &rel_ids_per_hop[hop_idx];
-                    let delta_nb: Vec<u64> = delta_all
-                        .iter()
-                        .filter(|r| {
-                            let r_src_label = (r.src.0 >> 32) as u32;
-                            let r_src_slot = r.src.0 & 0xFFFF_FFFF;
-                            if r_src_label != cur_label_id || r_src_slot != cur_slot {
-                                return false;
-                            }
-                            // Filter by relation-table IDs when a type constraint exists.
-                            hop_rel_ids.is_empty() || hop_rel_ids.contains(&r.rel_id.0)
-                        })
-                        .map(|r| r.dst.0 & 0xFFFF_FFFF)
-                        .collect();
 
-                    let mut seen: HashSet<u64> = HashSet::new();
-                    let all_nb: Vec<u64> = csr_nb
-                        .into_iter()
-                        .chain(delta_nb)
-                        .filter(|&nb| seen.insert(nb))
-                        .collect();
+                    // `(slot, resolved_label_id)` candidates for this hop.
+                    let all_nb: Vec<(u64, u32)> = match varlen_per_hop[hop_idx] {
+                        // ── #421: variable-length hop ────────────────────────
+                        Some((min_hops, max_hops)) => {
+                            // Per-path enumeration is only collapsed to
+                            // reachability when the query is DISTINCT and no
+                            // relationship variable is bound — same rule as
+                            // `execute_variable_length` (issue #165).
+                            let use_reachability = m.distinct && pat.rels[hop_idx].var.is_empty();
+                            let reached = self.execute_variable_hops(
+                                cur_slot,
+                                cur_label_id,
+                                min_hops,
+                                max_hops,
+                                &delta_idx,
+                                &node_label,
+                                &all_label_ids,
+                                &mut neighbors_buf,
+                                use_reachability,
+                                usize::MAX,
+                                hop_rel_ids,
+                            );
+                            reached
+                                .into_iter()
+                                .filter_map(|(slot, discovered_label)| {
+                                    match next_label_id_opt {
+                                        // A label on the pattern is a filter:
+                                        // drop nodes whose recovered label differs.
+                                        Some(required) if discovered_label != required => None,
+                                        Some(required) => Some((slot, required)),
+                                        None => Some((slot, discovered_label)),
+                                    }
+                                })
+                                .collect()
+                        }
+                        // ── fixed single hop ─────────────────────────────────
+                        None => {
+                            // Gather neighbors from CSR + delta for this hop.
+                            // SPA-284: use filtered CSR lookup when rel type is specified.
+                            let csr_nb: Vec<u64> =
+                                self.csr_neighbors_filtered(cur_slot, hop_rel_ids);
+                            let delta_nb: Vec<u64> = delta_all
+                                .iter()
+                                .filter(|r| {
+                                    let r_src_label = (r.src.0 >> 32) as u32;
+                                    let r_src_slot = r.src.0 & 0xFFFF_FFFF;
+                                    if r_src_label != cur_label_id || r_src_slot != cur_slot {
+                                        return false;
+                                    }
+                                    // Filter by relation-table IDs when a type constraint exists.
+                                    hop_rel_ids.is_empty() || hop_rel_ids.contains(&r.rel_id.0)
+                                })
+                                .map(|r| r.dst.0 & 0xFFFF_FFFF)
+                                .collect();
 
-                    for next_slot in all_nb {
-                        let next_node_id = if let Some(lbl_id) = next_label_id_opt {
-                            NodeId(((lbl_id as u64) << 32) | next_slot)
-                        } else {
-                            NodeId(next_slot)
-                        };
+                            let mut seen: HashSet<u64> = HashSet::new();
+                            csr_nb
+                                .into_iter()
+                                .chain(delta_nb)
+                                .filter(|&nb| seen.insert(nb))
+                                .map(|nb| (nb, next_label_id_opt.unwrap_or(0)))
+                                .collect()
+                        }
+                    };
+
+                    for (next_slot, next_label_id) in all_nb {
+                        let next_node_id = NodeId(((next_label_id as u64) << 32) | next_slot);
 
                         let next_props =
                             read_node_props(&self.snapshot.store, next_node_id, next_col_ids)?;

--- a/crates/sparrowdb-execution/src/engine/scan.rs
+++ b/crates/sparrowdb-execution/src/engine/scan.rs
@@ -418,6 +418,30 @@ impl Engine {
         if pat.nodes.len() < 2 || pat.rels.is_empty() {
             return Ok(vec![]);
         }
+
+        // #421: this executor takes a single step along `rels[0]` and ignores
+        // any quantifier on it.  A variable-length relationship inside a
+        // pipeline MATCH stage (`WITH … MATCH (a)-[:R*1..2]->(b) …`) would
+        // therefore be answered with depth-1 matches only — the same silent
+        // truncation #421 fixed in the top-level MATCH path.  Reject instead:
+        // an error the caller can see beats data they cannot check.
+        //
+        // It also drops `rels[1..]` of any multi-hop pattern, which is the same
+        // failure without a quantifier; that is tracked separately as #430 and
+        // deliberately left alone here.
+        if pat
+            .rels
+            .iter()
+            .any(|r| r.min_hops.is_some() || r.max_hops.is_some())
+        {
+            return Err(sparrowdb_common::Error::InvalidArgument(
+                "variable-length relationships are not supported inside a pipeline \
+                 MATCH stage (after WITH); run the variable-length pattern in the \
+                 leading MATCH instead — see issue #421"
+                    .to_string(),
+            ));
+        }
+
         let src_pat = &pat.nodes[0];
         let dst_pat = &pat.nodes[1];
         let rel_pat = &pat.rels[0];
@@ -726,27 +750,29 @@ impl Engine {
             });
         }
 
+        // #421: a variable-length quantifier combined with further hops —
+        // `(a)-[:R*1..2]->(b)-[:S]->(c)` — is executed by the chain traversal in
+        // `execute_n_hop`, which expands each varlen hop with
+        // `execute_variable_hops` and joins the result against the remaining
+        // fixed hops.  It must be tested *before* `is_two_hop`/`is_n_hop`:
+        // dispatching on rel count alone is what made `execute_two_hop` demote
+        // `*1..2` to a plain single hop and silently drop every depth >= 2 match.
+        let is_var_len_chain = m.pattern.len() == 1
+            && m.pattern[0].rels.len() > 1
+            && m.pattern[0]
+                .rels
+                .iter()
+                .any(|r| r.min_hops.is_some() || r.max_hops.is_some());
+
         // Determine if this is a 2-hop query.
-        let is_two_hop = m.pattern.len() == 1 && m.pattern[0].rels.len() == 2;
+        let is_two_hop = !is_var_len_chain && m.pattern.len() == 1 && m.pattern[0].rels.len() == 2;
         let is_one_hop = m.pattern.len() == 1 && m.pattern[0].rels.len() == 1;
         // N-hop (3+): generalised iterative traversal (SPA-252).
-        let is_n_hop = m.pattern.len() == 1 && m.pattern[0].rels.len() >= 3;
+        let is_n_hop = !is_var_len_chain && m.pattern.len() == 1 && m.pattern[0].rels.len() >= 3;
         // Detect variable-length path: single pattern with exactly 1 rel that has min_hops set.
         let is_var_len = m.pattern.len() == 1
             && m.pattern[0].rels.len() == 1
             && m.pattern[0].rels[0].min_hops.is_some();
-
-        // #421: `is_var_len` only recognises a variable-length quantifier when it
-        // is the *only* relationship in the pattern. With a trailing hop —
-        // `(a)-[:R*1..2]->(b)-[:S]->(c)` — `rels.len() == 2`, so `is_two_hop`
-        // wins and `execute_two_hop` treats `*1..2` as a plain single hop,
-        // silently discarding every match at depth >= 2 and returning a
-        // plausible but incomplete result set.
-        //
-        // Executing variable-length expansion followed by further hops is not
-        // implemented. Until it is, reject the pattern loudly: a clear error is
-        // far better than quietly wrong data the caller cannot detect.
-        reject_varlen_with_trailing_hops(m)?;
 
         let column_names = extract_return_column_names(&m.return_clause.items);
 
@@ -801,6 +827,9 @@ impl Engine {
 
         if is_var_len {
             self.execute_variable_length(m, &column_names)
+        } else if is_var_len_chain {
+            // #421: varlen expansion + trailing/leading fixed hops.
+            self.execute_n_hop(m, &column_names)
         } else if is_two_hop {
             self.execute_two_hop(m, &column_names)
         } else if is_one_hop {
@@ -1275,12 +1304,6 @@ impl Engine {
         };
 
         let column_names = extract_return_column_names(&om.return_clause.items);
-
-        // #421: this arm swallows InvalidArgument into a NULL row, which would
-        // turn the unsupported-pattern error below into silent nulls — exactly
-        // the silent-wrongness the guard exists to prevent. Check first so the
-        // error propagates instead of being absorbed.
-        reject_varlen_with_trailing_hops(&match_stmt)?;
 
         let result = self.execute_match(&match_stmt);
 
@@ -2727,39 +2750,4 @@ impl Engine {
             .collect();
         Value::List(label_strings)
     }
-}
-
-/// Reject `(a)-[:R*m..n]->(b)-[:S]->(c)` — a variable-length relationship
-/// followed by further hops (#421).
-///
-/// `is_var_len` in `execute_match` only recognises a variable-length quantifier
-/// when the varlen rel is the *only* relationship in the pattern. With a
-/// trailing hop `rels.len() >= 2`, so `is_two_hop`/`is_n_hop` wins and the
-/// quantifier is silently discarded — every match at depth >= 2 disappears and
-/// the caller gets a plausible but incomplete result set.
-///
-/// Executing varlen expansion followed by further hops is not implemented.
-/// Until it is, fail loudly: undetectable wrong data is worse than an error.
-///
-/// Must be called by every path that can dispatch such a pattern. In
-/// particular `execute_optional_match` has to call it *before* delegating,
-/// because that function absorbs `InvalidArgument` into a NULL row and would
-/// otherwise convert this error back into silent wrongness.
-pub(crate) fn reject_varlen_with_trailing_hops(m: &MatchStatement) -> Result<()> {
-    for pat in &m.pattern {
-        if pat.rels.len() > 1
-            && pat
-                .rels
-                .iter()
-                .any(|r| r.min_hops.is_some() || r.max_hops.is_some())
-        {
-            return Err(sparrowdb_common::Error::InvalidArgument(
-                "variable-length relationship followed by additional hops is not supported \
-                 (e.g. (a)-[:R*1..2]->(b)-[:S]->(c)); split the pattern into separate \
-                 MATCH clauses — see issue #421"
-                    .to_string(),
-            ));
-        }
-    }
-    Ok(())
 }

--- a/crates/sparrowdb-execution/tests/regression_421_varlen_plus_hop.rs
+++ b/crates/sparrowdb-execution/tests/regression_421_varlen_plus_hop.rs
@@ -1,0 +1,409 @@
+//! Regression tests for #421 — variable-length path followed by further hops.
+//!
+//! `MATCH (a)-[:R*1..2]->(b)-[:S]->(c)` used to dispatch on relationship count
+//! alone, so `execute_two_hop` demoted `*1..2` to a plain single hop and every
+//! match at depth >= 2 was dropped without an error.
+//!
+//! # Fixture (built by `build_fixture`, all expectations derived from it by hand)
+//!
+//! Six `Person` nodes, slots 0..=5, `pid` = slot.
+//! Two `City` nodes, slots 0..=1, `code` = 10 (slot 0) and 20 (slot 1).
+//!
+//! ```text
+//! knows   (Person→Person):  0→1, 0→4, 1→2, 2→3, 4→5
+//! livesIn (Person→City):    0→c0, 1→c0, 2→c1, 3→c1, 4→c1, 5→c0
+//! ```
+//!
+//! Reachability from person 0 over `knows`:
+//!   depth 1 → {1, 4}
+//!   depth 2 → {2, 5}
+//!   depth 3 → {3}
+//!
+//! So `-[:knows*1..2]->` from person 0 binds `{1, 4, 2, 5}` — the pre-fix code
+//! returned only `{1, 4}`.
+
+use sparrowdb_catalog::catalog::Catalog;
+use sparrowdb_execution::types::Value;
+use sparrowdb_execution::Engine;
+use sparrowdb_storage::csr::CsrForward;
+use sparrowdb_storage::node_store::{NodeStore, Value as StoreValue};
+
+const KNOWS: [(u64, u64); 5] = [(0, 1), (0, 4), (1, 2), (2, 3), (4, 5)];
+const LIVES_IN: [(u64, u64); 6] = [(0, 0), (1, 0), (2, 1), (3, 1), (4, 1), (5, 0)];
+
+/// City code for each city slot.
+const CITY_CODES: [i64; 2] = [10, 20];
+
+struct Fixture {
+    _dir: tempfile::TempDir,
+    engine: Engine,
+}
+
+fn build_fixture(chunked: bool) -> Fixture {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().to_path_buf();
+
+    let pid_col = sparrowdb_common::col_id_of("pid");
+    let code_col = sparrowdb_common::col_id_of("code");
+
+    let (knows_rel, lives_rel) = {
+        let mut store = NodeStore::open(&path).expect("node store");
+        let mut cat = Catalog::open(&path).expect("catalog");
+
+        let person_label = cat.create_label("Person").expect("Person") as u32;
+        let city_label = cat.create_label("City").expect("City") as u32;
+
+        for pid in 0..6i64 {
+            store
+                .create_node(person_label, &[(pid_col, StoreValue::Int64(pid))])
+                .expect("person");
+        }
+        for code in CITY_CODES {
+            store
+                .create_node(city_label, &[(code_col, StoreValue::Int64(code))])
+                .expect("city");
+        }
+
+        let knows_rel = cat
+            .create_rel_table(person_label as u16, person_label as u16, "knows")
+            .expect("knows rel table") as u32;
+        let lives_rel = cat
+            .create_rel_table(person_label as u16, city_label as u16, "livesIn")
+            .expect("livesIn rel table") as u32;
+
+        (knows_rel, lives_rel)
+    };
+
+    // CSR per rel table. Source slots are Person slots in both cases.
+    let mut csrs = std::collections::HashMap::new();
+    csrs.insert(knows_rel, CsrForward::build(6, &KNOWS));
+    csrs.insert(lives_rel, CsrForward::build(6, &LIVES_IN));
+
+    let store = NodeStore::open(&path).expect("reopen store");
+    let cat = Catalog::open(&path).expect("reopen catalog");
+    let engine = Engine::new(store, cat, csrs, &path);
+    let engine = if chunked {
+        engine.with_chunked_pipeline()
+    } else {
+        engine
+    };
+
+    Fixture { _dir: dir, engine }
+}
+
+/// Collect `(int, int)` pairs from a two-column result, sorted for comparison.
+fn int_pairs(result: &sparrowdb_execution::types::QueryResult) -> Vec<(i64, i64)> {
+    let mut out: Vec<(i64, i64)> = result
+        .rows
+        .iter()
+        .map(|row| {
+            let a = match &row[0] {
+                Value::Int64(v) => *v,
+                other => panic!("expected Int64 in column 0, got {other:?}"),
+            };
+            let b = match &row[1] {
+                Value::Int64(v) => *v,
+                other => panic!("expected Int64 in column 1, got {other:?}"),
+            };
+            (a, b)
+        })
+        .collect();
+    out.sort_unstable();
+    out
+}
+
+fn ints(result: &sparrowdb_execution::types::QueryResult) -> Vec<i64> {
+    let mut out: Vec<i64> = result
+        .rows
+        .iter()
+        .map(|row| match &row[0] {
+            Value::Int64(v) => *v,
+            other => panic!("expected Int64, got {other:?}"),
+        })
+        .collect();
+    out.sort_unstable();
+    out
+}
+
+// ── Baseline: the varlen pattern on its own is (and was) correct ─────────────
+
+#[test]
+fn varlen_alone_reaches_depth_two() {
+    let mut f = build_fixture(false);
+    let r = f
+        .engine
+        .execute("MATCH (a:Person {pid: 0})-[:knows*1..2]->(b:Person) RETURN DISTINCT b.pid")
+        .expect("query ok");
+    // depth 1 = {1, 4}; depth 2 = {2, 5}.
+    assert_eq!(
+        ints(&r),
+        vec![1, 2, 4, 5],
+        "knows*1..2 from person 0 reaches 1 and 4 at depth 1, 2 and 5 at depth 2"
+    );
+}
+
+// ── #421: varlen + one trailing hop ──────────────────────────────────────────
+
+#[test]
+fn varlen_plus_trailing_hop_keeps_depth_two_matches() {
+    let mut f = build_fixture(false);
+    let r = f
+        .engine
+        .execute(
+            "MATCH (a:Person {pid: 0})-[:knows*1..2]->(b:Person)-[:livesIn]->(c:City) \
+             RETURN DISTINCT b.pid, c.code",
+        )
+        .expect("query ok");
+
+    // b ∈ {1, 4} at depth 1 and {2, 5} at depth 2.
+    // livesIn: 1→c0(10), 4→c1(20), 2→c1(20), 5→c0(10).
+    assert_eq!(
+        int_pairs(&r),
+        vec![(1, 10), (2, 20), (4, 20), (5, 10)],
+        "every depth-1 and depth-2 friend must be joined to its city; \
+         before #421 was fixed only the depth-1 pair set {{(1,10),(4,20)}} came back"
+    );
+}
+
+#[test]
+fn varlen_plus_trailing_hop_enumerates_paths_without_distinct() {
+    let mut f = build_fixture(false);
+    let r = f
+        .engine
+        .execute(
+            "MATCH (a:Person {pid: 0})-[:knows*1..2]->(b:Person)-[:livesIn]->(c:City) \
+             RETURN b.pid, c.code",
+        )
+        .expect("query ok");
+
+    // Without DISTINCT the traversal enumerates simple paths. From person 0
+    // there is exactly one simple path to each of 1, 4, 2 and 5 within 2 hops
+    // (0→1, 0→4, 0→1→2, 0→4→5), so each contributes exactly one row.
+    assert_eq!(
+        int_pairs(&r),
+        vec![(1, 10), (2, 20), (4, 20), (5, 10)],
+        "one row per simple path"
+    );
+}
+
+#[test]
+fn varlen_plus_trailing_hop_respects_where_on_final_node() {
+    let mut f = build_fixture(false);
+    let r = f
+        .engine
+        .execute(
+            "MATCH (a:Person {pid: 0})-[:knows*1..2]->(b:Person)-[:livesIn]->(c:City) \
+             WHERE c.code = 20 RETURN DISTINCT b.pid",
+        )
+        .expect("query ok");
+    // City code 20 is city slot 1; residents among {1,4,2,5} are 4 and 2.
+    assert_eq!(
+        ints(&r),
+        vec![2, 4],
+        "WHERE on the trailing hop's node must filter the joined rows"
+    );
+}
+
+#[test]
+fn varlen_plus_trailing_hop_respects_inline_prop_on_final_node() {
+    let mut f = build_fixture(false);
+    let r = f
+        .engine
+        .execute(
+            "MATCH (a:Person {pid: 0})-[:knows*1..2]->(b:Person)-[:livesIn]->(c:City {code: 10}) \
+             RETURN DISTINCT b.pid",
+        )
+        .expect("query ok");
+    // City code 10 is city slot 0; residents among {1,4,2,5} are 1 and 5.
+    assert_eq!(
+        ints(&r),
+        vec![1, 5],
+        "inline prop filter on the trailing hop's node must be applied"
+    );
+}
+
+#[test]
+fn varlen_min_two_plus_trailing_hop_excludes_depth_one() {
+    let mut f = build_fixture(false);
+    let r = f
+        .engine
+        .execute(
+            "MATCH (a:Person {pid: 0})-[:knows*2..2]->(b:Person)-[:livesIn]->(c:City) \
+             RETURN DISTINCT b.pid",
+        )
+        .expect("query ok");
+    assert_eq!(
+        ints(&r),
+        vec![2, 5],
+        "min_hops = 2 must exclude the direct friends 1 and 4"
+    );
+}
+
+#[test]
+fn varlen_zero_hop_plus_trailing_hop_includes_source() {
+    let mut f = build_fixture(false);
+    let r = f
+        .engine
+        .execute(
+            "MATCH (a:Person {pid: 0})-[:knows*0..1]->(b:Person)-[:livesIn]->(c:City) \
+             RETURN DISTINCT b.pid",
+        )
+        .expect("query ok");
+    // *0..1 binds b to person 0 itself plus the depth-1 friends 1 and 4.
+    assert_eq!(
+        ints(&r),
+        vec![0, 1, 4],
+        "min_hops = 0 must bind the source node itself as well"
+    );
+}
+
+// ── #421: varlen followed by two fixed hops (3-rel chain) ────────────────────
+
+#[test]
+fn varlen_plus_two_trailing_hops() {
+    let mut f = build_fixture(false);
+    // City has no outgoing edges, so route the third hop back through knows:
+    // (a)-[:knows*1..2]->(b)-[:knows]->(d)-[:livesIn]->(c)
+    let r = f
+        .engine
+        .execute(
+            "MATCH (a:Person {pid: 0})-[:knows*1..2]->(b:Person)-[:knows]->(d:Person) \
+             -[:livesIn]->(c:City) RETURN DISTINCT d.pid, c.code",
+        )
+        .expect("query ok");
+    // b ∈ {1, 4, 2, 5}. Outgoing knows: 1→2, 4→5, 2→3, 5→none.
+    // d ∈ {2, 5, 3}. livesIn: 2→c1(20), 5→c0(10), 3→c1(20).
+    assert_eq!(
+        int_pairs(&r),
+        vec![(2, 20), (3, 20), (5, 10)],
+        "a varlen hop followed by two fixed hops must join all three levels"
+    );
+}
+
+// ── #421: a leading fixed hop followed by a varlen hop ──────────────────────
+
+#[test]
+fn leading_fixed_hop_then_varlen() {
+    let mut f = build_fixture(false);
+    // The quantifier is on the *second* relationship, not the first.
+    let r = f
+        .engine
+        .execute(
+            "MATCH (a:Person {pid: 0})-[:knows]->(b:Person)-[:knows*1..2]->(d:Person) \
+             RETURN DISTINCT d.pid",
+        )
+        .expect("query ok");
+    // b ∈ {1, 4}. From 1: depth 1 = {2}, depth 2 = {3}. From 4: depth 1 = {5}.
+    assert_eq!(
+        ints(&r),
+        vec![2, 3, 5],
+        "a varlen quantifier must be honoured when it is not the first hop"
+    );
+}
+
+// ── #421: shapes deliberately left unsupported must error, not mislead ──────
+
+#[test]
+fn incoming_varlen_in_a_chain_is_rejected() {
+    let mut f = build_fixture(false);
+    // `execute_variable_hops` walks outgoing edges only; answering an incoming
+    // quantifier with outgoing edges would be silently wrong.
+    let r = f.engine.execute(
+        "MATCH (a:Person {pid: 3})<-[:knows*1..2]-(b:Person)-[:livesIn]->(c:City) \
+         RETURN b.pid",
+    );
+    assert!(
+        matches!(r, Err(sparrowdb_common::Error::Unimplemented)),
+        "an incoming variable-length hop must be rejected, not answered; got {r:?}"
+    );
+}
+
+// ── #421: the chunked pipeline must not bypass the new support ───────────────
+
+#[test]
+fn chunked_pipeline_does_not_bypass_varlen_plus_hop() {
+    let mut f = build_fixture(true);
+    let r = f
+        .engine
+        .execute(
+            "MATCH (a:Person {pid: 0})-[:knows*1..2]->(b:Person)-[:livesIn]->(c:City) \
+             RETURN DISTINCT b.pid, c.code",
+        )
+        .expect("query ok");
+    assert_eq!(
+        int_pairs(&r),
+        vec![(1, 10), (2, 20), (4, 20), (5, 10)],
+        "the chunked pipeline must fall back to the varlen chain executor, \
+         not answer the pattern with a plain two-hop plan"
+    );
+}
+
+#[test]
+fn chunked_pipeline_varlen_alone_still_correct() {
+    let mut f = build_fixture(true);
+    let r = f
+        .engine
+        .execute("MATCH (a:Person {pid: 0})-[:knows*1..2]->(b:Person) RETURN DISTINCT b.pid")
+        .expect("query ok");
+    assert_eq!(ints(&r), vec![1, 2, 4, 5]);
+}
+
+// ── #421: OPTIONAL MATCH must not swallow the pattern into NULL rows ─────────
+
+#[test]
+fn optional_match_varlen_plus_hop_returns_real_rows() {
+    let mut f = build_fixture(false);
+    let r = f
+        .engine
+        .execute(
+            "OPTIONAL MATCH (a:Person {pid: 0})-[:knows*1..2]->(b:Person)-[:livesIn]->(c:City) \
+             RETURN DISTINCT b.pid, c.code",
+        )
+        .expect("query ok");
+    assert_eq!(
+        int_pairs(&r),
+        vec![(1, 10), (2, 20), (4, 20), (5, 10)],
+        "OPTIONAL MATCH absorbs InvalidArgument into a NULL row, so a rejected \
+         pattern would surface here as nulls rather than an error"
+    );
+}
+
+#[test]
+fn optional_match_varlen_plus_hop_no_match_yields_null_row() {
+    let mut f = build_fixture(false);
+    // Person 3 has no outgoing knows edges, so the varlen expansion is empty.
+    let r = f
+        .engine
+        .execute(
+            "OPTIONAL MATCH (a:Person {pid: 3})-[:knows*1..2]->(b:Person)-[:livesIn]->(c:City) \
+             RETURN b.pid, c.code",
+        )
+        .expect("query ok");
+    assert_eq!(r.rows.len(), 1, "OPTIONAL MATCH must yield one NULL row");
+    assert!(
+        r.rows[0].iter().all(|v| matches!(v, Value::Null)),
+        "all columns must be NULL; got {:?}",
+        r.rows[0]
+    );
+}
+
+// ── #421: a varlen hop in a pipeline MATCH stage is rejected, not truncated ──
+
+#[test]
+fn pipeline_match_stage_rejects_varlen() {
+    let mut f = build_fixture(false);
+    // `execute_pipeline_match_hop` only ever takes a single step along rels[0]
+    // and ignores the quantifier — the same silent truncation as #421.
+    let err = f.engine.execute(
+        "MATCH (a:Person {pid: 0}) WITH a MATCH (a)-[:knows*1..2]->(b:Person) RETURN b.pid",
+    );
+    match err {
+        Err(sparrowdb_common::Error::InvalidArgument(msg)) => {
+            assert!(
+                msg.contains("421"),
+                "error should name the tracking issue; got {msg}"
+            );
+        }
+        other => panic!("expected InvalidArgument rejecting the pattern, got {other:?}"),
+    }
+}

--- a/crates/sparrowdb/tests/spa_111_ldbc_ic3_ic14.rs
+++ b/crates/sparrowdb/tests/spa_111_ldbc_ic3_ic14.rs
@@ -29,22 +29,64 @@ fn load_mini_db() -> (tempfile::TempDir, GraphDb) {
 
 // ── IC3 ─────────────────────────────────────────────────────────────────────
 
+// Fixture facts used by IC3/IC11 below, read by hand out of
+// `crates/sparrowdb-bench/fixtures/ldbc/mini` — never captured from output.
+//
+// person_knows_person_0_0.csv (directed; the loader creates one edge per row):
+//   1→2, 1→3, 1→6, 2→4, 2→5, 3→4, 3→5, 4→6, 5→7, 6→7, 7→8, 8→9, 9→10
+// So from Alice (1): depth 1 = {2, 3, 6}; depth 2 = {4, 5, 7}.
+// `knows*1..2` therefore binds {2, 3, 4, 5, 6, 7}.
+//
+// person_isLocatedIn_place_0_0.csv, with place 1 = United States,
+// 2 = United Kingdom, 3 = Germany:
+//   1→1, 2→2, 3→1, 4→3, 5→2, 6→3, 7→1, 8→2, 9→3, 10→1
+//
+// person_0_0.csv names: 1 Alice Smith, 2 Bob Jones, 3 Carol White,
+//   4 Dave Brown, 5 Eve Davis, 6 Frank Miller, 7 Grace Wilson.
+
 #[test]
-#[ignore = "blocked on #421: this query uses (a)-[:knows*1..2]->(b)-[:isLocatedIn]->(c), \
-which silently returned only depth-1 matches. Now rejected outright rather than \
-answered incompletely. Un-ignore when variable-length + hop traversal is implemented."]
 fn ic3_friends_in_country() {
     let (_dir, db) = load_mini_db();
 
-    // Alice (ldbc_id=1) knows Bob (UK) and Carol (US).
-    // Person 1 is located in US, person 2 in UK.
+    // Alice's 1..2-hop friends are {2, 3, 4, 5, 6, 7}.
+    // In the United Kingdom (place 2): persons 2 (Bob Jones) and 5 (Eve Davis).
+    // The query is `RETURN DISTINCT friend.firstName, friend.lastName
+    // ORDER BY friend.lastName`, so Davis precedes Jones.
     let results =
         ic_queries::ic3_friends_in_countries(&db, 1, "United Kingdom", "Germany", 30).unwrap();
 
-    // Bob (ldbc_id=2) is in UK and is a direct friend of Alice.
-    assert!(
-        !results.is_empty(),
-        "IC3 should find friends in United Kingdom; got empty"
+    assert_eq!(
+        results,
+        vec![
+            ("Eve".to_string(), "Davis".to_string()),
+            ("Bob".to_string(), "Jones".to_string()),
+        ],
+        "IC3(1, United Kingdom): person 2 (Bob Jones, depth 1) and person 5 \
+         (Eve Davis, depth 2) are the UK residents within 2 hops of Alice; got {results:?}"
+    );
+}
+
+/// #421 regression: the depth-2 match must survive the trailing `isLocatedIn`
+/// hop.  Before the fix this returned only `[Frank Miller]` — Dave Brown sits
+/// at depth 2 (1→2→4 and 1→3→4) and was silently dropped.
+#[test]
+fn ic3_friends_in_germany_includes_depth_two_match() {
+    let (_dir, db) = load_mini_db();
+
+    // Germany is place 3; its residents are persons 4, 6 and 9.
+    // Within Alice's 1..2-hop set {2, 3, 4, 5, 6, 7}: person 4 (Dave Brown,
+    // depth 2) and person 6 (Frank Miller, depth 1). Person 9 is 5 hops away.
+    // ORDER BY lastName → Brown, Miller.
+    let results = ic_queries::ic3_friends_in_countries(&db, 1, "Germany", "France", 14).unwrap();
+
+    assert_eq!(
+        results,
+        vec![
+            ("Dave".to_string(), "Brown".to_string()),
+            ("Frank".to_string(), "Miller".to_string()),
+        ],
+        "IC3(1, Germany): Dave Brown is reached at depth 2 and must not be \
+         truncated away by the trailing isLocatedIn hop (#421); got {results:?}"
     );
 }
 
@@ -177,19 +219,52 @@ fn ic10_friend_recommendations() {
 
 // ── IC11 ────────────────────────────────────────────────────────────────────
 
+// IC11 walks `(p)-[:knows*1..2]->(friend)-[:workAt]->(org)-[:isLocatedIn]->(place)`
+// — a variable-length hop followed by *two* fixed hops.
+//
+// person_workAt_organisation_0_0.csv: 1→org1, 2→org1, 3→org2, 4→org3, 5→org1
+// organisation_isLocatedIn_place_0_0.csv: org1→place1, org2→place2, org3→place3
+// organisation_0_0.csv: 1 Acme Corp, 2 University of Oxford, 3 TechStart Inc
+//
+// Alice's 1..2-hop friend set is {2, 3, 4, 5, 6, 7} (see the IC3 notes above).
+
 #[test]
-#[ignore = "blocked on #421: variable-length relationship followed by additional hops. \
-Un-ignore when that traversal shape is implemented."]
 fn ic11_job_referral() {
     let (_dir, db) = load_mini_db();
 
-    // Alice (1) knows Bob (2). Bob works at Acme Corp (org 1) in United States.
-    // Alice (1) -> Bob (2) -> Dave (4). Dave works at TechStart (org 3) in Germany.
+    // United States is place 1, reached only via org 1 (Acme Corp).
+    // Acme employs persons 1, 2 and 5; of those, 2 (Bob Jones, depth 1) and
+    // 5 (Eve Davis, depth 2) are in Alice's friend set — Alice herself is not.
+    // ORDER BY lastName → Davis, Jones.
     let results = ic_queries::ic11_job_referral(&db, 1, "United States", 2005).unwrap();
 
-    assert!(
-        !results.is_empty(),
-        "IC11 should find friends working in US; got empty"
+    assert_eq!(
+        results,
+        vec![
+            ("Eve".to_string(), "Davis".to_string()),
+            ("Bob".to_string(), "Jones".to_string()),
+        ],
+        "IC11(1, United States): Acme Corp is the only US organisation and \
+         employs friends 2 and 5; got {results:?}"
+    );
+}
+
+/// #421 regression: IC11's varlen hop is followed by two fixed hops, so the
+/// depth-2 friend must survive both joins.
+#[test]
+fn ic11_job_referral_germany_is_depth_two_only() {
+    let (_dir, db) = load_mini_db();
+
+    // Germany is place 3, reached only via org 3 (TechStart Inc), which employs
+    // person 4 (Dave Brown) alone.  Dave sits at depth 2 from Alice, so before
+    // #421 was fixed this returned nothing at all.
+    let results = ic_queries::ic11_job_referral(&db, 1, "Germany", 2005).unwrap();
+
+    assert_eq!(
+        results,
+        vec![("Dave".to_string(), "Brown".to_string())],
+        "IC11(1, Germany): TechStart Inc is the only German organisation and \
+         its sole employee, Dave Brown, is a depth-2 friend; got {results:?}"
     );
 }
 


### PR DESCRIPTION
Closes #421. Replaces the interim guard from #424 with real support.

## The bug

```cypher
MATCH (a)-[:R*1..2]->(b)-[:S]->(c)   -- returned only depth-1 matches, no error
```

`execute_match` dispatched on relationship count. `is_var_len` required the
varlen relationship to be the **only** relationship in the pattern, so a
trailing hop made `rels.len() == 2`, `is_two_hop` won, and `execute_two_hop`
treated `*1..2` as a plain single hop — silently discarding every match at
depth >= 2. Same for `execute_n_hop` at 3+ rels.

#424 made this an error. This PR makes it work.

## Approach

`execute_n_hop` is already a general linear-chain traversal: it walks hop by
hop, carries a `HashMap<var, Value>` of accumulated bindings along each
in-progress path, evaluates WHERE over the full binding map at the end, and
projects `var.prop` columns. The only thing it could not do was take more than
one step per hop.

So each hop now checks for a quantifier. A varlen hop expands the frontier with
`execute_variable_hops` — the exact DFS/BFS the standalone
`execute_variable_length` path uses, including its simple-path constraint, its
`*0..n` handling and its `SAFETY_CAP` of 10 — instead of taking a single step.
Fixed hops are untouched. Projection, WHERE, DISTINCT, ORDER BY, SKIP and LIMIT
all come for free because they already operate on the accumulated bindings, not
on a hop-specific shape.

`execute_match` gains an `is_var_len_chain` test evaluated **before**
`is_two_hop`/`is_n_hop`, so relationship count can no longer silently outvote a
quantifier. The guard and its error message are removed.

Reachability-vs-enumeration follows the standalone path's rule (#165): a varlen
hop collapses to reachability BFS only when the query is `DISTINCT` and no
relationship variable is bound; otherwise it enumerates simple paths.

## Second bug found on the way — partial fix for #429

Making IC3 correct required fixing a separate silent-wrongness in the same
function, now filed as **#429**. `execute_n_hop` resolved relationship IDs by
**type name only** (`resolve_rel_ids_for_type`), while CSRs are keyed by
rel-table id and indexed by *source slot*. LDBC registers `isLocatedIn` twice —
`(Person)->(Place)` and `(Organisation)->(Place)` — so unioning both tables made
`Person` slot 2 inherit `Organisation` slot 2's edges. Concretely: IC3 for
Germany returned **Carol White**, who lives in the United States, because
TechStart Inc happened to occupy the same slot number.

Fixed hops now narrow to the single rel table for the `(src_label, dst_label,
rel_type)` triple — the discrimination `resolve_rel_table_id` already gives the
one- and two-hop executors. This also fixes plain 3+-hop queries that never
involved a quantifier.

**#429 stays open**: this only covers hops where *both* endpoint labels are
declared. Hops with an unlabeled intermediate node, and variable-length hops
(whose intermediate nodes are not constrained by the endpoint labels, so they
must keep the type-wide set), are still exposed. #429 also raises the broader
question of whether `csr_neighbors_filtered` should take a source label at all
rather than relying on every caller to pre-narrow. It is the same
slot-identity-treated-as-node-identity confusion as #427 and #415.

## What now works

- `(a)-[:R*m..n]->(b)-[:S]->(c)` — varlen plus one trailing fixed hop
- `(a)-[:R*m..n]->(b)-[:S]->(c)-[:T]->(d)` — varlen plus several trailing hops
- `(a)-[:S]->(b)-[:R*m..n]->(c)` — quantifier at any position, not just first
- more than one quantifier in the same chain
- `*0..n` (binds the source node itself), `*m..m`, `*m..`, `*`
- WHERE and inline property filters on any node in the chain, including the ones
  after the varlen hop
- DISTINCT, ORDER BY, SKIP, LIMIT across the join
- OPTIONAL MATCH of the shape — previously the guard's `InvalidArgument` was
  absorbed into a NULL row, turning a loud error back into silent wrongness
- the chunked pipeline does not intercept it: every `ChunkedPlan` variant is
  shape-gated on `min_hops.is_none()` or `rels.is_empty()`, and there is a test
  asserting the chunked engine returns the same rows

## Shapes still unsupported

These **error** rather than returning plausible-but-wrong rows:

- **Incoming varlen in a chain** — `(a)<-[:R*1..2]-(b)-[:S]->(c)`.
  `execute_variable_hops` walks outgoing edges only. Returns `Unimplemented`.
  The standalone `execute_variable_length` already rejected this the same way.
- **Varlen inside a pipeline MATCH stage** —
  `MATCH … WITH a MATCH (a)-[:R*1..2]->(b) …`. `execute_pipeline_match_hop`
  only ever steps once along `rels[0]` and ignores the quantifier — exactly
  #421's failure mode in a different executor. Now returns `InvalidArgument`
  naming #421. Implementing it there is a separate job; a guard is the honest
  interim.
- **Unlabeled chain source** — `execute_n_hop` requires a resolvable label on
  `nodes[0]` and returns `Unimplemented` without one. Pre-existing.
- **#431 — cross-label varlen on a checkpointed graph.** With an empty delta
  log, `get_node_neighbors_labeled` cannot recover a destination's label from
  CSR alone and falls back to the *source* label, so a varlen hop that crosses
  labels and is then filtered by a different destination label yields nothing.
  Pre-existing and identical in `execute_variable_length`, so this PR neither
  fixes nor worsens it; changing label recovery underneath both callers is a
  separate, separately-testable change. The #427 agent hit the same wall in
  `bfs_shortest_path` and worked around it by deriving the label from the rel
  table's `(src_label_id, dst_label_id)` — that is the right general fix and is
  written up in #431. Note this does **not** affect IC3/IC11: their varlen
  segment is Person→Person, and the label-crossing hops are fixed ones.

Two adjacent silent-truncation bugs were found but deliberately **not** fixed
here, since neither is varlen-specific:

- **#430** — `execute_pipeline_match_stage` drops hops `2..n` of any multi-rel
  pattern after a `WITH`; it only ever binds `nodes[0]` and `nodes[1]`, so the
  third node projects as `NULL` and the result reads like a complete answer to
  a shorter query.
- A multi-pattern `MATCH` whose patterns contain relationships
  (`MATCH (a)-[:R]->(b), (c)-[:S]->(d)`) falls through to `execute_scan`, which
  ignores relationships entirely. Not yet filed; noted here so it is not lost.

## Tests

`crates/sparrowdb-execution/tests/regression_421_varlen_plus_hop.rs` — 15 new
engine-level tests over a hand-built 6-person / 2-city fixture whose expected
values are spelled out in the module docs and derived by hand from the edge
lists. **Verified to fail against the pre-fix engine**: checking out
`engine/hop.rs` and `engine/scan.rs` from `25f3559` and re-running produces 10
failures, each showing exactly the depth-1 truncation #421 describes
(e.g. `left: [(1, 10), (4, 20)]` vs `right: [(1, 10), (2, 20), (4, 20), (5, 10)]`).

`crates/sparrowdb/tests/spa_111_ldbc_ic3_ic14.rs` — `ic3_friends_in_country` and
`ic11_job_referral` un-ignored, and both promoted from `!is_empty()` to exact
expected values. Two new tests pin the depth-2 cases #421 was dropping. Every
expectation is derived from the fixture CSVs, quoted in comments above the tests:

| query | expected | why |
|---|---|---|
| IC3(1, "Germany") | Dave Brown, Frank Miller | Germany is place 3; residents are 4, 6, 9. Alice's 1..2-hop set is {2,3,4,5,6,7}. Dave (4) is at depth 2, Frank (6) at depth 1. |
| IC3(1, "United Kingdom") | Eve Davis, Bob Jones | UK is place 2; residents 2, 5, 8. Bob (2) depth 1, Eve (5) depth 2. ORDER BY lastName. |
| IC11(1, "Germany") | Dave Brown | Germany ← org 3 (TechStart), whose only employee is person 4, at depth 2. |
| IC11(1, "United States") | Eve Davis, Bob Jones | US ← org 1 (Acme), employing 1, 2 and 5; 2 and 5 are in the friend set, Alice is not. |

The two `#[ignore]`d #421 tests in `crates/sparrowdb-bench/tests/ldbc_ic_test.rs`
(`ic3_friends_in_countries_returns_both_germans`, `ic11_job_referral`) also pass
now — confirmed with `--ignored` — but that file belongs to another change, so
the attributes are left for it to remove.

## Verification

All runs used an isolated `CARGO_TARGET_DIR=/Volumes/Dev/target-421`. The shared
target dir is being written by several agents concurrently and has already
produced one bogus green in this session — a test binary built from a different
worktree's source.

| command | result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --exclude sparrowdb-ruby --all-targets --keep-going -- -D warnings` | clean |
| `cargo test -p sparrowdb-execution --no-fail-fast` | 108 passed, 0 failed (11 binaries, incl. all 15 new #421 tests) |
| `cargo test -p sparrowdb --no-fail-fast` | 160 of 161 test binaries green, 0 failures (161st is #434, see below) |

**One target did not finish locally**: `spa_222_csr_lazy_load`. Its single test
builds 50 000 nodes and 100 000 edges through `execute_batch` in a debug build;
the local runner reaped it twice at ~49 and ~51 minutes, both SIGTERM rather than
failure. This is now accounted for independently rather than assumed: CI logs
show `spa222_mmap_open_and_traverse` takes **80 minutes and passes** on a green
`ubuntu-latest` run (03:37 start → 04:57 ok), i.e. one test is essentially the
whole ~85-minute CI wall-clock while the rest of the integration suite finishes
in minutes. Filed as #434. It is also unreachable from this change: its queries
are a two-node `MATCH (a:Person {id: i}), (b:Person {id: j}) CREATE (a)-[:KNOWS]->(b)`
— no relationships in the MATCH, so `execute_n_hop` is never entered — plus one
single-hop traversal.

Every target that could plausibly regress from this change **was** run and is
green, including `spa_252_three_hop_binding`, `spa_354_varlength_terminal_label`,
`spa_variable_paths`, `spa_224_varpath_reserved_label`, `spa_241_multihop_props`,
`spa_289_multi_label`, `spa_131_optional_match`, `spa_136_shortest_path`, and
`spa_299_{chunked_pipeline,phase2,phase3,phase4}_parity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE
