### PR TITLE
fix(engine): neighbour lookups carry (slot, label) and read labels from the catalog (#429, #431)

### DIFF
--- a/crates/sparrowdb-execution/src/engine/expr.rs
+++ b/crates/sparrowdb-execution/src/engine/expr.rs
@@ -408,7 +408,13 @@ impl Engine {
         let csr_nb: Vec<u64> = match rel_lookup {
             RelTableLookup::Found(rtid) => self.csr_neighbors(rtid, src_slot),
             RelTableLookup::NotFound => return false,
-            RelTableLookup::All => self.csr_neighbors_all(src_slot),
+            // Untyped edge: every table whose source label is this node's, and
+            // whose destination label is the one the pattern asks for.  A bare
+            // slot would otherwise let a neighbour of any label answer for one
+            // of `dst_label_id_opt`.
+            RelTableLookup::All => {
+                self.csr_neighbor_slots_to_label(src_slot, src_label_id, dst_label_id_opt, &[])
+            }
         };
         let delta_nb: Vec<u64> = self
             .read_delta_all()
@@ -603,28 +609,8 @@ impl Engine {
         // SPA-283: build HashMap index for O(1) per-node delta lookups.
         let delta_idx = build_delta_index(&delta_all);
 
-        // #427: derive CSR neighbour labels from the catalog rather than guessing.
-        //
-        // A relationship table is registered as `(rel_table_id, src_label_id,
-        // dst_label_id, rel_type)` and its CSR holds only that table's edges.  So
-        // for a CSR hit we know the destination's label exactly — it is the
-        // table's `dst_label_id` — and we know the table only applies to sources
-        // of its `src_label_id`.  Both matter: the shared
-        // `get_node_neighbors_labeled` helper instead falls back to the *source's*
-        // label whenever the delta log carries no hint, which is always true once
-        // a graph has been checkpointed, and it probes every CSR with the raw slot
-        // regardless of the source's label.
-        let rel_tables: Vec<(u32, u32, u32)> = self
-            .snapshot
-            .catalog
-            .list_rel_tables_with_ids()
-            .into_iter()
-            .filter(|(id, _, _, _)| rel_ids.is_empty() || rel_ids.contains(&(*id as u32)))
-            .map(|(id, s_lid, d_lid, _)| (id as u32, s_lid as u32, d_lid as u32))
-            .collect();
-
         // Frontier carries (slot, label_id) so each hop uses the correct label
-        // when probing the delta index.
+        // when looking up neighbours.
         let mut visited: std::collections::HashSet<(u64, u32)> = std::collections::HashSet::new();
         visited.insert((src_slot, src_label_id));
         let mut frontier: Vec<(u64, u32)> = vec![(src_slot, src_label_id)];
@@ -633,31 +619,18 @@ impl Engine {
         for depth in 1..=max_hops {
             let mut next_frontier: Vec<(u64, u32)> = Vec::new();
             for &(node_slot, node_label_id) in &frontier {
-                neighbors.clear();
-
-                // Checkpointed edges: one CSR per relationship table.
-                for &(rel_id, s_lid, d_lid) in &rel_tables {
-                    if s_lid != node_label_id {
-                        continue;
-                    }
-                    if let Some(csr) = self.snapshot.csrs.get(&rel_id) {
-                        for &nb_slot in csr.neighbors(node_slot) {
-                            neighbors.insert((nb_slot, d_lid));
-                        }
-                    }
-                }
-
-                // Uncheckpointed edges: the delta log carries full NodeIds, so
-                // the destination label is read off directly.
-                if let Some(recs) = delta_idx.get(&(node_label_id, node_slot)) {
-                    for r in recs {
-                        if !rel_ids.is_empty() && !rel_ids.contains(&r.rel_id.0) {
-                            continue;
-                        }
-                        let (nb_label, nb_slot) = node_id_parts(r.dst.0);
-                        neighbors.insert((nb_slot, nb_label));
-                    }
-                }
+                // #427/#431: both edge sources report the neighbour's label
+                // rather than leaving it to be guessed — the catalog's
+                // `dst_label_id` for checkpointed edges, the stored `NodeId` for
+                // delta edges.  This loop used to inline that logic; it now
+                // shares the one implementation with variable-length traversal.
+                self.get_node_neighbors_labeled(
+                    node_slot,
+                    node_label_id,
+                    &delta_idx,
+                    &mut neighbors,
+                    rel_ids,
+                );
 
                 for &(nb_slot, nb_label) in neighbors.iter() {
                     if (nb_slot, nb_label) == (dst_slot, dst_label_id) {

--- a/crates/sparrowdb-execution/src/engine/expr.rs
+++ b/crates/sparrowdb-execution/src/engine/expr.rs
@@ -603,42 +603,63 @@ impl Engine {
         // SPA-283: build HashMap index for O(1) per-node delta lookups.
         let delta_idx = build_delta_index(&delta_all);
 
-        // Label hints for CSR-only destinations, mirroring `execute_variable_length`:
-        // the delta log carries full NodeIds, so every (slot, label) pair it
-        // mentions is authoritative.
-        let mut node_label: std::collections::HashSet<(u64, u32)> =
-            std::collections::HashSet::new();
-        for r in &delta_all {
-            let (src_l, src_s) = node_id_parts(r.src.0);
-            node_label.insert((src_s, src_l));
-            let (dst_l, dst_s) = node_id_parts(r.dst.0);
-            node_label.insert((dst_s, dst_l));
-        }
-        let mut all_label_ids: Vec<u32> = node_label.iter().map(|&(_, l)| l).collect();
-        all_label_ids.sort_unstable();
-        all_label_ids.dedup();
+        // #427: derive CSR neighbour labels from the catalog rather than guessing.
+        //
+        // A relationship table is registered as `(rel_table_id, src_label_id,
+        // dst_label_id, rel_type)` and its CSR holds only that table's edges.  So
+        // for a CSR hit we know the destination's label exactly — it is the
+        // table's `dst_label_id` — and we know the table only applies to sources
+        // of its `src_label_id`.  Both matter: the shared
+        // `get_node_neighbors_labeled` helper instead falls back to the *source's*
+        // label whenever the delta log carries no hint, which is always true once
+        // a graph has been checkpointed, and it probes every CSR with the raw slot
+        // regardless of the source's label.
+        let rel_tables: Vec<(u32, u32, u32)> = self
+            .snapshot
+            .catalog
+            .list_rel_tables_with_ids()
+            .into_iter()
+            .filter(|(id, _, _, _)| rel_ids.is_empty() || rel_ids.contains(&(*id as u32)))
+            .map(|(id, s_lid, d_lid, _)| (id as u32, s_lid as u32, d_lid as u32))
+            .collect();
 
         // Frontier carries (slot, label_id) so each hop uses the correct label
         // when probing the delta index.
         let mut visited: std::collections::HashSet<(u64, u32)> = std::collections::HashSet::new();
         visited.insert((src_slot, src_label_id));
         let mut frontier: Vec<(u64, u32)> = vec![(src_slot, src_label_id)];
-        let mut neighbors_buf: std::collections::HashSet<(u64, u32)> =
-            std::collections::HashSet::new();
+        let mut neighbors: std::collections::HashSet<(u64, u32)> = std::collections::HashSet::new();
 
         for depth in 1..=max_hops {
             let mut next_frontier: Vec<(u64, u32)> = Vec::new();
             for &(node_slot, node_label_id) in &frontier {
-                self.get_node_neighbors_labeled(
-                    node_slot,
-                    node_label_id,
-                    &delta_idx,
-                    &node_label,
-                    &all_label_ids,
-                    &mut neighbors_buf,
-                    rel_ids,
-                );
-                for &(nb_slot, nb_label) in neighbors_buf.iter() {
+                neighbors.clear();
+
+                // Checkpointed edges: one CSR per relationship table.
+                for &(rel_id, s_lid, d_lid) in &rel_tables {
+                    if s_lid != node_label_id {
+                        continue;
+                    }
+                    if let Some(csr) = self.snapshot.csrs.get(&rel_id) {
+                        for &nb_slot in csr.neighbors(node_slot) {
+                            neighbors.insert((nb_slot, d_lid));
+                        }
+                    }
+                }
+
+                // Uncheckpointed edges: the delta log carries full NodeIds, so
+                // the destination label is read off directly.
+                if let Some(recs) = delta_idx.get(&(node_label_id, node_slot)) {
+                    for r in recs {
+                        if !rel_ids.is_empty() && !rel_ids.contains(&r.rel_id.0) {
+                            continue;
+                        }
+                        let (nb_label, nb_slot) = node_id_parts(r.dst.0);
+                        neighbors.insert((nb_slot, nb_label));
+                    }
+                }
+
+                for &(nb_slot, nb_label) in neighbors.iter() {
                     if (nb_slot, nb_label) == (dst_slot, dst_label_id) {
                         return Some(depth);
                     }

--- a/crates/sparrowdb-execution/src/engine/expr.rs
+++ b/crates/sparrowdb-execution/src/engine/expr.rs
@@ -510,20 +510,39 @@ impl Engine {
                 }
             };
 
-        let dst_slot = if let Some(nid) = self.resolve_node_id_from_var(&sp.dst_var, vals) {
-            nid.0 & 0xFFFF_FFFF
-        } else {
-            let dst_label_id = match self.snapshot.catalog.get_label(&sp.dst_label) {
-                Ok(Some(id)) => id as u32,
-                _ => return Value::Null,
+        // #427: the destination's label is part of its identity — a `NodeId` is
+        // `(label_id << 32) | slot`, so slot 0 exists once per label. Carrying
+        // only the slot let a `City` stand in for a `Person`.
+        let (dst_label_id, dst_slot) =
+            if let Some(nid) = self.resolve_node_id_from_var(&sp.dst_var, vals) {
+                (((nid.0 >> 32) as u32), nid.0 & 0xFFFF_FFFF)
+            } else {
+                let dst_label_id = match self.snapshot.catalog.get_label(&sp.dst_label) {
+                    Ok(Some(id)) => id as u32,
+                    _ => return Value::Null,
+                };
+                match self.find_node_by_props(dst_label_id, &sp.dst_props) {
+                    Some(slot) => (dst_label_id, slot),
+                    None => return Value::Null,
+                }
             };
-            match self.find_node_by_props(dst_label_id, &sp.dst_props) {
-                Some(slot) => slot,
-                None => return Value::Null,
-            }
-        };
 
-        match self.bfs_shortest_path(src_slot, src_label_id, dst_slot, 10) {
+        // #427: honour the pattern's relationship type. An empty `rel_ids` means
+        // "no type constraint" to the neighbour lookups, so a named type that is
+        // absent from the catalog must short-circuit rather than fall through to
+        // an unfiltered traversal of every edge type in the graph.
+        let rel_ids = self.resolve_rel_ids_for_type(&sp.rel_type);
+        if !sp.rel_type.is_empty() && rel_ids.is_empty() {
+            // No relationship table of that type exists, so no edge of that type
+            // can exist. The only reachable node is the source itself.
+            return if (src_label_id, src_slot) == (dst_label_id, dst_slot) {
+                Value::Int64(0)
+            } else {
+                Value::Null
+            };
+        }
+
+        match self.bfs_shortest_path(src_slot, src_label_id, dst_slot, dst_label_id, &rel_ids, 10) {
             Some(hops) => Value::Int64(hops as i64),
             None => Value::Null,
         }
@@ -552,53 +571,78 @@ impl Engine {
         None
     }
 
-    /// BFS from `src_slot` to `dst_slot`, returning the hop count or None.
+    /// BFS from `(src_slot, src_label_id)` to `(dst_slot, dst_label_id)`,
+    /// returning the hop count or `None` when no path exists.
     ///
-    /// Each frontier node carries its own `label_id` so that delta-log edge
-    /// lookups use the correct `(label_id, slot)` key at every hop.  Without
-    /// this, BFS through heterogeneous graphs would use the source label for
-    /// all intermediate nodes, missing WAL edges on label-boundary crossings.
+    /// Every node is identified by the **pair** `(slot, label_id)`, never by the
+    /// slot alone.  A `NodeId` is `(label_id << 32) | slot`, so slots are only
+    /// unique within a label: `Person` slot 0, `City` slot 0 and `Post` slot 0
+    /// are three different nodes.  Issue #427 was caused by comparing bare slots
+    /// in the zero-hop shortcut, in the destination test and in `visited`, which
+    /// both invented paths that did not exist and pruned real ones.
+    ///
+    /// `rel_ids` restricts the traversal to those relationship-table IDs; an
+    /// empty slice means "any type".  Callers that parsed an explicit type must
+    /// resolve it (see [`Engine::resolve_rel_ids_for_type`]) and pass the result
+    /// — issue #427 also covered the BFS passing `&[]` unconditionally, which
+    /// made `[:KNOWS*]` walk every edge type in the graph.
     pub(crate) fn bfs_shortest_path(
         &self,
         src_slot: u64,
         src_label_id: u32,
         dst_slot: u64,
+        dst_label_id: u32,
+        rel_ids: &[u32],
         max_hops: u32,
     ) -> Option<u32> {
-        if src_slot == dst_slot {
+        if (src_slot, src_label_id) == (dst_slot, dst_label_id) {
             return Some(0);
         }
         // Hoist delta read out of the BFS loop to avoid repeated I/O.
         let delta_all = self.read_delta_all();
         // SPA-283: build HashMap index for O(1) per-node delta lookups.
         let delta_idx = build_delta_index(&delta_all);
+
+        // Label hints for CSR-only destinations, mirroring `execute_variable_length`:
+        // the delta log carries full NodeIds, so every (slot, label) pair it
+        // mentions is authoritative.
+        let mut node_label: std::collections::HashSet<(u64, u32)> =
+            std::collections::HashSet::new();
+        for r in &delta_all {
+            let (src_l, src_s) = node_id_parts(r.src.0);
+            node_label.insert((src_s, src_l));
+            let (dst_l, dst_s) = node_id_parts(r.dst.0);
+            node_label.insert((dst_s, dst_l));
+        }
+        let mut all_label_ids: Vec<u32> = node_label.iter().map(|&(_, l)| l).collect();
+        all_label_ids.sort_unstable();
+        all_label_ids.dedup();
+
         // Frontier carries (slot, label_id) so each hop uses the correct label
         // when probing the delta index.
-        let mut visited: std::collections::HashSet<u64> = std::collections::HashSet::new();
-        visited.insert(src_slot);
+        let mut visited: std::collections::HashSet<(u64, u32)> = std::collections::HashSet::new();
+        visited.insert((src_slot, src_label_id));
         let mut frontier: Vec<(u64, u32)> = vec![(src_slot, src_label_id)];
+        let mut neighbors_buf: std::collections::HashSet<(u64, u32)> =
+            std::collections::HashSet::new();
 
         for depth in 1..=max_hops {
             let mut next_frontier: Vec<(u64, u32)> = Vec::new();
             for &(node_slot, node_label_id) in &frontier {
-                let neighbors =
-                    self.get_node_neighbors_by_slot(node_slot, node_label_id, &delta_idx, &[]);
-                for nb_slot in neighbors {
-                    if nb_slot == dst_slot {
+                self.get_node_neighbors_labeled(
+                    node_slot,
+                    node_label_id,
+                    &delta_idx,
+                    &node_label,
+                    &all_label_ids,
+                    &mut neighbors_buf,
+                    rel_ids,
+                );
+                for &(nb_slot, nb_label) in neighbors_buf.iter() {
+                    if (nb_slot, nb_label) == (dst_slot, dst_label_id) {
                         return Some(depth);
                     }
-                    if visited.insert(nb_slot) {
-                        // Recover the neighbor's label from the delta index; fall
-                        // back to node_label_id for CSR-only nodes in homogeneous
-                        // graphs (the same conservative default used elsewhere).
-                        let nb_label = delta_neighbors_labeled_from_index(
-                            &delta_idx,
-                            node_label_id,
-                            node_slot,
-                        )
-                        .find(|&(s, _)| s == nb_slot)
-                        .map(|(_, l)| l)
-                        .unwrap_or(node_label_id);
+                    if visited.insert((nb_slot, nb_label)) {
                         next_frontier.push((nb_slot, nb_label));
                     }
                 }

--- a/crates/sparrowdb-execution/src/engine/hop.rs
+++ b/crates/sparrowdb-execution/src/engine/hop.rs
@@ -1856,52 +1856,69 @@ impl Engine {
                 }
             }
 
-            // `frontier` holds (slot, accumulated_vals) pairs for the current
-            // boundary of the traversal.  Each entry represents one in-progress
-            // path; cloning ensures bindings are isolated across branches.
-            let mut frontier: Vec<(u64, HashMap<String, Value>)> = vec![(src_slot, row_vals)];
+            // `frontier` holds (slot, label_id, accumulated_vals) triples for the
+            // current boundary of the traversal.  Each entry represents one
+            // in-progress path; cloning ensures bindings are isolated across
+            // branches.
+            //
+            // #429: the label is carried, not re-derived.  It used to be taken
+            // from the *pattern* (`label_ids_per_node[hop_idx]`, falling back to
+            // the source's label when the position was unlabeled), so an
+            // unlabeled intermediate node was addressed as label 0 and every hop
+            // probed CSRs with a bare slot.  With `isLocatedIn` registered for
+            // both (Person)->(Place) and (Organisation)->(Place), that let
+            // Person slot 2 inherit Organisation slot 2's edges.
+            let mut frontier: Vec<(u64, u32, HashMap<String, Value>)> =
+                vec![(src_slot, src_label_id, row_vals)];
 
             for hop_idx in 0..n_rels {
                 let next_node_pat = &pat.nodes[hop_idx + 1];
                 let next_label_id_opt = label_ids_per_node[hop_idx + 1];
                 let next_col_ids = &col_ids_per_node[hop_idx + 1];
-                let cur_label_id = label_ids_per_node[hop_idx].unwrap_or(src_label_id);
 
-                let mut next_frontier: Vec<(u64, HashMap<String, Value>)> = Vec::new();
+                let mut next_frontier: Vec<(u64, u32, HashMap<String, Value>)> = Vec::new();
 
-                for (cur_slot, cur_vals) in frontier {
-                    // Gather neighbors from CSR + delta for this hop.
-                    // SPA-284: use filtered CSR lookup when rel type is specified.
-                    let csr_nb: Vec<u64> =
-                        self.csr_neighbors_filtered(cur_slot, &rel_ids_per_hop[hop_idx]);
+                for (cur_slot, cur_label_id, cur_vals) in frontier {
+                    // Gather neighbours from CSR + delta for this hop.  Both
+                    // sources report the neighbour's own label: the catalog's
+                    // `dst_label_id` for checkpointed edges, the stored NodeId
+                    // for delta edges.
+                    // SPA-284: `rel_ids` restricts the lookup to the requested types.
                     let hop_rel_ids = &rel_ids_per_hop[hop_idx];
-                    let delta_nb: Vec<u64> = delta_all
-                        .iter()
-                        .filter(|r| {
-                            let r_src_label = (r.src.0 >> 32) as u32;
-                            let r_src_slot = r.src.0 & 0xFFFF_FFFF;
-                            if r_src_label != cur_label_id || r_src_slot != cur_slot {
-                                return false;
-                            }
-                            // Filter by relation-table IDs when a type constraint exists.
-                            hop_rel_ids.is_empty() || hop_rel_ids.contains(&r.rel_id.0)
-                        })
-                        .map(|r| r.dst.0 & 0xFFFF_FFFF)
-                        .collect();
-
-                    let mut seen: HashSet<u64> = HashSet::new();
-                    let all_nb: Vec<u64> = csr_nb
+                    // `seen` deduplicates on the full identity `(slot, label)`;
+                    // `all_nb` keeps insertion order so row order stays
+                    // deterministic across runs for queries with no ORDER BY.
+                    let mut seen: HashSet<(u64, u32)> = HashSet::new();
+                    let mut all_nb: Vec<(u64, u32)> = self
+                        .csr_neighbors_labeled(cur_slot, cur_label_id, hop_rel_ids)
                         .into_iter()
-                        .chain(delta_nb)
-                        .filter(|&nb| seen.insert(nb))
+                        .filter(|nb| seen.insert(*nb))
                         .collect();
+                    for r in delta_all.iter() {
+                        let (r_src_label, r_src_slot) = node_id_parts(r.src.0);
+                        if r_src_label != cur_label_id || r_src_slot != cur_slot {
+                            continue;
+                        }
+                        // Filter by relation-table IDs when a type constraint exists.
+                        if !hop_rel_ids.is_empty() && !hop_rel_ids.contains(&r.rel_id.0) {
+                            continue;
+                        }
+                        let (r_dst_label, r_dst_slot) = node_id_parts(r.dst.0);
+                        if seen.insert((r_dst_slot, r_dst_label)) {
+                            all_nb.push((r_dst_slot, r_dst_label));
+                        }
+                    }
 
-                    for next_slot in all_nb {
-                        let next_node_id = if let Some(lbl_id) = next_label_id_opt {
-                            NodeId(((lbl_id as u64) << 32) | next_slot)
-                        } else {
-                            NodeId(next_slot)
-                        };
+                    for (next_slot, next_label_id) in all_nb {
+                        // When this position carries a label, the neighbour must
+                        // actually have it — matching on the slot alone would
+                        // admit the same-numbered node of any other label.
+                        if let Some(required) = next_label_id_opt {
+                            if next_label_id != required {
+                                continue;
+                            }
+                        }
+                        let next_node_id = NodeId(((next_label_id as u64) << 32) | next_slot);
 
                         let next_props =
                             read_node_props(&self.snapshot.store, next_node_id, next_col_ids)?;
@@ -1921,7 +1938,7 @@ impl Engine {
                             }
                         }
 
-                        next_frontier.push((next_slot, new_vals));
+                        next_frontier.push((next_slot, next_label_id, new_vals));
                     }
                 }
 
@@ -1929,7 +1946,7 @@ impl Engine {
             }
 
             // `frontier` now contains complete paths.  Project result rows.
-            for (_final_slot, path_vals) in frontier {
+            for (_final_slot, _final_label_id, path_vals) in frontier {
                 // Apply WHERE clause using the full accumulated binding map.
                 if let Some(ref where_expr) = m.where_clause {
                     let mut eval_vals = path_vals.clone();

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -76,23 +76,11 @@ pub(crate) fn delta_neighbors_from_index(
         .unwrap_or_default()
 }
 
-/// Look up delta neighbors for a given `(src_label_id, src_slot)` and return
-/// `(dst_slot, dst_label_id)` pairs extracted from the full dst `NodeId`.
-pub(crate) fn delta_neighbors_labeled_from_index(
-    index: &DeltaIndex,
-    src_label_id: u32,
-    src_slot: u64,
-) -> impl Iterator<Item = (u64, u32)> + '_ {
-    index
-        .get(&(src_label_id, src_slot))
-        .into_iter()
-        .flat_map(|recs| {
-            recs.iter().map(|r| {
-                let (dst_label, dst_slot) = node_id_parts(r.dst.0);
-                (dst_slot, dst_label)
-            })
-        })
-}
+// NOTE (#427): `delta_neighbors_labeled_from_index` was removed here.  Its only
+// caller was `bfs_shortest_path`, which used it to guess a neighbour's label
+// *after* the label had already been thrown away by a slot-only lookup.
+// `Engine::get_node_neighbors_labeled` keeps the label attached throughout and
+// is the correct entry point.
 
 // ── DegreeCache (SPA-272) ─────────────────────────────────────────────────────
 

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -237,9 +237,62 @@ pub struct ReadSnapshot {
     /// decode of the index file.  With it the file is read at most once per
     /// `(label, property)` pair per query.
     fts_cache: std::sync::Mutex<HashMap<(String, String), sparrowdb_storage::fts_index::FtsIndex>>,
+    /// Lazily-built CSR topology: which relationship tables exist and what
+    /// labels their endpoints carry.  See [`CsrTopology`].
+    ///
+    /// Built on first neighbour lookup.  `list_rel_tables_with_ids()` clones a
+    /// `String` per table, so calling it once per node in a traversal loop was
+    /// not an option; this caches the label triples the traversal actually
+    /// needs.  `OnceLock` (not `OnceCell`) keeps `ReadSnapshot: Sync`.
+    csr_topology: std::sync::OnceLock<CsrTopology>,
+}
+
+/// Which relationship tables a traversal may follow, and what labels their
+/// endpoints carry.
+///
+/// Derived from the catalog, which registers every relationship table as
+/// `(rel_table_id, src_label_id, dst_label_id, rel_type)`.  A `CsrForward` holds
+/// exactly one table's edges and is indexed by the source slot *of that table's
+/// source label*, so these triples are what make a CSR hit interpretable: they
+/// say which node the slot belongs to and which node the neighbour is.
+#[derive(Debug, Default)]
+struct CsrTopology {
+    /// `(rel_table_id, src_label_id, dst_label_id)` for every catalogued
+    /// relationship table that has a loaded CSR.
+    tables: Vec<(u32, u32, u32)>,
+    /// CSRs loaded without a catalog entry, so with no label metadata.
+    ///
+    /// `open_csr_map` always attempts `RelTableId(0)` so that CSRs checkpointed
+    /// before the catalog carried rel-table entries (pre-SPA-185 data, and
+    /// `Engine::with_single_csr`) remain readable.  Such graphs are
+    /// single-label by construction — the catalog gained rel tables in the same
+    /// release that made more than one label reachable — so the source label is
+    /// the only label there is, and is used for both endpoints.
+    unlabeled: Vec<u32>,
 }
 
 impl ReadSnapshot {
+    /// Return the CSR topology, building it from the catalog on first use.
+    fn csr_topology(&self) -> &CsrTopology {
+        self.csr_topology.get_or_init(|| {
+            let mut topo = CsrTopology::default();
+            let mut catalogued: HashSet<u32> = HashSet::new();
+            for (id, src_lid, dst_lid, _) in self.catalog.list_rel_tables_with_ids() {
+                let rid = id as u32;
+                catalogued.insert(rid);
+                if self.csrs.contains_key(&rid) {
+                    topo.tables.push((rid, src_lid as u32, dst_lid as u32));
+                }
+            }
+            for rid in self.csrs.keys() {
+                if !catalogued.contains(rid) {
+                    topo.unlabeled.push(*rid);
+                }
+            }
+            topo
+        })
+    }
+
     /// Return a reference to the FTS index for `(label, property)`, loading
     /// it from disk the first time it is requested within this query.
     ///
@@ -505,6 +558,7 @@ impl Engine {
             edge_props_cache: shared_edge_props_cache
                 .unwrap_or_else(|| std::sync::Arc::new(std::sync::RwLock::new(HashMap::new()))),
             fts_cache: std::sync::Mutex::new(HashMap::new()),
+            csr_topology: std::sync::OnceLock::new(),
         };
 
         // If a shared cached index was provided, clone it out so we start
@@ -700,32 +754,84 @@ impl Engine {
             .unwrap_or_default()
     }
 
-    /// Return neighbor slots merged across **all** registered rel types.
-    fn csr_neighbors_all(&self, src_slot: u64) -> Vec<u64> {
-        let mut out: Vec<u64> = Vec::new();
-        for csr in self.snapshot.csrs.values() {
-            out.extend_from_slice(csr.neighbors(src_slot));
+    /// Return the outgoing CSR neighbours of the node `(src_slot, src_label_id)`
+    /// as `(dst_slot, dst_label_id)` pairs.
+    ///
+    /// # Why the source label is a parameter
+    ///
+    /// A `NodeId` is `(label_id << 32) | slot`, so a slot number alone does not
+    /// identify a node: `Person` slot 2, `Place` slot 2 and `Post` slot 2 are
+    /// three different nodes.  A `CsrForward` is indexed by the source slot of
+    /// **one** relationship table, and a relationship table is registered in the
+    /// catalog as `(rel_table_id, src_label_id, dst_label_id, rel_type)`.
+    ///
+    /// The previous slot-only helpers (`csr_neighbors_all` /
+    /// `csr_neighbors_filtered`) probed every CSR with a bare slot, so a node of
+    /// label A inherited the edges of the node of label B that happened to
+    /// occupy the same slot number (#429), and returned bare slots, so callers
+    /// had to reconstruct the destination label by guesswork (#431) or drop it
+    /// entirely (#427).
+    ///
+    /// Consulting the catalog fixes both halves at once:
+    /// * skip any table whose `src_label_id` differs from the caller's — that
+    ///   table's CSR is not indexed by this node's slot at all;
+    /// * tag every hit with that table's `dst_label_id` — for a CSR hit the
+    ///   destination label is *known*, never inferred.
+    ///
+    /// `rel_ids` restricts the traversal to those relationship-table IDs; an
+    /// empty slice means "any type".
+    fn csr_neighbors_labeled(
+        &self,
+        src_slot: u64,
+        src_label_id: u32,
+        rel_ids: &[u32],
+    ) -> Vec<(u64, u32)> {
+        let topo = self.snapshot.csr_topology();
+        let mut out: Vec<(u64, u32)> = Vec::new();
+        for &(rid, tbl_src_lid, tbl_dst_lid) in &topo.tables {
+            if !rel_ids.is_empty() && !rel_ids.contains(&rid) {
+                continue;
+            }
+            if tbl_src_lid != src_label_id {
+                continue;
+            }
+            if let Some(csr) = self.snapshot.csrs.get(&rid) {
+                out.extend(csr.neighbors(src_slot).iter().map(|&s| (s, tbl_dst_lid)));
+            }
+        }
+        // Legacy CSRs with no catalog entry carry no label metadata; see
+        // [`CsrTopology::unlabeled`].  A type filter can never select one
+        // because a type name is exactly what they lack.
+        if rel_ids.is_empty() {
+            for rid in &topo.unlabeled {
+                if let Some(csr) = self.snapshot.csrs.get(rid) {
+                    out.extend(csr.neighbors(src_slot).iter().map(|&s| (s, src_label_id)));
+                }
+            }
         }
         out
     }
 
-    /// Return neighbor slots from the CSR, filtered to a specific set of
-    /// relation-type IDs.  When `rel_ids` is empty, falls back to scanning
-    /// all CSR tables (equivalent to [`csr_neighbors_all`]).
+    /// Destination **slots** of the outgoing CSR edges of `(src_slot,
+    /// src_label_id)`, restricted to edges that land on `dst_label_id` when it
+    /// is `Some`.
     ///
-    /// This avoids the overhead of merging neighbors from irrelevant relation
-    /// types on heterogeneous graphs where only one or a few types are needed.
-    fn csr_neighbors_filtered(&self, src_slot: u64, rel_ids: &[u32]) -> Vec<u64> {
-        if rel_ids.is_empty() {
-            return self.csr_neighbors_all(src_slot);
-        }
-        let mut out: Vec<u64> = Vec::new();
-        for &rid in rel_ids {
-            if let Some(csr) = self.snapshot.csrs.get(&rid) {
-                out.extend_from_slice(csr.neighbors(src_slot));
-            }
-        }
-        out
+    /// For callers that already know the destination's label because they build
+    /// the destination `NodeId` from it.  Filtering here rather than after the
+    /// `NodeId` is built is what stops a `Place` slot from being read as the
+    /// `Person` in the same slot.  See [`Engine::csr_neighbors_labeled`].
+    fn csr_neighbor_slots_to_label(
+        &self,
+        src_slot: u64,
+        src_label_id: u32,
+        dst_label_id: Option<u32>,
+        rel_ids: &[u32],
+    ) -> Vec<u64> {
+        self.csr_neighbors_labeled(src_slot, src_label_id, rel_ids)
+            .into_iter()
+            .filter(|(_, lid)| dst_label_id.is_none_or(|want| *lid == want))
+            .map(|(slot, _)| slot)
+            .collect()
     }
 
     /// Resolve all rel-table IDs whose type name matches `rel_type`.

--- a/crates/sparrowdb-execution/src/engine/mutation.rs
+++ b/crates/sparrowdb-execution/src/engine/mutation.rs
@@ -612,7 +612,10 @@ impl Engine {
                     for r in records {
                         let s = r.src.0;
                         let s_label = (s >> 32) as u32;
-                        if s_label == src_label_id {
+                        let d_label = (r.dst.0 >> 32) as u32;
+                        // Slots are label-relative: an edge landing on another
+                        // label must not be read as a `dst_label_id` node.
+                        if s_label == src_label_id && d_label == dst_label_id {
                             let s_slot = s & 0xFFFF_FFFF;
                             adj.entry(s_slot).or_default().push(r.dst.0 & 0xFFFF_FFFF);
                         }
@@ -645,7 +648,12 @@ impl Engine {
                     // Collect outgoing neighbours (CSR + delta adjacency map).
                     let csr_neighbors_vec: Vec<u64> = match rel_lookup {
                         RelTableLookup::Found(rtid) => self.csr_neighbors(rtid, src_slot),
-                        _ => self.csr_neighbors_all(src_slot),
+                        _ => self.csr_neighbor_slots_to_label(
+                            src_slot,
+                            src_label_id,
+                            Some(dst_label_id),
+                            &[],
+                        ),
                     };
                     let empty: Vec<u64> = Vec::new();
                     let delta_neighbors: &[u64] =

--- a/crates/sparrowdb-execution/src/engine/path.rs
+++ b/crates/sparrowdb-execution/src/engine/path.rs
@@ -268,28 +268,11 @@ impl Engine {
         results
     }
 
-    /// Compatibility shim used by callers that do not need per-node label tracking.
-    pub(crate) fn get_node_neighbors_by_slot(
-        &self,
-        src_slot: u64,
-        src_label_id: u32,
-        delta_idx: &DeltaIndex,
-        rel_ids: &[u32],
-    ) -> Vec<u64> {
-        // SPA-284: use filtered CSR lookup when rel type IDs are provided.
-        let csr_neighbors: Vec<u64> = self.csr_neighbors_filtered(src_slot, rel_ids);
-        // SPA-283: O(1) indexed lookup instead of linear scan.
-        // SPA-284: filter by relation-table IDs when a type constraint exists.
-        let mut all: std::collections::HashSet<u64> = csr_neighbors.into_iter().collect();
-        if let Some(recs) = delta_idx.get(&(src_label_id, src_slot)) {
-            all.extend(
-                recs.iter()
-                    .filter(|r| rel_ids.is_empty() || rel_ids.contains(&r.rel_id.0))
-                    .map(|r| node_id_parts(r.dst.0).1),
-            );
-        }
-        all.into_iter().collect()
-    }
+    // NOTE (#427): the former `get_node_neighbors_by_slot` shim lived here.  It
+    // returned bare `Vec<u64>` slots, discarding the neighbour labels, and its
+    // last caller (`bfs_shortest_path`) was the source of the #427 slot-aliasing
+    // bug.  Use `get_node_neighbors_labeled` instead — slots are only unique
+    // within a label, so a neighbour is never fully identified by its slot.
 
     /// Execute a variable-length path query: `MATCH (a:L1)-[:R*M..N]->(b:L2) RETURN …`.
     pub(crate) fn execute_variable_length(

--- a/crates/sparrowdb-execution/src/engine/path.rs
+++ b/crates/sparrowdb-execution/src/engine/path.rs
@@ -4,37 +4,42 @@ use super::*;
 impl Engine {
     // ── Variable-length path traversal: (a)-[:R*M..N]->(b) ──────────────────
 
-    /// Collect all neighbor slot-ids reachable from `src_slot` via the delta
-    /// log and CSR adjacency.  src_label_id is used to filter delta records.
+    /// Return the labeled outgoing neighbours of `(src_slot, src_label_id)`
+    /// into `out`, each entry a `(dst_slot, dst_label_id)` pair.
     ///
-    /// SPA-185: reads across all rel types (used by variable-length path
-    /// traversal which does not currently filter on rel_type).
-    /// Return the labeled outgoing neighbors of `(src_slot, src_label_id)`.
+    /// Both edge sources agree on where the destination's label comes from, and
+    /// neither guesses:
     ///
-    /// Each entry is `(dst_slot, dst_label_id)`.  The delta log encodes the full
-    /// NodeId in `r.dst`, so label_id is recovered precisely.  For CSR-only
-    /// destinations the label is looked up in the `node_label` hint map (built
-    /// from the delta by the caller); if absent, `src_label_id` is used as a
-    /// conservative fallback (correct for homogeneous graphs).
-    #[allow(clippy::too_many_arguments)]
+    /// * **Checkpointed edges** live in a CSR, one per relationship table, and
+    ///   the catalog registers every table as `(id, src_label_id, dst_label_id,
+    ///   rel_type)`.  So a CSR hit's label is *known* — see
+    ///   [`Engine::csr_neighbors_labeled`], which also skips tables whose
+    ///   `src_label_id` does not match, because their CSR is not indexed by this
+    ///   node's slot.
+    /// * **Uncheckpointed edges** live in the delta log, which stores full
+    ///   `NodeId`s, so the label is read straight off `r.dst`.
+    ///
+    /// Issue #431: this used to recover CSR neighbour labels from hints built
+    /// out of `read_delta_all()`, falling back to `src_label_id` when no hint
+    /// existed.  `checkpoint()` truncates the delta log, so every hint vanished
+    /// and every CSR neighbour silently took the source's label — making
+    /// cross-label variable-length traversal return correct results before a
+    /// checkpoint and empty ones after.
     pub(crate) fn get_node_neighbors_labeled(
         &self,
         src_slot: u64,
         src_label_id: u32,
         delta_idx: &DeltaIndex,
-        node_label: &std::collections::HashSet<(u64, u32)>,
-        all_label_ids: &[u32],
         out: &mut std::collections::HashSet<(u64, u32)>,
         rel_ids: &[u32],
     ) {
         out.clear();
 
-        // ── CSR neighbors (slot only; label recovered by scanning all label HWMs
-        //    or falling back to src_label_id for homogeneous graphs) ────────────
-        // SPA-284: use filtered CSR lookup when rel type IDs are provided.
-        let csr_slots: Vec<u64> = self.csr_neighbors_filtered(src_slot, rel_ids);
+        // ── CSR neighbours: label from the catalog ────────────────────────────
+        // SPA-284: `rel_ids` restricts the lookup to the requested types.
+        out.extend(self.csr_neighbors_labeled(src_slot, src_label_id, rel_ids));
 
-        // ── Delta neighbors (full NodeId available) ───────────────────────────
+        // ── Delta neighbours: label from the stored NodeId ────────────────────
         // SPA-283: O(1) indexed lookup instead of linear scan.
         // SPA-284: filter by relation-table IDs when a type constraint exists.
         if let Some(recs) = delta_idx.get(&(src_label_id, src_slot)) {
@@ -42,37 +47,8 @@ impl Engine {
                 if !rel_ids.is_empty() && !rel_ids.contains(&r.rel_id.0) {
                     continue;
                 }
-                let dst_slot = r.dst.0 & 0xFFFF_FFFF;
-                let dst_label = (r.dst.0 >> 32) as u32;
+                let (dst_label, dst_slot) = node_id_parts(r.dst.0);
                 out.insert((dst_slot, dst_label));
-            }
-        }
-
-        // For each CSR slot, determine label: prefer a delta-confirmed label,
-        // else scan all known label ids to find one whose HWM covers that slot.
-        // If no label confirms it, fall back to src_label_id.
-        'csr: for dst_slot in csr_slots {
-            // Check if delta already gave us a label for this slot.
-            for &lid in all_label_ids {
-                if out.contains(&(dst_slot, lid)) {
-                    continue 'csr; // already recorded with correct label
-                }
-            }
-            // Try to determine the dst label from the delta node_label registry.
-            // node_label contains (slot, label_id) pairs seen anywhere in delta.
-            let mut found = false;
-            for &lid in all_label_ids {
-                if node_label.contains(&(dst_slot, lid)) {
-                    out.insert((dst_slot, lid));
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                // No label info available — fallback to src_label_id (correct for
-                // homogeneous graphs, gracefully wrong for unmapped CSR-only nodes
-                // in heterogeneous graphs with no delta activity on those nodes).
-                out.insert((dst_slot, src_label_id));
             }
         }
     }
@@ -105,8 +81,6 @@ impl Engine {
         min_hops: u32,
         max_hops: u32,
         delta_idx: &DeltaIndex,
-        node_label: &std::collections::HashSet<(u64, u32)>,
-        all_label_ids: &[u32],
         neighbors_buf: &mut std::collections::HashSet<(u64, u32)>,
         use_reachability: bool,
         result_limit: usize,
@@ -152,8 +126,6 @@ impl Engine {
                     cur_slot,
                     cur_label,
                     delta_idx,
-                    node_label,
-                    all_label_ids,
                     neighbors_buf,
                     rel_ids,
                 );
@@ -200,8 +172,6 @@ impl Engine {
                 src_slot,
                 src_label_id,
                 delta_idx,
-                node_label,
-                all_label_ids,
                 neighbors_buf,
                 rel_ids,
             );
@@ -251,8 +221,6 @@ impl Engine {
                                 nb_slot,
                                 nb_label,
                                 delta_idx,
-                                node_label,
-                                all_label_ids,
                                 neighbors_buf,
                                 rel_ids,
                             );
@@ -377,26 +345,17 @@ impl Engine {
             .into_iter()
             .collect();
 
-        // SPA-275: hoist delta read and node_label map out of the per-source loop.
-        // Previously execute_variable_hops rebuilt these on every call — O(sources)
-        // delta reads and O(sources × delta_records) HashMap insertions per query.
-        // Now we build them once and pass references into the BFS.
+        // SPA-275: hoist the delta read out of the per-source loop.  Previously
+        // execute_variable_hops rebuilt it on every call — O(sources) delta reads
+        // per query.  Now we build it once and pass a reference into the BFS.
+        //
+        // #431: the `node_label` hint set and `all_label_ids` that used to be
+        // built here are gone.  They existed only to guess a CSR neighbour's
+        // label, and they were derived from the delta log, so `checkpoint()`
+        // erased them.  Neighbour labels now come from the catalog.
         let delta_all = self.read_delta_all();
         // SPA-283: build HashMap index for O(1) per-node delta lookups.
         let delta_idx = build_delta_index(&delta_all);
-        let mut node_label: std::collections::HashSet<(u64, u32)> =
-            std::collections::HashSet::new();
-        for r in &delta_all {
-            let src_s = r.src.0 & 0xFFFF_FFFF;
-            let src_l = (r.src.0 >> 32) as u32;
-            node_label.insert((src_s, src_l));
-            let dst_s = r.dst.0 & 0xFFFF_FFFF;
-            let dst_l = (r.dst.0 >> 32) as u32;
-            node_label.insert((dst_s, dst_l));
-        }
-        let mut all_label_ids: Vec<u32> = node_label.iter().map(|&(_, l)| l).collect();
-        all_label_ids.sort_unstable();
-        all_label_ids.dedup();
 
         // SPA-284: pre-resolve rel-type IDs so the BFS/DFS uses filtered CSR lookups.
         let rel_ids = self.resolve_rel_ids_for_type(&rel_pat.rel_type);
@@ -487,8 +446,8 @@ impl Engine {
                 }
 
                 // BFS to find all reachable (slot, label_id) pairs within [min_hops, max_hops].
-                // delta_all, node_label, all_label_ids, and neighbors_buf are hoisted out of
-                // this loop (SPA-275) and reused across all source nodes.
+                // delta_idx and neighbors_buf are hoisted out of this loop (SPA-275)
+                // and reused across all source nodes.
                 // Use reachability BFS when RETURN DISTINCT is present and no path variable
                 // is bound (issue #165). Otherwise use enumerative DFS for full path semantics.
                 let use_reachability = m.distinct && rel_pat.var.is_empty();
@@ -500,8 +459,6 @@ impl Engine {
                     min_hops,
                     max_hops,
                     &delta_idx,
-                    &node_label,
-                    &all_label_ids,
                     &mut neighbors_buf,
                     use_reachability,
                     remaining,

--- a/crates/sparrowdb-execution/src/engine/scan.rs
+++ b/crates/sparrowdb-execution/src/engine/scan.rs
@@ -517,16 +517,28 @@ impl Engine {
             let dst_slots: Vec<u64> = match &rel_table_id {
                 RelTableLookup::Found(rtid) => self.csr_neighbors(*rtid, src_slot),
                 RelTableLookup::NotFound => continue,
-                RelTableLookup::All => self.csr_neighbors_all(src_slot),
+                // Untyped edge: restrict to tables that run from this node's
+                // label to `dst_label_id`, which is the label the destination
+                // NodeId is built from a few lines below.
+                RelTableLookup::All => self.csr_neighbor_slots_to_label(
+                    src_slot,
+                    src_label_id,
+                    Some(dst_label_id),
+                    &[],
+                ),
             };
-            // Also check the delta.
+            // Also check the delta.  Slots are label-relative, so an edge that
+            // lands on a different label must not be read as `dst_label_id`.
             let delta_slots: Vec<u64> = self
                 .read_delta_all()
                 .into_iter()
                 .filter(|r| {
                     let r_src_label = (r.src.0 >> 32) as u32;
                     let r_src_slot = r.src.0 & 0xFFFF_FFFF;
-                    r_src_label == src_label_id && r_src_slot == src_slot
+                    let r_dst_label = (r.dst.0 >> 32) as u32;
+                    r_src_label == src_label_id
+                        && r_src_slot == src_slot
+                        && r_dst_label == dst_label_id
                 })
                 .map(|r| r.dst.0 & 0xFFFF_FFFF)
                 .collect();
@@ -1542,7 +1554,12 @@ impl Engine {
                 .filter(|r| {
                     let r_src_label = (r.src.0 >> 32) as u32;
                     let r_src_slot = r.src.0 & 0xFFFF_FFFF;
-                    r_src_label == src_label_id && r_src_slot == src_slot
+                    let r_dst_label = (r.dst.0 >> 32) as u32;
+                    // Slots are label-relative: an edge landing on another label
+                    // must not be read as a `dst_label_id` node.
+                    r_src_label == src_label_id
+                        && r_src_slot == src_slot
+                        && r_dst_label == dst_label_id
                 })
                 .map(|r| r.dst.0 & 0xFFFF_FFFF)
                 .collect()
@@ -1550,7 +1567,7 @@ impl Engine {
 
         let csr_neighbors = match rel_lookup {
             RelTableLookup::Found(rtid) => self.csr_neighbors(rtid, src_slot),
-            _ => self.csr_neighbors_all(src_slot),
+            _ => self.csr_neighbor_slots_to_label(src_slot, src_label_id, Some(dst_label_id), &[]),
         };
         let all_neighbors: Vec<u64> = csr_neighbors.into_iter().chain(delta_neighbors).collect();
 

--- a/crates/sparrowdb/tests/regression_427_shortest_path_heterogeneous.rs
+++ b/crates/sparrowdb/tests/regression_427_shortest_path_heterogeneous.rs
@@ -1,0 +1,307 @@
+//! Regression tests for issue #427 — `shortestPath()` on heterogeneous graphs.
+//!
+//! Two independent faults lived in `Engine::bfs_shortest_path`:
+//!
+//! 1. **The relationship-type filter was discarded.** The BFS called
+//!    `get_node_neighbors_by_slot(..., &[])`; the empty `rel_ids` slice means
+//!    "no type filter", so a BFS for `[:KNOWS*]` walked every edge type in the
+//!    graph.
+//! 2. **Nodes were identified by storage slot alone, without their label.**
+//!    A `NodeId` is `(label_id << 32) | slot`, so slot 0 exists once per label.
+//!    The destination test (`nb_slot == dst_slot`), the zero-hop test
+//!    (`src_slot == dst_slot`) and the `visited` set all compared bare slots,
+//!    so a `City` and a `Person` that happen to occupy the same slot aliased
+//!    each other. That produced both false positives (reporting a path that
+//!    does not exist) and silent pruning (dropping the only real path).
+//!
+//! Every expected value below is derived **by hand** from the fixture defined
+//! in [`build_graph`] — none of it was captured from program output. The
+//! derivation is spelled out in each test's comment.
+//!
+//! No-path contract: `shortestPath()` evaluates to `Value::Null` when no path
+//! exists (openCypher semantics, and what `spa_136_shortest_path.rs` and
+//! `spa_139_phase9_path_acceptance.rs` already assert).
+
+use sparrowdb::open;
+use sparrowdb_execution::types::Value;
+
+// ── Fixture ─────────────────────────────────────────────────────────────────
+//
+// Three node labels, four relationship types, and a deliberately isolated node.
+//
+// Slots are assigned per label in creation order, so the fixture is written so
+// that slot collisions ACROSS labels are unavoidable — that is the whole point.
+//
+//   Person slots: 0 Alice  1 Bob  2 Carol  3 Dave  4 Erin  5 Frank  6 Grace
+//   City   slots: 0 Metro   1 Junction
+//   Post   slots: 0 Hello
+//
+// Edges (creation order matters for the pruning test — see `Post`/`Person`
+// collision on slot 0 below):
+//
+//   e1  Alice -[:LIVES_IN]-> Junction     Person 0 -> City 1
+//   e2  Alice -[:KNOWS]->    Bob          Person 0 -> Person 1
+//   e3  Bob   -[:KNOWS]->    Carol        Person 1 -> Person 2
+//   e4  Carol -[:KNOWS]->    Dave         Person 2 -> Person 3
+//   e5  Dave  -[:LIVES_IN]-> Metro        Person 3 -> City 0
+//   e6  Dave  -[:LIKES]->    Hello        Person 3 -> Post 0
+//   e7  Erin  -[:LIVES_IN]-> Metro        Person 4 -> City 0
+//   e8  Alice -[:FOLLOWS]->  Erin         Person 0 -> Person 4
+//   e9  Bob   -[:MENTIONS]-> Hello        Person 1 -> Post 0     <-- created first
+//   e10 Bob   -[:MENTIONS]-> Alice        Person 1 -> Person 0   <-- same slot (0)
+//   e11 Alice -[:MENTIONS]-> Carol        Person 0 -> Person 2
+//   e12 Alice -[:MENTIONS]-> Frank        Person 0 -> Person 5
+//
+// Grace (Person 6) has no edges at all.
+//
+// The complete KNOWS sub-graph is the one-directional chain
+//   Alice -> Bob -> Carol -> Dave
+// so under `[:KNOWS*]`:
+//   * Erin, Frank, every City and every Post are unreachable from anywhere;
+//   * Dave and Erin have no outgoing KNOWS edge at all;
+//   * there is no route back from Carol or Dave to Alice.
+
+fn build_graph() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+
+    // Nodes — creation order fixes the per-label slot numbers listed above.
+    for name in ["Alice", "Bob", "Carol", "Dave", "Erin", "Frank", "Grace"] {
+        db.execute(&format!("CREATE (p:Person {{name: '{name}'}})"))
+            .expect("CREATE Person");
+    }
+    for name in ["Metro", "Junction"] {
+        db.execute(&format!("CREATE (c:City {{name: '{name}'}})"))
+            .expect("CREATE City");
+    }
+    db.execute("CREATE (p:Post {name: 'Hello'})")
+        .expect("CREATE Post");
+
+    // Edges, in the order documented above.
+    let edges: [(&str, &str, &str, &str, &str); 12] = [
+        ("Person", "Alice", "LIVES_IN", "City", "Junction"),
+        ("Person", "Alice", "KNOWS", "Person", "Bob"),
+        ("Person", "Bob", "KNOWS", "Person", "Carol"),
+        ("Person", "Carol", "KNOWS", "Person", "Dave"),
+        ("Person", "Dave", "LIVES_IN", "City", "Metro"),
+        ("Person", "Dave", "LIKES", "Post", "Hello"),
+        ("Person", "Erin", "LIVES_IN", "City", "Metro"),
+        ("Person", "Alice", "FOLLOWS", "Person", "Erin"),
+        ("Person", "Bob", "MENTIONS", "Post", "Hello"),
+        ("Person", "Bob", "MENTIONS", "Person", "Alice"),
+        ("Person", "Alice", "MENTIONS", "Person", "Carol"),
+        ("Person", "Alice", "MENTIONS", "Person", "Frank"),
+    ];
+    for (src_label, src_name, rel, dst_label, dst_name) in edges {
+        db.execute(&format!(
+            "MATCH (s:{src_label} {{name: '{src_name}'}}), \
+                   (d:{dst_label} {{name: '{dst_name}'}}) \
+             CREATE (s)-[:{rel}]->(d)"
+        ))
+        .expect("CREATE edge");
+    }
+
+    (dir, db)
+}
+
+/// Run `shortestPath((s)-[:REL*]->(d))` between two named nodes and return the
+/// single scalar it produced.
+fn sp(
+    db: &sparrowdb::GraphDb,
+    src_label: &str,
+    src_name: &str,
+    rel: &str,
+    dst_label: &str,
+    dst_name: &str,
+) -> Value {
+    let q = format!(
+        "MATCH (s:{src_label} {{name: '{src_name}'}}), \
+               (d:{dst_label} {{name: '{dst_name}'}}) \
+         RETURN shortestPath((s)-[:{rel}*]->(d))"
+    );
+    let result = db.execute(&q).expect("shortestPath query must not error");
+    assert_eq!(result.rows.len(), 1, "expected exactly one row for: {q}");
+    assert_eq!(
+        result.rows[0].len(),
+        1,
+        "expected exactly one column for: {q}"
+    );
+    result.rows[0][0].clone()
+}
+
+// ── Fault 1: the relationship-type filter must be honoured ──────────────────
+
+/// Alice reaches Erin in one hop — but only over `FOLLOWS` (e8), never over
+/// `KNOWS`. The KNOWS closure of Alice is exactly {Bob, Carol, Dave} (e2, e3,
+/// e4), so Erin is not in it and `shortestPath((Alice)-[:KNOWS*]->(Erin))` has
+/// no path: NULL.
+///
+/// Both endpoints are `Person`, so label aliasing cannot explain a wrong
+/// answer here — this isolates fault 1. Before the fix the BFS ignored the
+/// type and crossed the FOLLOWS edge, reporting 1.
+#[test]
+fn rel_type_filter_is_applied_between_same_label_nodes() {
+    let (_dir, db) = build_graph();
+    assert_eq!(
+        sp(&db, "Person", "Alice", "KNOWS", "Person", "Erin"),
+        Value::Null,
+        "Erin is reachable from Alice only via FOLLOWS; [:KNOWS*] must find no path"
+    );
+}
+
+/// The exact reproduction from issue #427.
+///
+/// Dave's only outgoing edges are `LIVES_IN` -> Metro (e5) and `LIKES` ->
+/// Hello (e6). He has no outgoing `KNOWS` edge at all, so under `[:KNOWS*]`
+/// his frontier is empty at depth 1 and nothing is reachable: NULL.
+///
+/// Before the fix both faults combined: the type filter was dropped, so Dave's
+/// neighbours were City slot 0 and Post slot 0; the destination Alice is
+/// Person slot 0; the bare-slot comparison matched and the query returned 1.
+#[test]
+fn source_with_no_edge_of_queried_type_has_no_path() {
+    let (_dir, db) = build_graph();
+    assert_eq!(
+        sp(&db, "Person", "Dave", "KNOWS", "Person", "Alice"),
+        Value::Null,
+        "Dave has no outgoing KNOWS edge, so no KNOWS path to Alice exists"
+    );
+}
+
+// ── Fault 2: nodes must be identified by (slot, label), not slot ────────────
+
+/// Erin's only outgoing edge is `LIVES_IN` -> Metro (e7), and Metro has no
+/// outgoing edges at all. So `shortestPath((Erin)-[:LIVES_IN*]->(Alice))` has
+/// no path: NULL.
+///
+/// This isolates fault 2. Erin has exactly one outgoing edge and it is of the
+/// queried type, so discarding the type filter changes nothing — the only way
+/// to get a wrong answer is the destination test. Metro is City slot 0 and
+/// Alice is Person slot 0; before the fix `nb_slot == dst_slot` matched and the
+/// query returned 1.
+#[test]
+fn destination_match_requires_the_label_to_agree() {
+    let (_dir, db) = build_graph();
+    assert_eq!(
+        sp(&db, "Person", "Erin", "LIVES_IN", "Person", "Alice"),
+        Value::Null,
+        "Erin's LIVES_IN neighbour is Metro (City), not Alice (Person)"
+    );
+}
+
+/// Alice is Person slot 0; Metro is City slot 0. They are different nodes and
+/// there is no edge between them: Alice's only `LIVES_IN` edge is e1, to
+/// Junction, and Junction has no outgoing edges. So
+/// `shortestPath((Alice)-[:LIVES_IN*]->(Metro))` has no path: NULL.
+///
+/// Before the fix the zero-hop shortcut `if src_slot == dst_slot { Some(0) }`
+/// fired on the bare slot and returned 0 — claiming the source and the
+/// destination were the same node.
+#[test]
+fn zero_hop_shortcut_requires_the_label_to_agree() {
+    let (_dir, db) = build_graph();
+    assert_eq!(
+        sp(&db, "Person", "Alice", "LIVES_IN", "City", "Metro"),
+        Value::Null,
+        "Person slot 0 (Alice) and City slot 0 (Metro) are different nodes"
+    );
+}
+
+/// The silent half of fault 2: a real path being pruned away.
+///
+/// Bob has two outgoing `MENTIONS` edges: e9 to Hello (Post slot 0) and e10 to
+/// Alice (Person slot 0). Alice in turn mentions Frank (e12). Bob has no
+/// `MENTIONS` edge to Frank, and Hello has no outgoing edges at all, so
+/// `shortestPath((Bob)-[:MENTIONS*]->(Frank))` = **2**: Bob -> Alice -> Frank.
+///
+/// Before the fix the two hop-1 neighbours collapsed into one:
+/// `get_node_neighbors_by_slot` returns a `HashSet<u64>` of bare slots, so
+/// `{Post 0, Person 0}` became the single entry `0`. The neighbour's label was
+/// then recovered by taking the first delta record with that destination slot
+/// — e9, created first, i.e. the Post. Alice was therefore never expanded, the
+/// frontier died at the dead-end Post, and the query returned NULL for a path
+/// that plainly exists. Frank sits at Person slot 5, which no node of any other
+/// label occupies in this fixture, so the destination test cannot rescue it.
+#[test]
+fn slot_aliasing_does_not_prune_the_only_real_path() {
+    let (_dir, db) = build_graph();
+    assert_eq!(
+        sp(&db, "Person", "Bob", "MENTIONS", "Person", "Frank"),
+        Value::Int64(2),
+        "Bob -[:MENTIONS]-> Alice -[:MENTIONS]-> Frank is 2 hops"
+    );
+}
+
+// ── Distances must not be understated by cross-type shortcuts ───────────────
+
+/// The KNOWS chain is Alice -> Bob -> Carol -> Dave (e2, e3, e4), so
+/// `shortestPath((Alice)-[:KNOWS*]->(Dave))` = **3**, and
+/// `shortestPath((Alice)-[:KNOWS*]->(Bob))` = **1**.
+///
+/// Before the fix the 3-hop answer came back as 2: with the type filter gone,
+/// Alice's `MENTIONS` edge to Carol (e11) was treated as a KNOWS hop, giving
+/// Alice -> Carol -> Dave. That is the "understates real distances" half of
+/// the issue. The 1-hop assertion is the control that the fix does not
+/// over-filter and lose genuine KNOWS edges.
+#[test]
+fn distance_is_not_understated_by_other_edge_types() {
+    let (_dir, db) = build_graph();
+    assert_eq!(
+        sp(&db, "Person", "Alice", "KNOWS", "Person", "Bob"),
+        Value::Int64(1),
+        "Alice -[:KNOWS]-> Bob is a direct edge"
+    );
+    assert_eq!(
+        sp(&db, "Person", "Alice", "KNOWS", "Person", "Dave"),
+        Value::Int64(3),
+        "Alice -> Bob -> Carol -> Dave is 3 KNOWS hops; the MENTIONS shortcut \
+         Alice -> Carol must not count"
+    );
+}
+
+// ── Unreachable pairs ───────────────────────────────────────────────────────
+
+/// Grace (Person slot 6) has no edges whatsoever, so nothing reaches her:
+/// `shortestPath((Alice)-[:KNOWS*]->(Grace))` is NULL.
+///
+/// The KNOWS chain is one-directional, so there is also no route back from
+/// Carol to Alice: Carol's only outgoing KNOWS edge is e4 to Dave, and Dave has
+/// no outgoing KNOWS edge. `shortestPath((Carol)-[:KNOWS*]->(Alice))` is NULL.
+///
+/// Before the fix the Grace assertion already passed on its own (no node of any
+/// label occupies slot 6 in the reachable set) — it is the honest control here.
+/// The Carol assertion returned 2: with the type filter gone,
+/// Carol -> Dave -> Metro (City slot 0) matched destination Alice (Person slot
+/// 0) at depth 2, so the test as a whole failed before the fix.
+#[test]
+fn unreachable_pairs_return_null() {
+    let (_dir, db) = build_graph();
+    assert_eq!(
+        sp(&db, "Person", "Alice", "KNOWS", "Person", "Grace"),
+        Value::Null,
+        "Grace has no edges; no path can reach her"
+    );
+    assert_eq!(
+        sp(&db, "Person", "Carol", "KNOWS", "Person", "Alice"),
+        Value::Null,
+        "the KNOWS chain is one-directional; there is no route back to Alice"
+    );
+}
+
+// ── A relationship type that does not exist at all ──────────────────────────
+
+/// `SPEAKS_TO` is not in the catalog, so no edge of that type can exist and
+/// `shortestPath((Alice)-[:SPEAKS_TO*]->(Bob))` is NULL — even though Alice and
+/// Bob are one KNOWS hop apart.
+///
+/// Before the fix the type name was ignored entirely, so this walked the KNOWS
+/// edge and returned 1.
+#[test]
+fn unknown_relationship_type_yields_no_path() {
+    let (_dir, db) = build_graph();
+    assert_eq!(
+        sp(&db, "Person", "Alice", "SPEAKS_TO", "Person", "Bob"),
+        Value::Null,
+        "no SPEAKS_TO edges exist in the graph"
+    );
+}

--- a/crates/sparrowdb/tests/regression_427_shortest_path_heterogeneous.rs
+++ b/crates/sparrowdb/tests/regression_427_shortest_path_heterogeneous.rs
@@ -27,7 +27,13 @@ use sparrowdb_execution::types::Value;
 
 // ── Fixture ─────────────────────────────────────────────────────────────────
 //
-// Three node labels, four relationship types, and a deliberately isolated node.
+// Three node labels (Person, City, Post), five relationship types (KNOWS,
+// LIVES_IN, LIKES, FOLLOWS, MENTIONS) and a deliberately isolated node.
+//
+// MENTIONS deliberately spans two label pairs — Person->Post (e9) and
+// Person->Person (e10, e11, e12) — so the catalog registers it as two separate
+// relationship tables that a traversal has to merge without confusing their
+// destination labels.
 //
 // Slots are assigned per label in creation order, so the fixture is written so
 // that slot collisions ACROSS labels are unavoidable — that is the whole point.

--- a/crates/sparrowdb/tests/regression_427_shortest_path_heterogeneous.rs
+++ b/crates/sparrowdb/tests/regression_427_shortest_path_heterogeneous.rs
@@ -305,3 +305,48 @@ fn unknown_relationship_type_yields_no_path() {
         "no SPEAKS_TO edges exist in the graph"
     );
 }
+
+// ── The same answers must hold once the graph is checkpointed ───────────────
+
+/// `checkpoint()` moves every edge out of the delta log and into the per-rel-type
+/// CSR files. The delta log carries full `NodeId`s, so a neighbour's label can be
+/// read straight off it; a CSR entry is a bare slot, so the label has to come
+/// from somewhere else. The answers must not change.
+///
+/// Every expectation below is the same hand derivation as the tests above,
+/// re-asserted against CSR-backed storage:
+///   * Alice -[:LIVES_IN]-> Junction (e1) is one hop, and Junction is a `City`
+///     while Alice is a `Person` — a cross-label destination, which is precisely
+///     the case a slot-only comparison cannot express.
+///   * Dave has no outgoing KNOWS edge, so no KNOWS path reaches Alice.
+///   * Alice -> Bob -> Carol -> Dave is 3 KNOWS hops.
+///   * Bob -> Alice -> Frank is 2 MENTIONS hops. `MENTIONS` spans two label
+///     pairs here (Person->Post via e9 and Person->Person via e10/e11/e12), so
+///     it is registered as two separate relationship tables — the traversal has
+///     to merge both and keep each one's destination label straight.
+#[test]
+fn answers_are_unchanged_after_checkpoint() {
+    let (_dir, db) = build_graph();
+    db.checkpoint().expect("checkpoint");
+
+    assert_eq!(
+        sp(&db, "Person", "Alice", "LIVES_IN", "City", "Junction"),
+        Value::Int64(1),
+        "Alice -[:LIVES_IN]-> Junction is a direct cross-label edge"
+    );
+    assert_eq!(
+        sp(&db, "Person", "Dave", "KNOWS", "Person", "Alice"),
+        Value::Null,
+        "Dave has no outgoing KNOWS edge"
+    );
+    assert_eq!(
+        sp(&db, "Person", "Alice", "KNOWS", "Person", "Dave"),
+        Value::Int64(3),
+        "Alice -> Bob -> Carol -> Dave is 3 KNOWS hops"
+    );
+    assert_eq!(
+        sp(&db, "Person", "Bob", "MENTIONS", "Person", "Frank"),
+        Value::Int64(2),
+        "Bob -[:MENTIONS]-> Alice -[:MENTIONS]-> Frank is 2 hops"
+    );
+}

--- a/crates/sparrowdb/tests/regression_slot_identity_root_cause.rs
+++ b/crates/sparrowdb/tests/regression_slot_identity_root_cause.rs
@@ -1,0 +1,383 @@
+//! Regression tests for the shared root cause behind #415, #427, #429 and #431:
+//! **slot identity treated as node identity**.
+//!
+//! A `NodeId` is `(label_id << 32) | slot`, so slot 2 exists independently in
+//! `Person`, `Place`, `Org` and every other label.  The neighbour lookups in
+//! `engine/mod.rs` used to take a bare slot with no label
+//! (`csr_neighbors_all` / `csr_neighbors_filtered`) and return bare slots, so
+//! every caller inherited two defects at once:
+//!
+//! 1. **Reading another label's edges.** A `CsrForward` is indexed by the source
+//!    slot of *one* relationship table.  Probing every table with a bare slot
+//!    lets a `Person` inherit the edges of the `Org` in the same slot number
+//!    (#429).
+//! 2. **Losing the neighbour's label.** Callers then had to reconstruct it,
+//!    which `get_node_neighbors_labeled` did from delta-log hints, falling back
+//!    to the *source's* label.  `checkpoint()` truncates the delta log, so after
+//!    a checkpoint every hint vanishes and every CSR neighbour silently takes
+//!    the source's label (#431).
+//!
+//! The fix threads `(slot, label_id)` through the neighbour APIs and reads both
+//! labels off the catalog, which registers every relationship table as
+//! `(id, src_label_id, dst_label_id, rel_type)`.  For a CSR hit the destination
+//! label is therefore *known*, and a table whose `src_label_id` does not match
+//! is skipped before its CSR is ever touched.
+//!
+//! **Every expected value below is derived by hand from [`build_graph`].**  None
+//! of it was captured from program output; each test spells out the derivation.
+//!
+//! The fixture has four node labels, three relationship *types* across four
+//! relationship *tables*, and every assertion is made both before and after
+//! `checkpoint()` — #431 only exists after a checkpoint, and #429's CSR
+//! contamination only exists after a checkpoint too, because the delta log
+//! carries full `NodeId`s and was already filtered by source label.
+
+use sparrowdb::open;
+use sparrowdb_execution::types::{QueryResult, Value};
+
+// ── Fixture ─────────────────────────────────────────────────────────────────
+//
+// Four node labels (Person, Place, Org, Post) and three relationship types
+// (KNOWS, LOCATED_IN, LIKES).  LOCATED_IN deliberately spans two label pairs,
+// so the catalog registers **four** relationship tables:
+//
+//   T1  (Person) -[:KNOWS]->      (Person)
+//   T2  (Person) -[:LOCATED_IN]-> (Place)
+//   T3  (Org)    -[:LOCATED_IN]-> (Place)
+//   T4  (Person) -[:LIKES]->      (Post)
+//
+// Slots are assigned per label in creation order, so the collisions below are
+// deliberate and unavoidable — they are the whole point of the fixture:
+//
+//   Person slots: 0 Alice        1 Bob        2 Carol
+//   Place  slots: 0 Springfield  1 Berlin     2 Kyoto
+//   Org    slots: 0 OrgZero      1 OrgOne     2 TechStart
+//   Post   slots: 0 PostZero
+//
+//   * Person 2 (Carol) and Org 2 (TechStart) both exist and are connected
+//     differently by the *same* relationship type — Carol to Kyoto, TechStart
+//     to Berlin.  That is the #429 collision.
+//   * Slot 0 is occupied in all four labels at once.
+//
+// Edges:
+//
+//   e1  Alice     -[:KNOWS]->      Bob          Person 0 -> Person 1
+//   e2  Bob       -[:KNOWS]->      Carol        Person 1 -> Person 2
+//   e3  Alice     -[:LOCATED_IN]-> Springfield  Person 0 -> Place  0
+//   e4  Bob       -[:LOCATED_IN]-> Springfield  Person 1 -> Place  0
+//   e5  Carol     -[:LOCATED_IN]-> Kyoto        Person 2 -> Place  2
+//   e6  TechStart -[:LOCATED_IN]-> Berlin       Org    2 -> Place  1   <-- slot 2
+//   e7  Alice     -[:LIKES]->      PostZero     Person 0 -> Post   0
+//
+// Nothing in the graph has an outgoing edge from any Place or Post, and OrgZero
+// and OrgOne have no edges at all.
+
+fn build_graph() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+
+    // Nodes — creation order fixes the per-label slot numbers listed above.
+    for name in ["Alice", "Bob", "Carol"] {
+        db.execute(&format!("CREATE (p:Person {{name: '{name}'}})"))
+            .expect("CREATE Person");
+    }
+    for name in ["Springfield", "Berlin", "Kyoto"] {
+        db.execute(&format!("CREATE (c:Place {{name: '{name}'}})"))
+            .expect("CREATE Place");
+    }
+    for name in ["OrgZero", "OrgOne", "TechStart"] {
+        db.execute(&format!("CREATE (o:Org {{name: '{name}'}})"))
+            .expect("CREATE Org");
+    }
+    db.execute("CREATE (t:Post {name: 'PostZero'})")
+        .expect("CREATE Post");
+
+    let edges: [(&str, &str, &str, &str, &str); 7] = [
+        ("Person", "Alice", "KNOWS", "Person", "Bob"),
+        ("Person", "Bob", "KNOWS", "Person", "Carol"),
+        ("Person", "Alice", "LOCATED_IN", "Place", "Springfield"),
+        ("Person", "Bob", "LOCATED_IN", "Place", "Springfield"),
+        ("Person", "Carol", "LOCATED_IN", "Place", "Kyoto"),
+        ("Org", "TechStart", "LOCATED_IN", "Place", "Berlin"),
+        ("Person", "Alice", "LIKES", "Post", "PostZero"),
+    ];
+    for (src_label, src_name, rel, dst_label, dst_name) in edges {
+        db.execute(&format!(
+            "MATCH (s:{src_label} {{name: '{src_name}'}}), \
+                   (d:{dst_label} {{name: '{dst_name}'}}) \
+             CREATE (s)-[:{rel}]->(d)"
+        ))
+        .expect("CREATE edge");
+    }
+
+    (dir, db)
+}
+
+/// Collect column `col` of a result as a sorted `Vec<String>`.
+///
+/// Sorted because none of these queries specifies an ORDER BY, so row order is
+/// not part of the contract; the *set* of rows is what the derivations pin down.
+fn sorted_col(result: &QueryResult, col: usize) -> Vec<String> {
+    let mut v: Vec<String> = result
+        .rows
+        .iter()
+        .map(|row| match &row[col] {
+            Value::String(s) => s.clone(),
+            other => panic!("expected a string in column {col}, got {other:?}"),
+        })
+        .collect();
+    v.sort();
+    v
+}
+
+fn query(db: &sparrowdb::GraphDb, q: &str) -> QueryResult {
+    db.execute(q)
+        .unwrap_or_else(|e| panic!("query failed: {q}\n{e:?}"))
+}
+
+// ── #429: a 3-hop chain must not inherit another label's edges ──────────────
+
+/// The exact #429 shape: three inline fixed hops, the last one over a
+/// relationship type that exists for two different source labels.
+///
+/// Derivation:
+///   * hop 1 — Alice (Person 0) `-[:KNOWS]->` Bob (Person 1), via e1.  Alice's
+///     only other edges are e3 (LOCATED_IN) and e7 (LIKES), neither of which is
+///     KNOWS, so Bob is the only hop-1 node.
+///   * hop 2 — Bob (Person 1) `-[:KNOWS]->` Carol (Person 2), via e2.
+///   * hop 3 — Carol (Person 2) `-[:LOCATED_IN]->` Kyoto (Place 2), via e5.
+///     That is Carol's only edge of any type.
+///
+/// So exactly **one** row: `(Carol, Kyoto)`.
+///
+/// Berlin must not appear.  Berlin is reachable in this graph only from
+/// TechStart, which is **Org** slot 2 — the same slot number as Carol, who is
+/// **Person** slot 2.  Before the fix hop 3 resolved LOCATED_IN by type name
+/// alone, giving both T2 and T3, then probed both CSRs with the bare slot `2`,
+/// so Carol collected TechStart's edge and the query returned two rows.
+///
+/// The contamination is CSR-only, hence the checkpoint: the delta log stores
+/// full `NodeId`s and was already filtered by source label, so the same query
+/// was correct before `checkpoint()` and wrong after it.
+#[test]
+fn three_hop_chain_does_not_inherit_another_labels_edges() {
+    let (_dir, db) = build_graph();
+    let q = "MATCH (a:Person {name: 'Alice'})-[:KNOWS]->(b:Person)\
+             -[:KNOWS]->(c:Person)-[:LOCATED_IN]->(pl:Place) \
+             RETURN c.name, pl.name";
+
+    // Uncheckpointed (delta-backed).
+    let before = query(&db, q);
+    assert_eq!(
+        sorted_col(&before, 1),
+        vec!["Kyoto".to_string()],
+        "Carol lives in Kyoto (e5); Berlin belongs to TechStart (Org slot 2)"
+    );
+    assert_eq!(sorted_col(&before, 0), vec!["Carol".to_string()]);
+
+    // Checkpointed (CSR-backed) — the answer must not change.
+    db.checkpoint().expect("checkpoint");
+    let after = query(&db, q);
+    assert_eq!(
+        sorted_col(&after, 1),
+        vec!["Kyoto".to_string()],
+        "after checkpoint the edges live in per-table CSRs indexed by source \
+         slot; Person slot 2 must not read Org slot 2's row"
+    );
+    assert_eq!(sorted_col(&after, 0), vec!["Carol".to_string()]);
+}
+
+/// The half of #429 that narrowing at the call site could not reach: an
+/// **unlabeled** intermediate node.  With `(b)` and `(c)` carrying no label
+/// there is nothing to narrow the relationship-table set against, so a fix that
+/// resolves `(src_label, dst_label, rel_type)` from the *pattern* has no
+/// information to work with.  Deriving the label from the catalog does.
+///
+/// Same derivation as above — the pattern matches the same single path
+/// Alice -> Bob -> Carol -> Kyoto — so the answer is the same one row, `Kyoto`.
+#[test]
+fn unlabeled_intermediates_do_not_inherit_another_labels_edges() {
+    let (_dir, db) = build_graph();
+    db.checkpoint().expect("checkpoint");
+
+    let result = query(
+        &db,
+        "MATCH (a:Person {name: 'Alice'})-[:KNOWS]->(b)-[:KNOWS]->(c)\
+         -[:LOCATED_IN]->(pl:Place) RETURN pl.name",
+    );
+    assert_eq!(
+        sorted_col(&result, 0),
+        vec!["Kyoto".to_string()],
+        "the traversal reaches Carol (Person 2), whose only LOCATED_IN edge is \
+         to Kyoto; TechStart (Org 2) is a different node"
+    );
+}
+
+// ── #431: cross-label variable-length traversal after a checkpoint ──────────
+
+/// A variable-length hop that crosses labels, asserted on both sides of
+/// `checkpoint()`.
+///
+/// Derivation: Alice is Person 0.  Her only LOCATED_IN edge is e3, to
+/// Springfield (Place 0).  Springfield has no outgoing edges, so depth 2 adds
+/// nothing.  `[:LOCATED_IN*1..2]` therefore yields exactly `["Springfield"]`.
+///
+/// Before the fix this returned one row before the checkpoint and **zero** after
+/// it.  `get_node_neighbors_labeled` recovered a CSR neighbour's label from
+/// hints built out of `read_delta_all()`; `checkpoint()` empties the delta log,
+/// so the hint set was empty and every neighbour fell back to the *source's*
+/// label — Person.  `execute_variable_length` then dropped it, because the
+/// destination pattern requires Place.  Silent, and empty in the safe-looking
+/// direction.
+#[test]
+fn cross_label_varlen_survives_checkpoint() {
+    let (_dir, db) = build_graph();
+    let q = "MATCH (p:Person {name: 'Alice'})-[:LOCATED_IN*1..2]->(pl:Place) \
+             RETURN pl.name";
+
+    let before = query(&db, q);
+    assert_eq!(
+        sorted_col(&before, 0),
+        vec!["Springfield".to_string()],
+        "Alice's only LOCATED_IN edge is e3, to Springfield; Springfield has no \
+         outgoing edges so depth 2 adds nothing"
+    );
+
+    db.checkpoint().expect("checkpoint");
+    let after = query(&db, q);
+    assert_eq!(
+        sorted_col(&after, 0),
+        vec!["Springfield".to_string()],
+        "checkpointing moves the edge into a CSR; the destination's label comes \
+         from the catalog, so the answer must be identical"
+    );
+}
+
+/// Both faults at once, in one variable-length query.
+///
+/// Derivation: Carol is Person 2.  Her only LOCATED_IN edge is e5, to Kyoto
+/// (Place 2).  So the answer is exactly `["Kyoto"]`.
+///
+/// Berlin is the trap: it is reached only by e6, from TechStart, which is **Org**
+/// slot 2 — Carol's slot number in a different label.  Before the fix, after a
+/// checkpoint, the traversal probed both LOCATED_IN CSRs with the bare slot `2`
+/// (picking up Berlin) and then relabelled every neighbour as Person (dropping
+/// both), so the query returned nothing at all.
+#[test]
+fn cross_label_varlen_does_not_read_a_colliding_slot() {
+    let (_dir, db) = build_graph();
+    db.checkpoint().expect("checkpoint");
+
+    let result = query(
+        &db,
+        "MATCH (p:Person {name: 'Carol'})-[:LOCATED_IN*1..1]->(pl:Place) \
+         RETURN pl.name",
+    );
+    assert_eq!(
+        sorted_col(&result, 0),
+        vec!["Kyoto".to_string()],
+        "Carol (Person 2) lives in Kyoto; Berlin belongs to TechStart (Org 2)"
+    );
+}
+
+/// Control: the homogeneous case that hid all of this for so long.
+///
+/// Derivation: the KNOWS chain is Alice -> Bob -> Carol (e1, e2).  From Alice,
+/// `[:KNOWS*1..2]` reaches Bob at depth 1 and Carol at depth 2, and nothing
+/// else — Carol has no outgoing KNOWS edge.  So `["Bob", "Carol"]`.
+///
+/// A Person->Person traversal is unaffected by either fault, because the source
+/// label *is* the correct destination label.  This asserts the fix does not
+/// over-filter and lose genuine edges.
+#[test]
+fn homogeneous_varlen_is_unchanged() {
+    let (_dir, db) = build_graph();
+    db.checkpoint().expect("checkpoint");
+
+    let result = query(
+        &db,
+        "MATCH (p:Person {name: 'Alice'})-[:KNOWS*1..2]->(f:Person) RETURN f.name",
+    );
+    assert_eq!(
+        sorted_col(&result, 0),
+        vec!["Bob".to_string(), "Carol".to_string()],
+        "Alice -> Bob is 1 hop and Alice -> Bob -> Carol is 2"
+    );
+}
+
+// ── #427: shortestPath, re-asserted against the shared neighbour lookup ─────
+
+/// `bfs_shortest_path` grew its own catalog-driven neighbour loop in the #427
+/// fix; the root fix replaces it with the shared `get_node_neighbors_labeled`.
+/// These assertions guard that swap — they must keep holding.
+///
+/// Derivations, all after `checkpoint()`:
+///   * `Alice -[:KNOWS*]-> Carol` = **2** (e1 then e2).
+///   * `Carol -[:KNOWS*]-> Alice` = **NULL**.  The KNOWS chain is
+///     one-directional and Carol's only edge is e5, a LOCATED_IN to Kyoto.
+///     Kyoto is Place slot 2 and Alice is Person slot 0, so no slot coincidence
+///     can rescue it either.
+///   * `Alice -[:LOCATED_IN*]-> Springfield` = **1** (e3) — a cross-label
+///     destination, which a slot-only comparison cannot express.
+///   * `Carol -[:LOCATED_IN*]-> Berlin` = **NULL**.  Berlin is reachable only
+///     from TechStart (Org 2); Carol is Person 2.  Reading the colliding slot
+///     would report 1.
+#[test]
+fn shortest_path_still_correct_through_the_shared_lookup() {
+    let (_dir, db) = build_graph();
+    db.checkpoint().expect("checkpoint");
+
+    let sp = |src_label: &str, src: &str, rel: &str, dst_label: &str, dst: &str| -> Value {
+        let q = format!(
+            "MATCH (s:{src_label} {{name: '{src}'}}), (d:{dst_label} {{name: '{dst}'}}) \
+             RETURN shortestPath((s)-[:{rel}*]->(d))"
+        );
+        let r = query(&db, &q);
+        assert_eq!(r.rows.len(), 1, "expected one row for: {q}");
+        r.rows[0][0].clone()
+    };
+
+    assert_eq!(
+        sp("Person", "Alice", "KNOWS", "Person", "Carol"),
+        Value::Int64(2),
+        "Alice -> Bob -> Carol is 2 KNOWS hops"
+    );
+    assert_eq!(
+        sp("Person", "Carol", "KNOWS", "Person", "Alice"),
+        Value::Null,
+        "the KNOWS chain is one-directional"
+    );
+    assert_eq!(
+        sp("Person", "Alice", "LOCATED_IN", "Place", "Springfield"),
+        Value::Int64(1),
+        "Alice -[:LOCATED_IN]-> Springfield is a direct cross-label edge"
+    );
+    assert_eq!(
+        sp("Person", "Carol", "LOCATED_IN", "Place", "Berlin"),
+        Value::Null,
+        "Berlin belongs to TechStart (Org 2), not to Carol (Person 2)"
+    );
+}
+
+// ── One-hop control ─────────────────────────────────────────────────────────
+
+/// The single-hop path resolves `(src_label, dst_label, rel_type)` to one table
+/// already, so it was never exposed to #429.  Asserted anyway so that a
+/// regression in the shared helper cannot pass unnoticed.
+///
+/// Derivation: Carol's only LOCATED_IN edge is e5, to Kyoto.  One row.
+#[test]
+fn one_hop_control_is_unchanged() {
+    let (_dir, db) = build_graph();
+    db.checkpoint().expect("checkpoint");
+
+    let result = query(
+        &db,
+        "MATCH (p:Person {name: 'Carol'})-[:LOCATED_IN]->(pl:Place) RETURN pl.name",
+    );
+    assert_eq!(
+        sorted_col(&result, 0),
+        vec!["Kyoto".to_string()],
+        "Carol -[:LOCATED_IN]-> Kyoto (e5) is her only edge"
+    );
+}


### PR DESCRIPTION
## The one bug behind four tickets

A `NodeId` is `(label_id << 32) | slot`, so slot 2 exists independently in
`Person`, `Place`, `Org` and every other label. `csr_neighbors_filtered` and
`csr_neighbors_all` took a **bare slot with no label** and returned **bare
slots**:

```rust
fn csr_neighbors_filtered(&self, src_slot: u64, rel_ids: &[u32]) -> Vec<u64>
```

The signature made it impossible for a caller to be correct, and every caller
inherited both halves of the defect:

1. **Reading another label's edges.** A `CsrForward` is indexed by the source
   slot of *one* relationship table. Probing every table with a bare slot lets
   `Person` slot 2 inherit `Org` slot 2's edges (#429).
2. **Losing the destination's label.** Callers had to reconstruct it.
   `get_node_neighbors_labeled` did so from delta-log hints, falling back to the
   **source's** label. `checkpoint()` truncates the delta log, so after a
   checkpoint every hint vanished and every CSR neighbour silently took the
   source's label (#431).

## The fix

The catalog already registers every relationship table as
`(id, src_label_id, dst_label_id, rel_type)`, and a CSR holds exactly one
table's edges. So for a CSR hit the destination label is **known**, and a table
whose `src_label_id` differs is not indexed by this node's slot at all.

```rust
fn csr_neighbors_labeled(&self, src_slot: u64, src_label_id: u32, rel_ids: &[u32])
    -> Vec<(u64, u32)>   // (dst_slot, dst_label_id)
```

plus `csr_neighbor_slots_to_label(..)` for callers that already know the
destination label. Both old helpers are gone. A lazily-built `CsrTopology` on
`ReadSnapshot` caches the label triples per snapshot —
`list_rel_tables_with_ids()` clones a `String` per table and is called inside
traversal loops.

Call sites:

| site | change |
|---|---|
| `get_node_neighbors_labeled` (path.rs) | drops the `node_label` / `all_label_ids` delta-hint parameters entirely |
| `execute_n_hop` (hop.rs) | frontier carries `(slot, label_id)` instead of re-deriving the label from the pattern; each hop filters destinations on the label; unlabeled intermediates are addressed by their real label, not label 0 |
| `bfs_shortest_path` (expr.rs) | drops the catalog loop it grew in #432 and calls the shared helper |
| `RelTableLookup::All` arms in expr.rs / scan.rs / mutation.rs | restrict to tables running from this node's label to the destination label they build the `NodeId` from; the paired delta filters gain the same destination-label check |

## What this closes

* **#431 — closed.** Neighbour labels come from the catalog; the delta-hint
  fallback is deleted, not guarded. Nothing about the answer now depends on
  whether the graph has been checkpointed.
* **#429 — closed**, including both parts the ticket left open: undeclared
  endpoint labels (the label is carried, so there is nothing to declare) and
  `execute_variable_hops` / `execute_variable_length` (they go through the same
  helper).
* **#427 — already closed by #432**; this replaces that fix's local catalog loop
  with the shared helper, which is now the only implementation. The #427
  regression suite still passes unchanged.
* **#415 — not addressed.** It is the same *family* of confusion but a different
  mechanism: the chunked pipeline resolves nodes by `labels[0]` against that
  label's own primary store. That is a node-scan path, not a neighbour lookup;
  the gating from #416 remains necessary and #419 tracks the row engine's
  matching gap.

## Test

`crates/sparrowdb/tests/regression_slot_identity_root_cause.rs` — four node
labels, three relationship types across **four** relationship tables
(`LOCATED_IN` spans `(Person)->(Place)` and `(Org)->(Place)`), deliberate
cross-label slot collisions (Person 2 = Carol → Kyoto, Org 2 = TechStart →
Berlin), asserted on **both sides of `checkpoint()`**. Every expected value is
derived by hand in the test comments; none was captured from program output.

**Measured against the pre-fix engine files** (engine sources checked out at the
base commit, test file unchanged, then restored byte-exact — sha256 verified):

```
test result: FAILED. 3 passed; 4 failed
  three_hop_chain_does_not_inherit_another_labels_edges     ["Berlin","Kyoto"] vs ["Kyoto"]   (#429)
  unlabeled_intermediates_do_not_inherit_another_labels_edges ["Berlin","Kyoto"] vs ["Kyoto"] (#429)
  cross_label_varlen_survives_checkpoint                    [] vs ["Springfield"]             (#431)
  cross_label_varlen_does_not_read_a_colliding_slot         [] vs ["Kyoto"]                   (#431)
```

The 3 that pass pre-fix are deliberate controls: homogeneous varlen, one-hop,
and shortestPath (already fixed by #432).

## Verification

* `cargo test -p sparrowdb-execution --no-fail-fast` — 10 binaries, all ok
* `cargo test -p sparrowdb --no-fail-fast` — 163 binaries, **1033 passed, 0
  failed, 10 ignored**, excluding `spa_222_csr_lazy_load` (~80 min runtime,
  being addressed separately in #434)
* `cargo fmt --all -- --check` — clean, re-verified in a fresh clone of the
  pushed branch
* `cargo clippy --workspace --exclude sparrowdb-ruby --all-targets --keep-going
  -- -D warnings` — clean

No existing test changed behaviour; nothing was weakened.

## Branching note

Requested base is `fix/issue-427-...` (#432) "on top of both #432 and #433". In
git, #432's branch is **not** a descendant of #433's — both fork from `25f3559`
— so this sits on #432 only. It does not contain #433's `execute_n_hop` changes,
and since this rewrites that function's frontier, expect a conflict there when
#433 lands. The root fix subsumes what #433 does for `execute_n_hop` (narrowing
the rel-table set when both endpoint labels are declared), so the resolution
should be to take this version.

Refs #415 #427 #429 #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE
