### PR TITLE
perf(test): cut spa222_mmap_open_and_traverse from ~80min to ~2s (closes #434)

### DIFF
--- a/crates/sparrowdb/tests/spa_222_csr_lazy_load.rs
+++ b/crates/sparrowdb/tests/spa_222_csr_lazy_load.rs
@@ -1,79 +1,254 @@
 //! SPA-222: CSR lazy-load via memory-map.
 //!
-//! Verifies that opening a database with large CSR files does not eagerly copy
-//! all adjacency data into heap-allocated vectors, and that traversal still
-//! returns correct results through the mmap-backed CSR.
+//! Verifies that opening a database whose edges have been folded into CSR base
+//! files goes through the mmap-backed path, and that traversal through that
+//! mapping still returns correct results.
+//!
+//! ## Fixture sizing (issue #434)
+//!
+//! `CsrForward::open` / `CsrBackward::open` in `sparrowdb-storage::csr` memory-map
+//! **unconditionally** — there is no size threshold anywhere that chooses between
+//! a heap read and an mmap, so a smaller fixture cannot silently fall off the
+//! lazy-load path.  The only size that matters is the *page* granularity of the
+//! mapping: the fixture must produce a CSR file spanning many OS pages, so that
+//! reading a neighbour list genuinely faults a page in rather than being served
+//! by the single page that already holds the header.
+//!
+//! With `N` nodes and `E` edges the on-disk CSR is exactly
+//!
+//! ```text
+//! 8 + (N + 1) * 8 + E * 8   bytes
+//! [n_nodes][offsets x (N+1)][neighbours x E]
+//! ```
+//!
+//! For `N = 10_000`, `E = 20_000` that is 240_016 bytes — 15 pages at the 16 KiB
+//! page size used on Apple Silicon, 59 pages at the 4 KiB size used by the Linux
+//! CI runners.  The neighbours array alone starts at byte 80_016, i.e. page 4
+//! (16 KiB) or page 19 (4 KiB), so **no** neighbour lookup can be satisfied by
+//! the header page.  The test traverses both the first and the last node, and
+//! the last node's neighbour entries are the final two `u64`s in the file — the
+//! last page of the mapping.
+//!
+//! The previous 50K/100K fixture crossed exactly the same boundaries; it was 5x
+//! larger for no additional coverage, and seeding it one Cypher statement at a
+//! time took ~80 minutes.  Seeding now goes through `WriteTx` in chunked
+//! transactions: the traversal is the subject of this test, the ingest path is
+//! not.
 
-use sparrowdb::open;
+use sparrowdb::{open, GraphDb};
 use sparrowdb_execution::types::Value;
+use sparrowdb_storage::node_store::Value as StoreValue;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-/// Build a graph with 50K nodes and ~100K edges, checkpoint it, then reopen
-/// and verify that:
-///   1. Reopening is fast (the CSR is mmapped, not heap-copied).
-///   2. Traversal through the mmap still returns correct results.
+/// Number of `Person` nodes in the fixture.
+const N: u64 = 10_000;
+
+/// Each node gets two out-edges: `next` (`i+1`) and `skip-7` (`i+7`).
+///
+/// The two coincide only if `N` divides 6, which 10_000 does not — so the edge
+/// set contains no duplicates and `E` below is exact after CSR de-duplication.
+const EDGES_PER_NODE: u64 = 2;
+
+/// Total edges in the fixture.
+const E: u64 = N * EDGES_PER_NODE;
+
+/// Nodes (or edges) staged per write transaction.
+///
+/// `WriteTx::create_edge` scans the transaction's own pending-op buffer to
+/// derive the next edge id, so staging every edge in one transaction would be
+/// quadratic.  Chunking bounds that scan while keeping the number of WAL fsyncs
+/// small.
+const CHUNK: usize = 2_000;
+
+/// Locate the single rel table's forward CSR base file under `<db_root>/edges/`.
+fn csr_forward_path(db_root: &Path) -> PathBuf {
+    let edges_dir = db_root.join("edges");
+    let mut found: Vec<PathBuf> = Vec::new();
+    for entry in std::fs::read_dir(&edges_dir).expect("edges/ must exist after checkpoint") {
+        let candidate = entry.expect("read_dir entry").path().join("base.fwd.csr");
+        if candidate.is_file() {
+            found.push(candidate);
+        }
+    }
+    assert_eq!(
+        found.len(),
+        1,
+        "fixture defines exactly one rel table (KNOWS), found {found:?}"
+    );
+    found.pop().unwrap()
+}
+
+/// Decode `(n_nodes, n_edges)` from a CSR file using the documented layout:
+/// `[n_nodes: u64][offsets: u64 x (n_nodes + 1)][neighbours: u64 x n_edges]`,
+/// where `n_edges` is the sentinel entry `offsets[n_nodes]`.
+fn read_csr_header(path: &Path) -> (u64, u64) {
+    let bytes = std::fs::read(path).expect("read CSR base file");
+    assert!(bytes.len() >= 8, "CSR file too short for n_nodes");
+    let n_nodes = u64::from_le_bytes(bytes[0..8].try_into().unwrap());
+
+    let sentinel = 8 + n_nodes as usize * 8;
+    assert!(
+        bytes.len() >= sentinel + 8,
+        "CSR file too short for the offsets array"
+    );
+    let n_edges = u64::from_le_bytes(bytes[sentinel..sentinel + 8].try_into().unwrap());
+    (n_nodes, n_edges)
+}
+
+/// Seed `N` `Person` nodes and `E` `KNOWS` edges through `WriteTx`.
+///
+/// Returns the packed node ids in `id` order, so `node_ids[i]` is the node whose
+/// `id` property is `i`.
+fn seed_graph(db: &GraphDb) -> Vec<sparrowdb_common::NodeId> {
+    let mut node_ids = Vec::with_capacity(N as usize);
+
+    for chunk_start in (0..N).step_by(CHUNK) {
+        let chunk_end = (chunk_start + CHUNK as u64).min(N);
+        let mut tx = db.begin_write().expect("begin_write (nodes)");
+        let label_id = tx
+            .get_or_create_label_id("Person")
+            .expect("get_or_create_label_id");
+        for i in chunk_start..chunk_end {
+            let node_id = tx
+                .create_node_named(label_id, &[("id".to_string(), StoreValue::Int64(i as i64))])
+                .expect("create_node_named");
+            node_ids.push(node_id);
+        }
+        tx.commit().expect("commit (nodes)");
+    }
+    assert_eq!(node_ids.len(), N as usize, "seeded node count");
+
+    // Two edges per node, so halve the chunk to keep transactions the same size.
+    let edge_chunk = CHUNK / 2;
+    for chunk_start in (0..N).step_by(edge_chunk) {
+        let chunk_end = (chunk_start + edge_chunk as u64).min(N);
+        let mut tx = db.begin_write().expect("begin_write (edges)");
+        for i in chunk_start..chunk_end {
+            let next = (i + 1) % N;
+            let skip = (i + 7) % N;
+            tx.create_edge(
+                node_ids[i as usize],
+                node_ids[next as usize],
+                "KNOWS",
+                HashMap::new(),
+            )
+            .expect("create_edge (next)");
+            tx.create_edge(
+                node_ids[i as usize],
+                node_ids[skip as usize],
+                "KNOWS",
+                HashMap::new(),
+            )
+            .expect("create_edge (skip-7)");
+        }
+        tx.commit().expect("commit (edges)");
+    }
+
+    node_ids
+}
+
+/// Run a one-hop traversal from the `Person` whose `id` property is `id`, and
+/// return the neighbours' `id` values in ascending order.
+fn neighbour_ids(db: &GraphDb, id: u64) -> Vec<i64> {
+    let cypher = format!("MATCH (a:Person {{id: {id}}})-[:KNOWS]->(b) RETURN b.id ORDER BY b.id");
+    db.execute(&cypher)
+        .expect("traversal query")
+        .rows
+        .iter()
+        .map(|row| match &row[0] {
+            Value::Int64(v) => *v,
+            other => panic!("expected Int64, got {other:?}"),
+        })
+        .collect()
+}
+
+/// Build the graph, checkpoint it into CSR base files, reopen the database, and
+/// verify that traversal through the mmap-backed CSR returns correct results.
 #[test]
 fn spa222_mmap_open_and_traverse() {
     let dir = tempfile::tempdir().unwrap();
     let db = open(dir.path()).unwrap();
 
-    // Create 50K Person nodes in a single batch transaction.
-    let n = 50_000u64;
-    let node_queries: Vec<String> = (0..n)
-        .map(|i| format!("CREATE (:Person {{id: {}}})", i))
-        .collect();
-    let node_query_refs: Vec<&str> = node_queries.iter().map(String::as_str).collect();
-    db.execute_batch(&node_query_refs).unwrap();
+    seed_graph(&db);
 
-    // Create edges in a single batch: each node connects to next and skip-7.
-    let edge_queries: Vec<String> = (0..n)
-        .flat_map(|i| {
-            let next = (i + 1) % n;
-            let skip = (i + 7) % n;
-            [
-                format!(
-                    "MATCH (a:Person {{id: {}}}), (b:Person {{id: {}}}) CREATE (a)-[:KNOWS]->(b)",
-                    i, next
-                ),
-                format!(
-                    "MATCH (a:Person {{id: {}}}), (b:Person {{id: {}}}) CREATE (a)-[:KNOWS]->(b)",
-                    i, skip
-                ),
-            ]
-        })
-        .collect();
-    let edge_query_refs: Vec<&str> = edge_queries.iter().map(String::as_str).collect();
-    db.execute_batch(&edge_query_refs).unwrap();
-
-    // Checkpoint to flush edges into CSR files.
+    // Fold the delta log into the CSR base files on real disk.
     db.checkpoint().unwrap();
     drop(db);
 
-    // Reopen — this should use mmap, not fs::read + decode.
+    // ── The on-disk CSR must be a real, multi-page mapping target ────────────
+    let csr_path = csr_forward_path(dir.path());
+
+    // The checkpoint truncates the delta log, so every edge the traversal below
+    // returns has to come out of the CSR base file.  Without this the test could
+    // pass while reading edges from the delta log and never touch the mapping.
+    let delta_path = csr_path.with_file_name("delta.log");
+    let delta_len = std::fs::metadata(&delta_path).map(|m| m.len()).unwrap_or(0);
+    assert_eq!(
+        delta_len, 0,
+        "delta log must be empty after CHECKPOINT so traversal reads the CSR"
+    );
+
+    let file_len = std::fs::metadata(&csr_path)
+        .expect("stat CSR base file")
+        .len() as usize;
+    let (n_nodes, n_edges) = read_csr_header(&csr_path);
+
+    assert_eq!(n_nodes, N, "CSR should span every seeded Person slot");
+    assert_eq!(
+        n_edges, E,
+        "each of the {N} nodes contributes exactly {EDGES_PER_NODE} distinct edges"
+    );
+
+    // Layout is fully determined by the fixture: 8 + (N+1)*8 + E*8 = 240_016.
+    let expected_len = 8 + (N as usize + 1) * 8 + E as usize * 8;
+    assert_eq!(
+        file_len, expected_len,
+        "CSR file must match the documented [n_nodes][offsets][neighbours] layout"
+    );
+
+    // The largest page size in play is 16 KiB (Apple Silicon); Linux CI uses
+    // 4 KiB.  Requiring >10 pages at the *larger* size proves the mapping is
+    // comfortably multi-page on every platform we build on, so neighbour reads
+    // cannot be served by the page holding the header.
+    const LARGEST_PAGE: usize = 16 * 1024;
+    assert!(
+        file_len > 10 * LARGEST_PAGE,
+        "CSR file is {file_len} bytes — too small to exercise lazy paging \
+         (need > {} bytes, i.e. >10 pages of {LARGEST_PAGE})",
+        10 * LARGEST_PAGE
+    );
+
+    // The neighbours array starts after the header and the offsets array, so no
+    // neighbour lookup can land on the header page.
+    let neighbours_start = 8 + (n_nodes as usize + 1) * 8;
+    assert!(
+        neighbours_start > LARGEST_PAGE,
+        "neighbours array starts at byte {neighbours_start}, inside the header page"
+    );
+
+    // ── Reopen: this goes through CsrForward::open, i.e. mmap ────────────────
     let start = Instant::now();
     let db2 = open(dir.path()).unwrap();
     let open_ms = start.elapsed().as_millis();
+    eprintln!("SPA-222: reopen with {N} nodes + {E} edges took {open_ms}ms");
 
-    // Sanity: open should be fast (mmap doesn't read data eagerly).
-    eprintln!(
-        "SPA-222: reopen with 50K nodes + 100K edges took {}ms",
-        open_ms
+    // ── Traversal through the mapping, at both ends of the neighbours array ──
+
+    // Node 0 is the first CSR slot: its neighbours are (0+1)=1 and (0+7)=7.
+    assert_eq!(
+        neighbour_ids(&db2, 0),
+        vec![1i64, 7],
+        "node 0 must reach exactly its next and skip-7 neighbours"
     );
 
-    // Verify traversal returns correct results.
-    let res = db2
-        .execute("MATCH (a:Person {id: 0})-[:KNOWS]->(b) RETURN b.id ORDER BY b.id")
-        .unwrap();
-
-    let ids: Vec<i64> = res
-        .rows
-        .iter()
-        .map(|r| match &r[0] {
-            Value::Int64(v) => *v,
-            other => panic!("expected Int64, got {:?}", other),
-        })
-        .collect();
-
-    // Node 0 connects to exactly node 1 (next) and node 7 (skip-7) — no more, no less.
-    assert_eq!(ids, vec![1i64, 7], "expected exactly [1, 7], got {:?}", ids);
+    // Node N-1 is the last CSR slot, so its two neighbour entries are the final
+    // two u64s in the file — reading them faults in the last page of the
+    // mapping.  Its neighbours wrap: (9999+1) % 10000 = 0 and (9999+7) % 10000 = 6.
+    assert_eq!(
+        neighbour_ids(&db2, N - 1),
+        vec![0i64, 6],
+        "last node must reach exactly its wrapped next and skip-7 neighbours"
+    );
 }


### PR DESCRIPTION
Closes #434.

`spa222_mmap_open_and_traverse` was ~80 minutes of an ~85-minute CI run — essentially the entire wall-clock. Since #412 made CI actually gate, that is a correctness-of-process problem: a gate that slow is a gate people route around.

## Timings

| | before | after |
|---|---|---|
| CI (`Test (ubuntu-latest)`, debug) | **~4,800 s** — 03:37:00 → 04:57:30 on the green run cited in #434 | **124 s** — 02:50:02 → 02:52:06, run [30729546810](https://github.com/ryaker/SparrowDB/actions/runs/30729546810) |

**Confirmed on CI, back to back on identical infrastructure.** The `main` run for the immediately preceding commit (`74c1219`, run [30729151306](https://github.com/ryaker/SparrowDB/actions/runs/30729151306), started 02:36:15Z) was **still in progress 23 minutes later**, on its way to the usual ~80 minutes. The `main` run for this change finished `Test (ubuntu-latest)` in **2 m 04 s**. Full PR check set green, including `Test (macos-latest)` at 2 m 43 s.

That is ~4,800 s → ~124 s, a ~39× cut, and it beats the ~5 minute target in #434.
| Local (M-series, debug, isolated `CARGO_TARGET_DIR`) | **> 3,960 s — did not complete** (see below) | **1.67 s** (harness-reported; 1.96 s wall incl. process start) |

**On the local "before" number, stated plainly:** I could not obtain a completed local baseline. I ran the pre-change test on this machine with an isolated target dir; it was still running at ~66 minutes when it was killed, having never printed a result. So the local before-figure is a **lower bound, not a measurement** — the honest comparison is CI's ~4,800 s against the measured 1.67 s after.

That failure is itself the point of #434: this is the fourth recorded instance of an agent being unable to watch this test finish locally. The after-number, by contrast, was measured directly and repeatedly.

## Approach: bulk seed (option 2) + shrink (option 1)

The time was never in the code under test. The fixture was seeded with ~150,000 sequential Cypher statements in a debug build: 50,000 `CREATE`, then 100,000 `MATCH … CREATE` where **both** endpoints were resolved by an unindexed property scan over 50,000 nodes. That ingest is quadratic in the fixture size.

1. **Seed through `WriteTx` in chunked transactions** rather than one Cypher statement at a time. The traversal is the subject of this test; the ingest path is not, and it is covered elsewhere. Chunking (2,000 ops/tx) also bounds the O(n²) pending-op scan inside `WriteTx::create_edge`, which would otherwise reintroduce quadratic cost if every edge were staged in one large transaction.
2. **Shrink the fixture** from 50K nodes / 100K edges to 10K / 20K — see the threshold analysis below for why this number rather than "50K ÷ 10".

Option 3 (`#[ignore]` / a `slow-tests` feature) was **not** needed and was not used: the test stays in the PR signal at ~2 s.

## What the test still verifies

Everything it verified before, plus more. It still hits real disk, a real `CHECKPOINT`, and a real mmap reopen — no unit-level substitution.

- Checkpoint folds the delta log into real CSR base files on disk.
- Reopening the database goes through `CsrForward::open`, i.e. the mmap path.
- One-hop traversal through the mapping returns correct results.

New assertions that make the previously-implicit "this is really an mmap workload" claim explicit and checkable:

- The CSR base file matches the documented layout **exactly** — `8 + (N+1)*8 + E*8` = 240,016 bytes — with `n_nodes` and `n_edges` decoded from the file header by the test itself.
- `n_edges == 20_000` exactly, i.e. CSR de-duplication did not silently collapse the edge set.
- **The delta log is empty after `CHECKPOINT`.** Without this, the test could pass while reading edges out of the delta log and never touch the mapping at all. This was not checked before.
- Coverage widened from one traversal to two. The old test traversed node 0 only; it now also traverses node `N-1`, whose neighbour entries are the **final two u64s in the file** and therefore fault in the last page of the mapping.

All expected values are derived from the fixture by hand, not captured from program output:

- node 0 → `next = 1`, `skip-7 = 7` → `[1, 7]`
- node 9999 → `next = (9999+1) % 10000 = 0`, `skip-7 = (9999+7) % 10000 = 6` → `[0, 6]`

## Threshold evidence: the reduced fixture still exercises lazy CSR load

**There is no size threshold to fall below.** `CsrForward::open` and `CsrBackward::open` (`crates/sparrowdb-storage/src/csr.rs:199` and `:279`) memory-map unconditionally — no branch, no size condition:

```rust
pub fn open(path: &Path) -> Result<Self> {
    let file = File::open(path).map_err(Error::Io)?;
    let mmap = unsafe { Mmap::map(&file) }.map_err(Error::Io)?;
    let _ = mmap.advise(memmap2::Advice::Sequential);
    let (n_nodes, data) = CsrData::from_mmap(mmap)?;
    Ok(CsrForward { n_nodes, data })
}
```

`CsrData::from_mmap` always produces the `Mapped` variant. The heap-backed `Owned` variant is reachable only via `build()` (in-memory construction) and `decode()`, and `decode()` is used only by the stats path (`db.rs:466`) and one procedure — never by traversal. Every traversal reaches the CSR through `CsrForward`, so it is always reading the mapping.

**What *does* depend on size is page granularity**, and the test now asserts that directly rather than assuming it. With `N` nodes and `E` edges the on-disk CSR is `8 + (N+1)*8 + E*8` bytes, laid out `[n_nodes][offsets × (N+1)][neighbours × E]`. For 10,000 / 20,000:

| | value | 16 KiB pages (Apple Silicon) | 4 KiB pages (Linux CI) |
|---|---|---|---|
| total file | 240,016 B | 15 pages | 59 pages |
| neighbours array starts at | byte 80,016 | page 4 | page 19 |

So:

- The mapping is comfortably multi-page **at the larger of the two page sizes in play** — the test asserts `> 10` pages of 16 KiB, which is the conservative direction.
- The neighbours array begins well past the header page, so **no neighbour lookup can be satisfied by the page already faulted in for the header** — asserted.
- Traversing node `N-1` reads the last two u64s of the file, faulting in the final page.

The old 50K/100K fixture crossed exactly these same boundaries. It was 5× larger for no additional coverage.

### The test is not vacuous — mutation probe

Structural argument aside, I checked empirically that the reduced fixture's traversal really does read through the CSR file. In a throwaway clone I zeroed every byte of the neighbours array on disk between `CHECKPOINT` and the reopen, and re-ran:

```
assertion `left == right` failed: node 0 must reach exactly its next and skip-7 neighbours
  left: [0, 1, 7]
 right: [1, 7]
```

The test fails when the CSR file is corrupted, so the mapping is genuinely on the read path at 10K/20K. This probe was **not** committed.

## Verification

Run with `CARGO_TARGET_DIR` isolated from concurrently-building sibling agents.

- `cargo test -p sparrowdb --test spa_222_csr_lazy_load` — **pass**, 1.67 s
- `cargo test -p sparrowdb --no-fail-fast` — **167 binaries, 1034 passed, 0 failed, 10 ignored** (cargo exit 0). No pre-existing failures surfaced. All 10 ignored are pre-existing documented gaps (SPA-252, SPA-289/#419, the GAP-B/D/E/F/G/J set under SPA-151); none were added here.
- `cargo fmt --all -- --check` — clean, and re-verified in a **fresh clone of this pushed branch** (exit 0)
- `cargo clippy -p sparrowdb --all-targets -- -D warnings` — clean

Only `crates/sparrowdb/tests/spa_222_csr_lazy_load.rs` is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE
