### PR TITLE
fix(vector): surface vector index load errors instead of swallowing them (closes #445)

### DIFF
--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -26,7 +26,7 @@ use sparrowdb_storage::wal::codec::WalPayload;
 use sparrowdb_storage::wal::writer::WalWriter;
 use sparrowdb_storage::wal::WalReplayer;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use tracing::{info_span, warn};
@@ -2180,24 +2180,42 @@ impl GraphDb {
         Ok(())
     }
 
-    /// Report every persisted vector index under `path` that exists on disk but
-    /// cannot be loaded.  Each entry is `(label, prop, reason)`.
+    /// Report every persisted vector index under `path` whose bytes are
+    /// damaged.  Each entry is `(label, prop, path, reason)`, sorted for
+    /// determinism.
     ///
-    /// [`GraphDb::open`] refuses to open such a database (it returns
-    /// [`Error::Corruption`]) because a damaged HNSW file is not recoverable
-    /// derived state — vectors written via `addToVectorIndex` exist nowhere
-    /// else — and opening anyway would silently drop every subsequent vector
-    /// write for that `(label, prop)`.  This function is the diagnostic side of
-    /// that policy: it never fails, so an operator or a repair tool can call it
-    /// on a database that will not open and find out exactly which files are at
-    /// fault.
-    ///
-    /// An empty result means every index file present loads cleanly, which
+    /// This never returns `Err`, so it can be called on a database that refuses
+    /// to open — it is the diagnostic side of the fail-closed policy in
+    /// [`GraphDb::open`]. An empty result means no damage is present, which
     /// includes the ordinary case of a database with no vector indexes at all.
     /// That is the distinction the loader used to collapse: an **absent** index
-    /// file means "no index configured" and is not an error, while a
-    /// **present-but-unloadable** file is reported here and blocks `open`.
-    pub fn vector_index_load_failures(path: &Path) -> Vec<(String, String, String)> {
+    /// file means "no index configured" and is not an error, while a damaged
+    /// one is reported here.
+    ///
+    /// Damage is reported in both the places it can live:
+    ///
+    /// * a live `hnsw_<label>_<prop>.bin` that will not load — these also make
+    ///   `open` fail;
+    /// * a `hnsw_<label>_<prop>.bin.corrupt.<millis>` artifact that a previous
+    ///   load attempt rejected and moved aside (#442) — `open` succeeds once a
+    ///   file has been quarantined, so this is the *only* remaining signal that
+    ///   the vectors for that `(label, prop)` are gone.
+    ///
+    /// Reporting only the first kind would mean a health check built on this
+    /// call returns "no problems" for a store whose index has been quarantined
+    /// and whose vector writes are therefore being dropped — the same silent
+    /// failure this API exists to eliminate.
+    ///
+    /// The `path` is exact. The `reason` for a quarantine artifact is
+    /// reconstructed rather than recovered: the original decode failure is
+    /// reported only in the error returned at quarantine time and is not
+    /// persisted to disk.
+    ///
+    /// Note that this is not a read-only call when composed with #442: probing
+    /// a live entry may quarantine it. See the crate-internal
+    /// `helpers::vector_index_load_failures` for why that does not change the
+    /// result you observe.
+    pub fn vector_index_load_failures(path: &Path) -> Vec<(String, String, PathBuf, String)> {
         crate::helpers::vector_index_load_failures(path)
     }
 

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -103,7 +103,7 @@ impl GraphDb {
         } else {
             0
         };
-        let vector_indexes = RwLock::new(load_vector_indexes(path));
+        let vector_indexes = RwLock::new(load_vector_indexes(path)?);
         Ok(GraphDb {
             inner: Arc::new(DbInner {
                 path: path.to_path_buf(),
@@ -166,7 +166,7 @@ impl GraphDb {
         } else {
             0
         };
-        let vector_indexes = RwLock::new(load_vector_indexes(path));
+        let vector_indexes = RwLock::new(load_vector_indexes(path)?);
         Ok(GraphDb {
             inner: Arc::new(DbInner {
                 path: path.to_path_buf(),
@@ -2165,6 +2165,27 @@ impl GraphDb {
         let dir = self.inner.path.join("vector_indexes");
         sparrowdb_storage::VectorIndex::remove(&dir, label, prop);
         Ok(())
+    }
+
+    /// Report every persisted vector index under `path` that exists on disk but
+    /// cannot be loaded.  Each entry is `(label, prop, reason)`.
+    ///
+    /// [`GraphDb::open`] refuses to open such a database (it returns
+    /// [`Error::Corruption`]) because a damaged HNSW file is not recoverable
+    /// derived state — vectors written via `addToVectorIndex` exist nowhere
+    /// else — and opening anyway would silently drop every subsequent vector
+    /// write for that `(label, prop)`.  This function is the diagnostic side of
+    /// that policy: it never fails, so an operator or a repair tool can call it
+    /// on a database that will not open and find out exactly which files are at
+    /// fault.
+    ///
+    /// An empty result means every index file present loads cleanly, which
+    /// includes the ordinary case of a database with no vector indexes at all.
+    /// That is the distinction the loader used to collapse: an **absent** index
+    /// file means "no index configured" and is not an error, while a
+    /// **present-but-unloadable** file is reported here and blocks `open`.
+    pub fn vector_index_load_failures(path: &Path) -> Vec<(String, String, String)> {
+        crate::helpers::vector_index_load_failures(path)
     }
 
     /// Return a handle to the HNSW vector index for `(label, prop)`, if one exists.

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -67,6 +67,17 @@ impl GraphDb {
     }
 
     /// Open (or create) a SparrowDB database at `path`.
+    ///
+    /// # Errors
+    ///
+    /// Besides the usual I/O and WAL-replay failures, this returns
+    /// [`Error::Corruption`] when a persisted vector index file exists under
+    /// `<path>/vector_indexes/` but cannot be loaded.  Opening anyway would
+    /// silently drop every subsequent vector write for that `(label, prop)` and
+    /// return nothing for every search, so the database refuses to open instead.
+    /// Use [`GraphDb::vector_index_load_failures`] to find out which files are
+    /// at fault.  A database with *no* vector index files is unaffected —
+    /// absent is not the same as damaged.
     pub fn open(path: &Path) -> Result<Self> {
         std::fs::create_dir_all(path)?;
         let wal_dir = path.join("wal");
@@ -134,7 +145,9 @@ impl GraphDb {
     /// fail with [`Error::EncryptionAuthFailed`].
     ///
     /// # Errors
-    /// Returns an error if the directory cannot be created.
+    /// Returns an error if the directory cannot be created, or
+    /// [`Error::Corruption`] if a persisted vector index file exists but cannot
+    /// be loaded — see [`GraphDb::open`] for why that is fatal.
     pub fn open_encrypted(path: &Path, key: [u8; 32]) -> Result<Self> {
         std::fs::create_dir_all(path)?;
         let wal_dir = path.join("wal");

--- a/crates/sparrowdb/src/helpers.rs
+++ b/crates/sparrowdb/src/helpers.rs
@@ -3,7 +3,7 @@
 // Utility functions used across multiple submodules.
 
 use sparrowdb_catalog::catalog::Catalog;
-use sparrowdb_common::col_id_of;
+use sparrowdb_common::{col_id_of, Error};
 use sparrowdb_storage::csr::CsrForward;
 use sparrowdb_storage::edge_store::{EdgeStore, RelTableId};
 use sparrowdb_storage::node_store::{NodeStore, Value};
@@ -334,46 +334,118 @@ pub(crate) fn try_open_csr_map(path: &Path) -> crate::Result<HashMap<u32, CsrFor
 
 // ── Vector index helpers (issue #394) ────────────────────────────────────────
 
-/// Scan `<db_root>/vector_indexes/` and load all persisted HNSW indexes.
+/// Enumerate the `(label, prop)` pairs that `<dir>` claims to hold an index for.
 ///
-/// The directory contains files named `hnsw_<label>_<prop>.bin`. This function
-/// loads each one and reconstructs the `(label, prop)` key from the file name.
-/// Unreadable files are silently skipped.
-pub(crate) fn load_vector_indexes(db_root: &Path) -> crate::types::VectorIndexMap {
-    let dir = db_root.join("vector_indexes");
-    let mut map: crate::types::VectorIndexMap = HashMap::new();
-    let entries = match std::fs::read_dir(&dir) {
-        Ok(e) => e,
-        Err(_) => return map,
+/// Only files named exactly `hnsw_<label>_<prop>.bin` are considered.  The
+/// `.bin` extension check matters: PR #442 quarantines a rejected index to
+/// `<path>.corrupt.<millis>`, and those artifacts must stay invisible to the
+/// loader — a quarantined file is deliberately *not* a live index, so it must
+/// never be re-read nor turned into an open-time failure.
+///
+/// Returns an empty vector when the directory does not exist (a database that
+/// has never had a vector index created).
+fn vector_index_keys(dir: &Path) -> Vec<(String, String)> {
+    let mut keys = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return keys;
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        let fname = match path.file_stem().and_then(|s| s.to_str()) {
-            Some(s) => s.to_string(),
-            None => continue,
-        };
-        // Expected format: "hnsw_<label>_<prop>"
-        if !fname.starts_with("hnsw_") {
+        if path.extension().and_then(|s| s.to_str()) != Some("bin") {
             continue;
         }
-        let rest = &fname[5..]; // strip "hnsw_"
-                                // Split on the first '_' to recover label and prop.
-                                // Labels can contain underscores, so we use the *last* underscore as separator.
-        if let Some(sep) = rest.rfind('_') {
-            let label = &rest[..sep];
-            let prop = &rest[sep + 1..];
-            if label.is_empty() || prop.is_empty() {
-                continue;
+        let Some(fname) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        // Expected format: "hnsw_<label>_<prop>"
+        let Some(rest) = fname.strip_prefix("hnsw_") else {
+            continue;
+        };
+        // Labels can contain underscores, so we use the *last* underscore as separator.
+        let Some(sep) = rest.rfind('_') else {
+            continue;
+        };
+        let (label, prop) = (&rest[..sep], &rest[sep + 1..]);
+        if label.is_empty() || prop.is_empty() {
+            continue;
+        }
+        keys.push((label.to_string(), prop.to_string()));
+    }
+    keys
+}
+
+/// Scan `<db_root>/vector_indexes/` and load all persisted HNSW indexes.
+///
+/// The directory contains files named `hnsw_<label>_<prop>.bin`; the
+/// `(label, prop)` key is reconstructed from the file name.
+///
+/// # Errors
+///
+/// Returns [`Error::Corruption`] if an index file **exists but cannot be
+/// loaded** (truncated, corrupt, unreadable, or rejected by the header/CRC
+/// validation added in #442).
+///
+/// This is deliberately fail-closed, and deliberately different from the
+/// stance taken for [`PropertyIndex`](sparrowdb_storage::property_index::PropertyIndex),
+/// whose load failures are *not* fatal because that index is derived state —
+/// the next `Engine` simply rebuilds it from the column files.  An HNSW index
+/// is **not** derived state: vectors added through `addToVectorIndex` (#441)
+/// live only in this file and cannot be rebuilt from anything else.
+///
+/// Swallowing the error here is what turned one damaged file into a silent
+/// total outage: a missing key in the map means "no index configured", so
+/// every later vector write for that `(label, prop)` is dropped on the floor
+/// and every `vectorSearch` returns nothing, while the engine reports "no
+/// vector index; call createVectorIndex first" — indistinguishable from an
+/// operator configuration mistake.  Refusing to open is louder, recoverable
+/// (move the file aside and re-open, then rebuild deliberately) and never
+/// destroys data that a running-but-broken database would have discarded.
+///
+/// An *absent* file is not an error: it legitimately means no index is
+/// configured for that `(label, prop)`, and the map simply has no entry.
+pub(crate) fn load_vector_indexes(db_root: &Path) -> crate::Result<crate::types::VectorIndexMap> {
+    let dir = db_root.join("vector_indexes");
+    let mut map: crate::types::VectorIndexMap = HashMap::new();
+    for (label, prop) in vector_index_keys(&dir) {
+        match sparrowdb_storage::VectorIndex::load(&dir, &label, &prop) {
+            Ok(Some(idx)) => {
+                map.insert((label, prop), Arc::new(RwLock::new(idx)));
             }
-            if let Ok(Some(idx)) = sparrowdb_storage::VectorIndex::load(&dir, label, prop) {
-                map.insert(
-                    (label.to_string(), prop.to_string()),
-                    Arc::new(RwLock::new(idx)),
-                );
+            // The directory listing said the file was there but `load` found it
+            // gone — it was removed between the scan and the read.  Nothing was
+            // lost that we can observe, so treat it as absent.
+            Ok(None) => continue,
+            Err(e) => {
+                return Err(Error::Corruption(format!(
+                    "vector index for ({label}, {prop}) exists at {} but could not be loaded: {e}. \
+                     Refusing to open: continuing would silently drop every vector write for this \
+                     index and return no results for every search. Move the file aside and re-open \
+                     to run without it, then rebuild the index.",
+                    dir.join(format!("hnsw_{label}_{prop}.bin")).display(),
+                )));
             }
         }
     }
-    map
+    Ok(map)
+}
+
+/// Report every vector index file that exists but cannot be loaded.
+///
+/// Diagnostic counterpart to [`load_vector_indexes`]: it never fails, so it can
+/// be called on a database that refuses to open in order to find out *which*
+/// files are the problem.  Each entry is `(label, prop, reason)`.
+///
+/// An empty result means every present index file loads — including the case
+/// where there are no index files at all.
+pub(crate) fn vector_index_load_failures(db_root: &Path) -> Vec<(String, String, String)> {
+    let dir = db_root.join("vector_indexes");
+    let mut failures = Vec::new();
+    for (label, prop) in vector_index_keys(&dir) {
+        if let Err(e) = sparrowdb_storage::VectorIndex::load(&dir, &label, &prop) {
+            failures.push((label, prop, e.to_string()));
+        }
+    }
+    failures
 }
 
 // ── Storage-size helpers (SPA-171) ────────────────────────────────────────────

--- a/crates/sparrowdb/src/helpers.rs
+++ b/crates/sparrowdb/src/helpers.rs
@@ -8,7 +8,7 @@ use sparrowdb_storage::csr::CsrForward;
 use sparrowdb_storage::edge_store::{EdgeStore, RelTableId};
 use sparrowdb_storage::node_store::{NodeStore, Value};
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 // ── FNV-1a col_id derivation ─────────────────────────────────────────────────
@@ -334,44 +334,77 @@ pub(crate) fn try_open_csr_map(path: &Path) -> crate::Result<HashMap<u32, CsrFor
 
 // ── Vector index helpers (issue #394) ────────────────────────────────────────
 
-/// Enumerate the `(label, prop)` pairs that `<dir>` claims to hold an index for.
+/// Recover the `(label, prop)` pair from an `hnsw_<label>_<prop>` file stem.
 ///
-/// Only files named exactly `hnsw_<label>_<prop>.bin` are considered.  The
-/// `.bin` extension check matters: PR #442 quarantines a rejected index to
-/// `<path>.corrupt.<millis>`, and those artifacts must stay invisible to the
-/// loader — a quarantined file is deliberately *not* a live index, so it must
-/// never be re-read nor turned into an open-time failure.
+/// Labels may contain underscores, so the *last* underscore is the separator.
+fn parse_index_stem(stem: &str) -> Option<(String, String)> {
+    let rest = stem.strip_prefix("hnsw_")?;
+    let sep = rest.rfind('_')?;
+    let (label, prop) = (&rest[..sep], &rest[sep + 1..]);
+    if label.is_empty() || prop.is_empty() {
+        return None;
+    }
+    Some((label.to_string(), prop.to_string()))
+}
+
+/// One recognised entry in `<db_root>/vector_indexes/`.
+enum IndexFile {
+    /// `hnsw_<label>_<prop>.bin` — a live index the loader will try to read.
+    Live { label: String, prop: String },
+    /// `hnsw_<label>_<prop>.bin.corrupt.<millis>` — bytes a previous load
+    /// attempt rejected and moved aside (#442).  Deliberately *not* live: it
+    /// must never be loaded, and it must never block `open`.  It is still
+    /// evidence of damage, so it must remain visible to the diagnostic.
+    Quarantined {
+        label: String,
+        prop: String,
+        path: PathBuf,
+    },
+}
+
+/// Take one snapshot of `<dir>` and classify every recognised entry.
+///
+/// A single `read_dir` pass matters. `VectorIndex::load` quarantines the file
+/// it rejects, so probing a live entry can *create* a quarantine artifact while
+/// we are working; snapshotting first means such an artifact cannot also be
+/// picked up in the same call and reported twice.
+///
+/// Results are sorted so callers get a deterministic order regardless of
+/// directory iteration order.
 ///
 /// Returns an empty vector when the directory does not exist (a database that
 /// has never had a vector index created).
-fn vector_index_keys(dir: &Path) -> Vec<(String, String)> {
-    let mut keys = Vec::new();
+fn scan_vector_index_dir(dir: &Path) -> Vec<IndexFile> {
+    let mut found = Vec::new();
     let Ok(entries) = std::fs::read_dir(dir) else {
-        return keys;
+        return found;
     };
     for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) != Some("bin") {
-            continue;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if let Some(stem) = name.strip_suffix(".bin") {
+            if let Some((label, prop)) = parse_index_stem(stem) {
+                found.push(IndexFile::Live { label, prop });
+            }
+        } else if let Some((head, _stamp)) = name.split_once(".bin.corrupt.") {
+            if let Some((label, prop)) = parse_index_stem(head) {
+                found.push(IndexFile::Quarantined {
+                    label,
+                    prop,
+                    path: entry.path(),
+                });
+            }
         }
-        let Some(fname) = path.file_stem().and_then(|s| s.to_str()) else {
-            continue;
-        };
-        // Expected format: "hnsw_<label>_<prop>"
-        let Some(rest) = fname.strip_prefix("hnsw_") else {
-            continue;
-        };
-        // Labels can contain underscores, so we use the *last* underscore as separator.
-        let Some(sep) = rest.rfind('_') else {
-            continue;
-        };
-        let (label, prop) = (&rest[..sep], &rest[sep + 1..]);
-        if label.is_empty() || prop.is_empty() {
-            continue;
-        }
-        keys.push((label.to_string(), prop.to_string()));
     }
-    keys
+    found.sort_by(|a, b| sort_key(a).cmp(&sort_key(b)));
+    found
+}
+
+fn sort_key(f: &IndexFile) -> (&str, &str, &Path) {
+    match f {
+        IndexFile::Live { label, prop } => (label, prop, Path::new("")),
+        IndexFile::Quarantined { label, prop, path } => (label, prop, path.as_path()),
+    }
 }
 
 /// Scan `<db_root>/vector_indexes/` and load all persisted HNSW indexes.
@@ -403,10 +436,17 @@ fn vector_index_keys(dir: &Path) -> Vec<(String, String)> {
 ///
 /// An *absent* file is not an error: it legitimately means no index is
 /// configured for that `(label, prop)`, and the map simply has no entry.
+/// Neither is a quarantine artifact (#442) — those bytes have already been
+/// taken out of service, so they must not hold the database hostage on every
+/// subsequent start.  They stay visible through
+/// [`vector_index_load_failures`] instead.
 pub(crate) fn load_vector_indexes(db_root: &Path) -> crate::Result<crate::types::VectorIndexMap> {
     let dir = db_root.join("vector_indexes");
     let mut map: crate::types::VectorIndexMap = HashMap::new();
-    for (label, prop) in vector_index_keys(&dir) {
+    for (label, prop) in scan_vector_index_dir(&dir).into_iter().filter_map(|f| match f {
+        IndexFile::Live { label, prop } => Some((label, prop)),
+        IndexFile::Quarantined { .. } => None,
+    }) {
         match sparrowdb_storage::VectorIndex::load(&dir, &label, &prop) {
             Ok(Some(idx)) => {
                 map.insert((label, prop), Arc::new(RwLock::new(idx)));
@@ -429,20 +469,66 @@ pub(crate) fn load_vector_indexes(db_root: &Path) -> crate::Result<crate::types:
     Ok(map)
 }
 
-/// Report every vector index file that exists but cannot be loaded.
+/// Report every vector index whose bytes are damaged, whether they are still
+/// in place or have already been moved aside.  Each entry is
+/// `(label, prop, path, reason)`, sorted for determinism.
 ///
-/// Diagnostic counterpart to [`load_vector_indexes`]: it never fails, so it can
-/// be called on a database that refuses to open in order to find out *which*
-/// files are the problem.  Each entry is `(label, prop, reason)`.
+/// Diagnostic counterpart to [`load_vector_indexes`]: it never returns `Err`,
+/// so it can be called on a database that refuses to open in order to find out
+/// *which* files are the problem.  An empty result means no damage is present —
+/// including the ordinary case of a database with no vector indexes at all.
 ///
-/// An empty result means every present index file loads — including the case
-/// where there are no index files at all.
-pub(crate) fn vector_index_load_failures(db_root: &Path) -> Vec<(String, String, String)> {
+/// Two kinds of damage are reported, because #442 leaves damage in two
+/// different places and reporting only one of them recreates the very defect
+/// this function exists to prevent:
+///
+/// * **Live but unloadable** — `hnsw_<label>_<prop>.bin` is present and
+///   `VectorIndex::load` rejects it.  `open` fails on these.  #442 quarantines
+///   *some* of them (bad magic/length/CRC) but deliberately not all: a file
+///   that decodes cleanly and then fails `validate_invariants` is left in place
+///   for inspection, so it stays visible here as a live entry.
+/// * **Already quarantined** — `hnsw_<label>_<prop>.bin.corrupt.<millis>`, the
+///   bytes a previous load attempt rejected and renamed aside (#442).  `open`
+///   succeeds once a file has been quarantined, because the damaged bytes are
+///   out of service; without this arm the *only* remaining evidence of the
+///   damage would be invisible, and a health check built on this call would
+///   report a clean bill on exactly the database whose vectors are gone.
+///
+/// The `reason` for a quarantined artifact is reconstructed, not recovered:
+/// #442 records the decode failure only in the `io::Error` it returns at
+/// quarantine time and writes no sidecar, so the original message is not
+/// recoverable from disk afterwards.  The path is exact.
+///
+/// # Side effects
+///
+/// Not read-only when composed with #442: probing a live entry calls
+/// `VectorIndex::load`, which quarantines the file it rejects.  That is the
+/// intended behaviour of quarantine — it protects the only surviving copy of
+/// the vectors from the next `save()` — and the observable result of this
+/// function is unchanged by it, since a file that is quarantined during one
+/// call is reported as a quarantine artifact by the next.
+pub(crate) fn vector_index_load_failures(db_root: &Path) -> Vec<(String, String, PathBuf, String)> {
     let dir = db_root.join("vector_indexes");
     let mut failures = Vec::new();
-    for (label, prop) in vector_index_keys(&dir) {
-        if let Err(e) = sparrowdb_storage::VectorIndex::load(&dir, &label, &prop) {
-            failures.push((label, prop, e.to_string()));
+    for entry in scan_vector_index_dir(&dir) {
+        match entry {
+            IndexFile::Live { label, prop } => {
+                if let Err(e) = sparrowdb_storage::VectorIndex::load(&dir, &label, &prop) {
+                    let path = dir.join(format!("hnsw_{label}_{prop}.bin"));
+                    failures.push((label, prop, path, e.to_string()));
+                }
+            }
+            IndexFile::Quarantined { label, prop, path } => {
+                let reason = format!(
+                    "index file was rejected by a previous load attempt and preserved as {} \
+                     (#442 quarantine). The vectors it held are not in service and cannot be \
+                     rebuilt from column data; the original decode failure is not recorded on \
+                     disk. Recover from these bytes or rebuild the index deliberately, then \
+                     remove the artifact to clear this report.",
+                    path.display(),
+                );
+                failures.push((label, prop, path, reason));
+            }
         }
     }
     failures

--- a/crates/sparrowdb/src/helpers.rs
+++ b/crates/sparrowdb/src/helpers.rs
@@ -443,10 +443,13 @@ fn sort_key(f: &IndexFile) -> (&str, &str, &Path) {
 pub(crate) fn load_vector_indexes(db_root: &Path) -> crate::Result<crate::types::VectorIndexMap> {
     let dir = db_root.join("vector_indexes");
     let mut map: crate::types::VectorIndexMap = HashMap::new();
-    for (label, prop) in scan_vector_index_dir(&dir).into_iter().filter_map(|f| match f {
-        IndexFile::Live { label, prop } => Some((label, prop)),
-        IndexFile::Quarantined { .. } => None,
-    }) {
+    for (label, prop) in scan_vector_index_dir(&dir)
+        .into_iter()
+        .filter_map(|f| match f {
+            IndexFile::Live { label, prop } => Some((label, prop)),
+            IndexFile::Quarantined { .. } => None,
+        })
+    {
         match sparrowdb_storage::VectorIndex::load(&dir, &label, &prop) {
             Ok(Some(idx)) => {
                 map.insert((label, prop), Arc::new(RwLock::new(idx)));

--- a/crates/sparrowdb/tests/vector_index_load_errors.rs
+++ b/crates/sparrowdb/tests/vector_index_load_errors.rs
@@ -1,0 +1,236 @@
+//! Regression tests: a damaged vector index file must never be indistinguishable
+//! from an absent one (see the issue filed alongside this test; relates to #441
+//! and #442).
+//!
+//! The defect: `load_vector_indexes` did
+//!
+//! ```ignore
+//! if let Ok(Some(idx)) = VectorIndex::load(&dir, label, prop) { map.insert(..) }
+//! ```
+//!
+//! so every load error was discarded and the `(label, prop)` key simply never
+//! appeared in the map.  Downstream, a missing key means "no index configured",
+//! which makes the insert path drop every vector write for that pair and makes
+//! every `vectorSearch` return nothing, while the engine reports "no vector
+//! index; call createVectorIndex first" — a data-loss condition wearing the
+//! costume of a configuration mistake.
+//!
+//! Policy asserted here: **fail-closed**.  `GraphDb::open` returns
+//! `Error::Corruption` when an index file is present but unloadable, and
+//! `GraphDb::vector_index_load_failures` names the offending files without
+//! failing, so the condition is diagnosable on a database that will not open.
+//!
+//! Every expected value below is derived by hand from the on-disk format; none
+//! was captured from program output.
+
+use sparrowdb::{Error, GraphDb};
+use std::path::{Path, PathBuf};
+
+/// Build a database at `dir` holding one persisted 3-dimensional cosine index
+/// on `(Memory, embedding)`, then close it.  Returns the path of the index file.
+///
+/// Hand-derived path: `VectorIndex::index_path` formats
+/// `hnsw_{label}_{prop}.bin` under `<db_root>/vector_indexes/`, so with
+/// label `Memory` and prop `embedding` the file is
+/// `<db_root>/vector_indexes/hnsw_Memory_embedding.bin`.
+fn make_db_with_persisted_index(dir: &Path) -> PathBuf {
+    let db = GraphDb::open(dir).expect("open fresh db");
+    db.create_vector_index("Memory", "embedding", 3, "cosine")
+        .expect("create vector index");
+    drop(db);
+
+    let file = dir.join("vector_indexes").join("hnsw_Memory_embedding.bin");
+    assert!(
+        file.is_file(),
+        "fixture precondition: create_vector_index must persist {}",
+        file.display()
+    );
+    file
+}
+
+/// Damage `file` so that it cannot possibly deserialize.
+///
+/// Hand-derivation: the file is `bincode::serialize(&VectorIndex)` and the first
+/// field of `VectorIndex` is `nodes: Vec<Node>`, which bincode encodes as an
+/// 8-byte little-endian length prefix followed by the elements.  Truncating the
+/// file to 4 bytes leaves the *length prefix itself* incomplete, so the very
+/// first read hits end-of-input.  There is no byte string of length 4 that
+/// bincode can decode into a `VectorIndex`, so `load` must return `Err` — this
+/// does not depend on which 4 bytes survive, on the field values, or on any
+/// header/CRC scheme layered on top later (#442 would reject it too).
+fn truncate_to_4_bytes(file: &Path) {
+    let original = std::fs::metadata(file).expect("stat index file").len();
+    assert!(
+        original > 4,
+        "fixture precondition: a serialized VectorIndex must be longer than the \
+         4-byte truncation point, got {original} bytes"
+    );
+    let f = std::fs::OpenOptions::new()
+        .write(true)
+        .open(file)
+        .expect("open index file for truncation");
+    f.set_len(4).expect("truncate index file to 4 bytes");
+}
+
+// ── 1. The failure is surfaced, not swallowed ─────────────────────────────────
+
+#[test]
+fn damaged_index_file_makes_open_fail() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file = make_db_with_persisted_index(dir.path());
+    truncate_to_4_bytes(&file);
+
+    // Expected by hand: the file exists and cannot deserialize, therefore the
+    // loader must report corruption rather than pretend no index is configured.
+    let err = match GraphDb::open(dir.path()) {
+        Ok(_) => panic!(
+            "open() must fail when {} exists but cannot be loaded; succeeding here is \
+             exactly the swallow that turns one damaged file into silently dropped \
+             vector writes",
+            file.display()
+        ),
+        Err(e) => e,
+    };
+
+    match &err {
+        Error::Corruption(msg) => {
+            // The message must name the index, or an operator cannot act on it.
+            assert!(
+                msg.contains("Memory") && msg.contains("embedding"),
+                "corruption message must name the (label, prop) pair, got: {msg}"
+            );
+        }
+        other => panic!("expected Error::Corruption, got {other:?}"),
+    }
+}
+
+// ── 2. Absent and unloadable are distinguishable ──────────────────────────────
+
+#[test]
+fn absent_index_and_unloadable_index_are_distinguishable() {
+    // Case A — no index file at all.  Hand-derived expectation: a fresh database
+    // has no `vector_indexes/` directory, so the map is empty, `open` succeeds
+    // and `get_vector_index` yields `None` meaning "no index configured".
+    let absent_dir = tempfile::tempdir().expect("tempdir");
+    let absent_db = GraphDb::open(absent_dir.path()).expect("absent case must open cleanly");
+    assert!(
+        absent_db.get_vector_index("Memory", "embedding").is_none(),
+        "absent case: no index was ever created, so there must be no handle"
+    );
+    assert!(
+        GraphDb::vector_index_load_failures(absent_dir.path()).is_empty(),
+        "absent case: nothing on disk can have failed to load"
+    );
+    drop(absent_db);
+
+    // Case B — the index file exists and is damaged.
+    let damaged_dir = tempfile::tempdir().expect("tempdir");
+    let file = make_db_with_persisted_index(damaged_dir.path());
+    truncate_to_4_bytes(&file);
+
+    let damaged_result = GraphDb::open(damaged_dir.path());
+    assert!(
+        damaged_result.is_err(),
+        "damaged case must not produce the same observable as the absent case"
+    );
+
+    // The bug being guarded is precisely that these two produced the *same*
+    // observable: open() -> Ok, get_vector_index() -> None.
+    let failures = GraphDb::vector_index_load_failures(damaged_dir.path());
+    // Hand-derived: exactly one file was planted, for exactly one (label, prop).
+    assert_eq!(
+        failures.len(),
+        1,
+        "expected exactly 1 unloadable index, got {failures:?}"
+    );
+    assert_eq!(
+        (failures[0].0.as_str(), failures[0].1.as_str()),
+        ("Memory", "embedding"),
+        "the reported failure must identify the (label, prop) pair"
+    );
+}
+
+// ── 3. Happy path is unchanged ────────────────────────────────────────────────
+
+#[test]
+fn valid_index_still_loads_across_restart() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path();
+
+    {
+        let db = GraphDb::open(path).expect("open fresh db");
+        db.create_vector_index("Memory", "embedding", 3, "cosine")
+            .expect("create vector index");
+        let arc = db.get_vector_index("Memory", "embedding").expect("handle");
+        arc.write()
+            .expect("write lock")
+            .insert(7, &[1.0_f32, 0.0, 0.0]);
+        arc.read()
+            .expect("read lock")
+            .save(&path.join("vector_indexes"), "Memory", "embedding")
+            .expect("persist index");
+    }
+
+    let db = GraphDb::open(path).expect("re-open with a valid index must succeed");
+    let arc = db
+        .get_vector_index("Memory", "embedding")
+        .expect("valid index must survive restart");
+    let guard = arc.read().expect("read lock");
+
+    // Hand-derived: one vector was inserted, node id 7 = [1,0,0].  A k=1 cosine
+    // search for [1,0,0] can only return that node, and cos([1,0,0],[1,0,0]) =
+    // (1*1+0*0+0*0) / (1*1) = 1.0 exactly — the components are exactly
+    // representable in f32 and the norms are exactly 1, so no rounding occurs.
+    assert_eq!(guard.len(), 1, "exactly one vector was inserted");
+    let hits = guard.search(&[1.0_f32, 0.0, 0.0], 1, 16);
+    assert_eq!(hits.len(), 1, "k=1 over a 1-element index returns 1 hit");
+    assert_eq!(hits[0].0, 7, "the only node id in the index is 7");
+    assert_eq!(
+        hits[0].1, 1.0_f32,
+        "cosine of a unit vector with itself is 1.0"
+    );
+}
+
+#[test]
+fn absent_index_is_not_an_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Hand-derived: nothing has created a vector index, so `vector_indexes/`
+    // does not exist and there is nothing to load or to fail on.
+    assert!(
+        !dir.path().join("vector_indexes").exists(),
+        "fixture precondition: a fresh db has no vector_indexes directory"
+    );
+    let db = GraphDb::open(dir.path()).expect("a db with no vector index must open");
+    assert!(db.get_vector_index("Memory", "embedding").is_none());
+    assert!(GraphDb::vector_index_load_failures(dir.path()).is_empty());
+}
+
+// ── 4. Interop with the #442 quarantine naming ────────────────────────────────
+
+#[test]
+fn quarantined_corrupt_file_is_not_treated_as_a_live_index() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let vidx = dir.path().join("vector_indexes");
+    std::fs::create_dir_all(&vidx).expect("create vector_indexes dir");
+
+    // PR #442 renames a rejected index to `<path>.corrupt.<millis>`.  Such a
+    // file is deliberately no longer a live index: it must neither be loaded
+    // nor block `open`.  Hand-derived: the file name's extension is `1712345678901`,
+    // not `bin`, so it is not a candidate index file at all.
+    std::fs::write(
+        vidx.join("hnsw_Memory_embedding.bin.corrupt.1712345678901"),
+        [0xFF_u8; 32],
+    )
+    .expect("plant quarantined file");
+
+    let db = GraphDb::open(dir.path())
+        .expect("a quarantined artifact must not prevent the database from opening");
+    assert!(
+        db.get_vector_index("Memory", "embedding").is_none(),
+        "a quarantined file is not a live index, so no handle must be produced"
+    );
+    assert!(
+        GraphDb::vector_index_load_failures(dir.path()).is_empty(),
+        "a quarantined file is not a pending failure — it has already been dealt with"
+    );
+}

--- a/crates/sparrowdb/tests/vector_index_load_errors.rs
+++ b/crates/sparrowdb/tests/vector_index_load_errors.rs
@@ -20,6 +20,13 @@
 //! `GraphDb::vector_index_load_failures` names the offending files without
 //! failing, so the condition is diagnosable on a database that will not open.
 //!
+//! These tests must hold both on this branch and composed with #442, which
+//! quarantines a rejected index by renaming it to `.corrupt.<millis>` during
+//! the load attempt.  Where the two states differ they are called out inline:
+//! the assertions are written against the (label, prop) that is damaged and the
+//! path where its bytes now live, never against which of the two routes put
+//! them there.
+//!
 //! Every expected value below is derived by hand from the on-disk format; none
 //! was captured from program output.
 
@@ -137,16 +144,35 @@ fn absent_index_and_unloadable_index_are_distinguishable() {
     // The bug being guarded is precisely that these two produced the *same*
     // observable: open() -> Ok, get_vector_index() -> None.
     let failures = GraphDb::vector_index_load_failures(damaged_dir.path());
-    // Hand-derived: exactly one file was planted, for exactly one (label, prop).
+    // Hand-derived: exactly one file was planted, for exactly one (label, prop),
+    // so exactly one entry must be reported.
+    //
+    // This must hold on both integration states, and it reaches that count by
+    // two different routes.  Without #442 the `.bin` is still in place after the
+    // failed `open`, and is reported as a live unloadable index.  With #442 the
+    // failed `open` renamed it to `.bin.corrupt.<millis>`, and it is reported as
+    // a quarantine artifact.  Either way the damage is reported exactly once —
+    // asserting on the count and the (label, prop) rather than on which of the
+    // two routes produced it is what makes this guard hold across the
+    // composition.
     assert_eq!(
         failures.len(),
         1,
-        "expected exactly 1 unloadable index, got {failures:?}"
+        "expected exactly 1 damaged index, got {failures:?}"
     );
     assert_eq!(
         (failures[0].0.as_str(), failures[0].1.as_str()),
         ("Memory", "embedding"),
         "the reported failure must identify the (label, prop) pair"
+    );
+    // The reported path must point at bytes that are actually on disk.  A
+    // report naming a file that is not there is not actionable, and this is the
+    // assertion that would have caught the reported path going stale when the
+    // file is renamed out from under it.
+    assert!(
+        failures[0].2.is_file(),
+        "reported path {} must exist on disk",
+        failures[0].2.display()
     );
 }
 
@@ -202,35 +228,114 @@ fn absent_index_is_not_an_error() {
     );
     let db = GraphDb::open(dir.path()).expect("a db with no vector index must open");
     assert!(db.get_vector_index("Memory", "embedding").is_none());
-    assert!(GraphDb::vector_index_load_failures(dir.path()).is_empty());
+    assert!(
+        GraphDb::vector_index_load_failures(dir.path()).is_empty(),
+        "no files at all means no damage to report"
+    );
 }
 
 // ── 4. Interop with the #442 quarantine naming ────────────────────────────────
 
 #[test]
-fn quarantined_corrupt_file_is_not_treated_as_a_live_index() {
+fn quarantined_corrupt_file_is_not_loaded_but_is_reported() {
     let dir = tempfile::tempdir().expect("tempdir");
     let vidx = dir.path().join("vector_indexes");
     std::fs::create_dir_all(&vidx).expect("create vector_indexes dir");
 
-    // PR #442 renames a rejected index to `<path>.corrupt.<millis>`.  Such a
-    // file is deliberately no longer a live index: it must neither be loaded
-    // nor block `open`.  Hand-derived: the file name's extension is `1712345678901`,
-    // not `bin`, so it is not a candidate index file at all.
-    std::fs::write(
-        vidx.join("hnsw_Memory_embedding.bin.corrupt.1712345678901"),
-        [0xFF_u8; 32],
-    )
-    .expect("plant quarantined file");
+    // PR #442 renames a rejected index to `<path>.corrupt.<millis>`.  This
+    // plants the state a #442 database is left in *after* it has quarantined a
+    // damaged index — reproducible without #442 in the tree, because the
+    // artifact is just a file with a known name.
+    let artifact = vidx.join("hnsw_Memory_embedding.bin.corrupt.1712345678901");
+    std::fs::write(&artifact, [0xFF_u8; 32]).expect("plant quarantined file");
 
+    // Not loaded, and not fatal.  The bytes are already out of service, so
+    // holding the database shut on every subsequent start would force an
+    // operator to choose between "the store will not start" and "delete the
+    // only surviving copy of my vectors".
     let db = GraphDb::open(dir.path())
         .expect("a quarantined artifact must not prevent the database from opening");
     assert!(
         db.get_vector_index("Memory", "embedding").is_none(),
         "a quarantined file is not a live index, so no handle must be produced"
     );
+
+    // But it must be VISIBLE.  Not-loaded and not-visible are different
+    // properties; conflating them is the defect.  Once #442 has quarantined an
+    // index, this report is the only remaining evidence that the vectors for
+    // (Memory, embedding) are gone — a health check that returns empty here
+    // gives a clean bill of health to a store that is silently dropping every
+    // vector write.
+    //
+    // Hand-derived: one artifact was planted, naming exactly one (label, prop)
+    // — strip the `.bin.corrupt.<millis>` suffix from
+    // `hnsw_Memory_embedding.bin.corrupt.1712345678901` to get the stem
+    // `hnsw_Memory_embedding`, then split at the last underscore, giving
+    // label `Memory` and prop `embedding`.  So exactly one entry.
+    let failures = GraphDb::vector_index_load_failures(dir.path());
+    assert_eq!(
+        failures.len(),
+        1,
+        "the quarantine artifact must be reported, got {failures:?}"
+    );
+    assert_eq!(
+        (failures[0].0.as_str(), failures[0].1.as_str()),
+        ("Memory", "embedding"),
+        "the report must identify the (label, prop) whose vectors are gone"
+    );
+    assert_eq!(
+        failures[0].2, artifact,
+        "the report must name the quarantine path, so the bytes can be recovered"
+    );
+}
+
+#[test]
+fn healthy_and_quarantined_indexes_are_reported_separately() {
+    // A store can hold a working index and the wreckage of another at the same
+    // time.  The healthy one must not be dragged down, and the wreckage must
+    // not be hidden by the healthy one.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path();
+    {
+        let db = GraphDb::open(path).expect("open fresh db");
+        db.create_vector_index("Memory", "embedding", 3, "cosine")
+            .expect("create vector index");
+        let arc = db.get_vector_index("Memory", "embedding").expect("handle");
+        arc.write()
+            .expect("write lock")
+            .insert(7, &[1.0_f32, 0.0, 0.0]);
+        arc.read()
+            .expect("read lock")
+            .save(&path.join("vector_indexes"), "Memory", "embedding")
+            .expect("persist index");
+    }
+    let artifact = path
+        .join("vector_indexes")
+        .join("hnsw_Doc_vec.bin.corrupt.1712345678901");
+    std::fs::write(&artifact, [0xFF_u8; 32]).expect("plant quarantined file");
+
+    // Hand-derived: the (Memory, embedding) file is valid and its pair is not
+    // quarantined, so it loads and contributes no failure.  The (Doc, vec)
+    // artifact contributes exactly one.  Total: 1 failure, 1 live handle.
+    let db = GraphDb::open(path).expect("a healthy index plus an artifact must still open");
     assert!(
-        GraphDb::vector_index_load_failures(dir.path()).is_empty(),
-        "a quarantined file is not a pending failure — it has already been dealt with"
+        db.get_vector_index("Memory", "embedding").is_some(),
+        "the healthy index must still load"
+    );
+    assert!(
+        db.get_vector_index("Doc", "vec").is_none(),
+        "the quarantined index must not produce a handle"
+    );
+
+    let failures = GraphDb::vector_index_load_failures(path);
+    assert_eq!(
+        failures.len(),
+        1,
+        "exactly the damaged pair must be reported, got {failures:?}"
+    );
+    assert_eq!(
+        (failures[0].0.as_str(), failures[0].1.as_str()),
+        ("Doc", "vec"),
+        "the healthy pair must not be reported as damaged"
     );
 }


### PR DESCRIPTION
Closes #445 and #450. Relates to #441 and #442.

## The defect

`load_vector_indexes` (`crates/sparrowdb/src/helpers.rs`) discarded every error from
`VectorIndex::load`:

```rust
if let Ok(Some(idx)) = VectorIndex::load(&dir, label, prop) { ... }
```

A damaged, unreadable, or rejected index file produced the same observable as a database
that never had an index configured: no key in the map. That collapse is the bug. A
missing key is the signal every downstream path reads as "no index configured", so one
damaged file silently caused every subsequent vector write for that `(label, prop)` to be
dropped, every `vectorSearch` to return nothing, and the engine to report *"no vector
index; call createVectorIndex first"* — data loss wearing the costume of a configuration
mistake. Observed in production as a store that "refuses inserts, persistently across
restarts".

## Policy: fail-closed

`GraphDb::open` and `open_encrypted` now return `Error::Corruption` when an index file is
**present but unloadable**. An **absent** file is still not an error and still means "no
index configured".

Why fail-closed here, when `property_index.rs` documents the opposite stance ("not fatal;
the next `Engine` will simply rebuild from column files"): the property index is *derived*
state, so discarding it costs time, not data. An HNSW index is not derived state —
vectors added via `addToVectorIndex` (#441) live only in that file and cannot be rebuilt
from column data. A load failure there is already data loss, and continuing to run
compounds it with every write that follows. Refusing to open is loud, recoverable (move
the file aside, re-open, rebuild deliberately), and destroys nothing that a
running-but-broken database would not have discarded anyway.

Fail-open with a recorded failure was the alternative considered. It was rejected because
the only place the recorded failure could be re-checked is the vector write/search path in
`engine/*.rs`; until those consult it, a fail-open database still silently drops writes —
which is the exact behaviour being fixed. Fail-closed needs no cooperation from any other
layer to be correct.

## Distinguishability

| on disk | `GraphDb::open` | `get_vector_index` | `vector_index_load_failures` |
|---|---|---|---|
| no file | `Ok` | `None` = no index configured | `[]` |
| present, loads | `Ok` | `Some(handle)` | `[]` |
| present, unloadable | `Err(Corruption)` naming label, prop, path, reason | — (db never opens) | `[(label, prop, reason)]` |
| `.corrupt.<millis>` quarantine (#442) | `Ok` | `None` | `[]` |

New `GraphDb::vector_index_load_failures(path) -> Vec<(String, String, String)>` never
fails, so the condition stays diagnosable on a database that refuses to open — an operator
who hits the `open` error can enumerate every offending file before repairing.

## Interop with #442

#442 quarantines a rejected index to `<path>.corrupt.<millis>`. The loader's filename scan
now requires the `.bin` extension exactly, so quarantine artifacts are neither loaded nor
turned into open-time failures — a quarantined file has already been dealt with and is
deliberately no longer a live index. Without this, #442 plus the swallow turned a silent
partial loss into a silent total outage: file quarantined, loader finds nothing, consumer
sees zero vectors and no error.

## Tests

`crates/sparrowdb/tests/vector_index_load_errors.rs` — 5 tests. Every expected value is
hand-derived from the on-disk format in a comment; none was captured from program output.

1. `damaged_index_file_makes_open_fail` — truncates a persisted index to 4 bytes and
   asserts `open` returns `Error::Corruption` naming the `(label, prop)`.
   *Derivation:* the file is `bincode::serialize(&VectorIndex)`, whose first field
   `nodes: Vec<Node>` is encoded as an 8-byte little-endian length prefix. Truncating to 4
   bytes leaves the length prefix itself incomplete, so the first read hits end-of-input.
   No 4-byte string decodes to a `VectorIndex`, independent of which bytes survive or of
   any header/CRC layered on later.
2. `absent_index_and_unloadable_index_are_distinguishable` — asserts the two cases produce
   different observables (`Ok` + `None` vs `Err`), and that exactly 1 failure is reported
   for the 1 planted file, identifying `("Memory", "embedding")`.
   *Derivation:* one file planted for one `(label, prop)`, therefore exactly one entry.
3. `valid_index_still_loads_across_restart` — happy path. Inserts node id 7 = `[1,0,0]`,
   persists, re-opens, asserts `len() == 1`, `search(&[1,0,0], k=1)` returns exactly
   `(7, 1.0)`.
   *Derivation:* k=1 over a 1-element index returns 1 hit and it can only be node 7;
   cos([1,0,0],[1,0,0]) = (1·1+0·0+0·0)/(1·1) = 1.0 exactly — components are exactly
   representable in f32 and both norms are exactly 1, so no rounding occurs.
4. `absent_index_is_not_an_error` — a fresh db has no `vector_indexes/` directory, so
   `open` succeeds, `get_vector_index` is `None`, and no failures are reported.
5. `quarantined_corrupt_file_is_not_treated_as_a_live_index` — plants
   `hnsw_Memory_embedding.bin.corrupt.1712345678901` (#442's naming) filled with `0xFF`
   and asserts `open` succeeds with no handle and no reported failure.
   *Derivation:* that file's extension is `1712345678901`, not `bin`, so it is not a
   candidate index file.

### Pre-fix failure proof (measured)

Source reverted to `origin/main` for `helpers.rs` + `db.rs`, test file kept.

- **Run 1** — full test file against pre-fix source: **does not compile**, 4 ×
  `error[E0599]: no associated function ... vector_index_load_failures found for struct
  GraphDb`. The diagnostic accessor is additive API, so its assertions cannot fail pre-fix;
  they can only fail to compile.
- **Run 2** — same pre-fix source, test file with the 4 `vector_index_load_failures`
  assertions removed so the behavioural guards can execute:
  `test result: FAILED. 3 passed; 2 failed; 0 ignored`.
  The 2 failures are `damaged_index_file_makes_open_fail` and
  `absent_index_and_unloadable_index_are_distinguishable`, both with the reported symptom —
  `open()` returned `Ok` on a database whose only index file was truncated.
  The 3 passes are the happy-path guards, which must pass pre-fix.
- **Post-fix**: `test result: ok. 5 passed; 0 failed; 0 ignored`.

Source files were restored byte-exact afterwards (sha256 verified identical to the
pre-run copies).

## Fallout

None. No existing test relied on the swallow — no test in the suite plants a damaged
vector index file, and the only tests that touch `vector_indexes/` (`vector_index.rs`,
`hybrid_search.rs`) write valid indexes via `VectorIndex::save`. No assertion was weakened.

## Verification

```
export CARGO_TARGET_DIR=/Volumes/Dev/target-loaderr
cargo fmt --all -- --check                    # clean
cargo clippy --workspace --exclude sparrowdb-ruby --all-targets --keep-going -- -D warnings   # clean
cargo test -p sparrowdb --test vector_index_load_errors                                       # 5 passed, 0 failed
cargo test -p sparrowdb --no-fail-fast         # exit 0 — 168 test binaries ok, 0 failed,
                                              #          1037 passed, 12 ignored (pre-existing)
```

`fmt --check` was also re-run in a fresh clone of the pushed branch at this HEAD: clean.

## Update — also closes #450 (composition with #442)

The first version of this PR did not compose with #442. Reported and measured by the
coordinator, reproduced and fixed here.

**The interaction.** #442 quarantines a rejected index by renaming it to
`.corrupt.<millis>` *during the load attempt*. My accessor scanned for `*.bin` and
deliberately filtered quarantine artifacts out — correct in isolation, since a
quarantined file must never be loaded as a live index. Composed, the `.bin` no longer
exists by the time the accessor runs:

```
BEFORE:  ["hnsw_Memory_embedding.bin"]        open() -> Err(Corruption)   correct
AFTER:   ["hnsw_Memory_embedding.bin.corrupt.1785645973245"]
         vector_index_load_failures() -> []                               wrong
```

`vector_index_load_failures` exists to be callable on a database that refuses to open,
and it never returns `Err`, so `[]` is indistinguishable from a healthy store. A health
check built on it would report no problems on precisely the database whose vectors are
gone — the same defect class this series is fixing, one layer up.

**Fix.** Report damage in both places it can live. `scan_vector_index_dir` takes one
snapshot of the directory and classifies each entry as live (`.bin`) or quarantined
(`.bin.corrupt.<millis>`); `load_vector_indexes` consumes only live entries, and
`vector_index_load_failures` reports both. The single snapshot is load-bearing: probing a
live entry can create a quarantine artifact mid-call, and a second scan would report the
same damage twice.

The return type is now `(label, prop, path, reason)` — the path is exact and
machine-readable so a health check does not have to parse it out of prose.

**Two things worth flagging about #442's behaviour**, both confirmed by reading
`VectorIndex::load` / `VectorIndex::quarantine` on `origin/fix/vector-index-durability`:

1. #442 records **no reason at quarantine time** — the decode failure appears only in the
   `io::Error` it returns, with no sidecar written. So the `reason` for a quarantine
   artifact is *reconstructed*, not recovered. The path is exact; the original message is
   not available from disk afterwards. Flagged rather than worked around: adding a reason
   sidecar is #442's call, not mine.
2. #442 has a load failure it deliberately does **not** quarantine — a file that decodes
   cleanly and then fails `validate_invariants` is left in place for inspection. That one
   stays visible as a live entry, so both of #442's failure modes are covered.

**`open` still does not fail on a quarantine artifact**, and that is deliberate. Once the
bytes are out of service, holding the database shut on every subsequent start would force
an operator to choose between "the store will not start" and "delete the only surviving
copy of my vectors". See the residual risk below, which I am raising rather than deciding
unilaterally.

### Residual risk this surfaces — needs a decision from #442's author

Composed, my fail-closed `open` is **one-shot**. First start after damage: `open` fails
loudly and #442 quarantines the file. Second start: the `.bin` is gone, so `open`
succeeds and the index is silently absent again — vector writes for that `(label, prop)`
resume being dropped. The condition remains *detectable* only because
`vector_index_load_failures` now reports the artifact; nothing forces anyone to look.

I did not make `open` keep failing while an unacknowledged artifact exists, for the
reason above. The durable fix is for the write path to refuse to silently drop vectors
when no index exists for the target `(label, prop)` — engine territory, #441's area, not
mine. Raising it here so it is not lost.

### Tests

`quarantined_corrupt_file_is_not_loaded_but_is_reported` (was
`quarantined_corrupt_file_is_not_treated_as_a_live_index`) keeps asserting no live handle
and adds that the artifact is reported with its exact path. Not-loaded and not-visible
are different properties; conflating them is the bug.

`absent_index_and_unloadable_index_are_distinguishable` now also asserts the reported
path exists on disk — the assertion that catches a report going stale when the file is
renamed out from under it. It reaches its expected count of 1 by two different routes
(live entry without #442, quarantine artifact with it), which is why it is written
against the damaged `(label, prop)` and not against which route produced it.

New: `healthy_and_quarantined_indexes_are_reported_separately` — a working index and the
wreckage of another in the same store; the healthy one must not be dragged down and the
wreckage must not be hidden.

### Verification, measured on the composition

Scratch branch = `origin/fix/vector-index-durability` (contains #442) + this branch,
clean merge, isolated `CARGO_TARGET_DIR`.

- **Pre-fix composed** (#442 + previous head `3551291`, original test file): reproduced
  the reported failure exactly — `test result: FAILED. 4 passed; 1 failed`,
  `absent_index_and_unloadable_index_are_distinguishable` with
  *"expected exactly 1 unloadable index, got []"*.
- **New tests vs pre-fix composed source**: does not compile (2 × tuple-arity errors —
  the 4-tuple is new API). With only the 4-tuple assertions removed so the behavioural
  guards can execute: `test result: FAILED. 3 passed; 3 failed` — all three of the new
  and updated guards fail with `got []`, the reported symptom.
- **Pre-fix on this branch alone** (no #442, `3551291`, same adaptation): `test result:
  FAILED. 4 passed; 2 failed` — the two artifact-visibility guards fail with `got []`
  even without #442 in the tree, so the fix stands on its own and is not merely a
  compatibility shim. (Test 2 passes here: without quarantine the `.bin` stays in place
  and the old accessor still sees it. That asymmetry is exactly the composition gap.)
- **Post-fix composed, full suite**: exit 0 — 169 test binaries ok, 0 failed, 1048 passed,
  12 ignored (pre-existing). Targeted file: `6 passed; 0 failed`.
- **Post-fix on this branch alone**: `test result: ok. 6 passed; 0 failed`.
- `cargo fmt --all -- --check` and
  `cargo clippy --workspace --exclude sparrowdb-ruby --all-targets --keep-going -- -D warnings`
  clean on this branch.

One process note: an earlier composed suite run shared a `CARGO_TARGET_DIR` with builds
from this worktree. Per this repo's own guidance that makes the result unverified, so it
was discarded and re-run in a dedicated target directory rather than reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE
