### PR TITLE
fix(vector): guarantee HNSW inserts stay reachable (closes #443)

### DIFF
--- a/crates/sparrowdb-node/src/lib.rs
+++ b/crates/sparrowdb-node/src/lib.rs
@@ -261,14 +261,15 @@ pub struct NodeResult {
 ///
 /// ```typescript
 /// interface VectorIndexHealth {
-///   /** Vectors stored in the index. */
-///   stored: number;
-///   /** Vectors `vectorSearch` can actually reach. */
-///   reachable: number;
-///   /** `stored - reachable`; must be 0 on a healthy index. */
-///   unreachable: number;
+///   stored: number;       // vectors stored in the index
+///   reachable: number;    // vectors `vectorSearch` can actually reach
+///   unreachable: number;  // stored - reachable; must be 0 when healthy
 /// }
 /// ```
+///
+/// Note the `//` comments above rather than nested doc comments: a `*/` inside
+/// a generated JSDoc block closes it early, which is why the checked-in
+/// `npm/sparrowdb/index.d.ts` does not currently parse as TypeScript.
 #[napi(object)]
 pub struct VectorIndexHealth {
     /// Vectors stored in the index.

--- a/crates/sparrowdb-node/src/lib.rs
+++ b/crates/sparrowdb-node/src/lib.rs
@@ -255,6 +255,30 @@ pub struct NodeResult {
     pub score: f64,
 }
 
+// ── VectorIndexHealth ─────────────────────────────────────────────────────────
+
+/// Coverage report for an HNSW index — see `SparrowDB.vectorIndexHealth`.
+///
+/// ```typescript
+/// interface VectorIndexHealth {
+///   /** Vectors stored in the index. */
+///   stored: number;
+///   /** Vectors `vectorSearch` can actually reach. */
+///   reachable: number;
+///   /** `stored - reachable`; must be 0 on a healthy index. */
+///   unreachable: number;
+/// }
+/// ```
+#[napi(object)]
+pub struct VectorIndexHealth {
+    /// Vectors stored in the index.
+    pub stored: u32,
+    /// Vectors reachable by greedy traversal from the entry point.
+    pub reachable: u32,
+    /// `stored - reachable`. Non-zero means silent recall loss.
+    pub unreachable: u32,
+}
+
 // ── SparrowDB ─────────────────────────────────────────────────────────────────
 
 /// Top-level database handle.
@@ -636,6 +660,169 @@ impl SparrowDB {
             .map_err(|e| to_napi(format!("commit failed: {e}")))?;
 
         Ok(())
+    }
+
+    /// Whether `node_id` currently has a vector in the `(label, property)`
+    /// index.
+    ///
+    /// This answers the question `vectorSearch` cannot.  "Not returned by
+    /// `vectorSearch`" and "absent from the index" are different facts, and
+    /// with only `vectorSearch` to probe with there was no way to tell them
+    /// apart — which is how issue #443 stayed invisible, and how an
+    /// investigation twice concluded that writes were failing when the vectors
+    /// were in fact stored and merely unreachable.
+    ///
+    /// Returns `false` when the node has no vector, and also when no node with
+    /// that id exists.  Throws `RangeError` only if the index itself is absent.
+    ///
+    /// ```typescript
+    /// db.hasVector('Memory', 'embedding', 'node-uuid-here')  // => true
+    /// ```
+    #[napi]
+    pub fn has_vector(
+        &self,
+        label: String,
+        property: String,
+        node_id: String,
+    ) -> napi::Result<bool> {
+        validate_cypher_identifier(&label)?;
+        let arc = self
+            .inner
+            .get_vector_index(&label, &property)
+            .ok_or_else(|| {
+                napi::Error::new(
+                    napi::Status::GenericFailure,
+                    format!(
+                        "RangeError: no vector index on ({label}, {property}); \
+                         call createVectorIndex first"
+                    ),
+                )
+            })?;
+        let Some(internal_id) = self.resolve_internal_id(&label, &node_id)? else {
+            return Ok(false);
+        };
+        let idx = arc
+            .read()
+            .map_err(|e| to_napi(format!("lock poisoned: {e}")))?;
+        Ok(idx.has_vector(internal_id))
+    }
+
+    /// Coverage of the `(label, property)` index: how many vectors are stored
+    /// versus how many `vectorSearch` can actually reach.
+    ///
+    /// `stored === reachable` on a healthy index.  Any gap is silent recall
+    /// loss: those vectors are in the file, `hasVector` reports them present,
+    /// and no search will ever return them.  Issue #443 went unnoticed for
+    /// months because this number was not observable — the live store sat at
+    /// 1347 stored / 1307 reachable with nothing to surface it.
+    ///
+    /// Cheap: one graph walk, no distance arithmetic.
+    ///
+    /// ```typescript
+    /// const h = db.vectorIndexHealth('Memory', 'embedding')
+    /// // { stored: 1347, reachable: 1307, unreachable: 40 }
+    /// ```
+    #[napi]
+    pub fn vector_index_health(
+        &self,
+        label: String,
+        property: String,
+    ) -> napi::Result<VectorIndexHealth> {
+        let arc = self
+            .inner
+            .get_vector_index(&label, &property)
+            .ok_or_else(|| {
+                napi::Error::new(
+                    napi::Status::GenericFailure,
+                    format!(
+                        "RangeError: no vector index on ({label}, {property}); \
+                         call createVectorIndex first"
+                    ),
+                )
+            })?;
+        let idx = arc
+            .read()
+            .map_err(|e| to_napi(format!("lock poisoned: {e}")))?;
+        let stored = idx.len() as u32;
+        let reachable = idx.reachable_count() as u32;
+        Ok(VectorIndexHealth {
+            stored,
+            reachable,
+            unreachable: stored - reachable,
+        })
+    }
+
+    /// Reconnect every stored-but-unreachable vector and persist the result.
+    /// Returns the number of vectors re-linked.
+    ///
+    /// Needed for any index written before the reciprocal-link guarantee
+    /// shipped: those orphans live in the file, and nothing else repairs them —
+    /// re-inserting the same node takes the "already present" path, so a
+    /// backfill cannot heal it either.
+    ///
+    /// A no-op (returns 0) on a healthy index, so it is safe to call on
+    /// startup.
+    ///
+    /// ```typescript
+    /// const n = db.repairVectorIndex('Memory', 'embedding')  // => 40
+    /// ```
+    #[napi]
+    pub fn repair_vector_index(&self, label: String, property: String) -> napi::Result<u32> {
+        validate_cypher_identifier(&label)?;
+        let arc = self
+            .inner
+            .get_vector_index(&label, &property)
+            .ok_or_else(|| {
+                napi::Error::new(
+                    napi::Status::GenericFailure,
+                    format!(
+                        "RangeError: no vector index on ({label}, {property}); \
+                         call createVectorIndex first"
+                    ),
+                )
+            })?;
+
+        // Hold the database write lock for the same reason `addToVectorIndex`
+        // does: a concurrent `dropVectorIndex` must not be silently undone by
+        // our save().  The WriteTx is dropped without committing — the HNSW
+        // file is written outside the WAL.
+        let _write_guard = self
+            .inner
+            .begin_write()
+            .map_err(|e| to_napi(format!("WriterBusy: cannot acquire write lock: {e}")))?;
+
+        let vidx_dir = self.inner.path().join("vector_indexes");
+        let mut idx = arc
+            .write()
+            .map_err(|e| to_napi(format!("lock poisoned: {e}")))?;
+        let repaired = idx.repair();
+        if repaired > 0 {
+            idx.save(&vidx_dir, &label, &property)
+                .map_err(|e| to_napi(format!("HNSW save failed: {e}")))?;
+        }
+        Ok(repaired as u32)
+    }
+
+    /// Resolve a user-facing `id` property to the internal `u64` node id.
+    /// `Ok(None)` when no such node exists.
+    fn resolve_internal_id(&self, label: &str, node_id: &str) -> napi::Result<Option<u64>> {
+        let cypher = format!("MATCH (n:{label} {{id: $id}}) RETURN id(n) AS nid");
+        let mut params = std::collections::HashMap::new();
+        params.insert(
+            "id".to_string(),
+            sparrowdb_execution::Value::String(node_id.to_owned()),
+        );
+        let result = self
+            .inner
+            .execute_with_params(&cypher, params)
+            .map_err(|e| to_napi(format!("{e}")))?;
+        match result.rows.first().and_then(|r| r.first()) {
+            Some(sparrowdb_execution::Value::Int64(n)) => Ok(Some(*n as u64)),
+            Some(other) => Err(to_napi(format!(
+                "unexpected id(n) type from query: {other:?}"
+            ))),
+            None => Ok(None),
+        }
     }
 
     /// Search the HNSW vector index for `k` nearest neighbours.

--- a/crates/sparrowdb-storage/src/vector_index.rs
+++ b/crates/sparrowdb-storage/src/vector_index.rs
@@ -926,25 +926,33 @@ impl VectorIndex {
             self.nodes[slot as usize].connections[layer] = selected.clone();
 
             // Wire selected → slot (reciprocal links), pruning if needed.
+            //
+            // `linked_back` records whether *any* neighbour ended up pointing at
+            // `slot`.  Every branch below can legitimately decline: a full
+            // neighbour keeps its m_max closest links, and `slot` is simply not
+            // one of them.  Losing every contest leaves `slot` a pure sink —
+            // full outgoing degree, zero incoming — and greedy descent only ever
+            // follows outgoing edges, so nothing can reach it.  See issue #443.
+            //
+            // `adopted` carries the nodes this call has re-homed onto `slot`
+            // (see [`Self::link_back`]).  They are by construction far from
+            // `slot` — each was somebody else's *furthest* neighbour — so
+            // without this set the next adoption evicts the previous one and
+            // strands the very node it was protecting.  That is the sequence
+            // that survived the first draft of this fix: inserting node 368
+            // removed the last inbound edge of node 194.
+            let mut adopted: HashSet<u32> = HashSet::new();
+            let mut linked_back = false;
             for &nb in &selected {
-                let nb_connections = self.nodes[nb as usize].connections[layer].clone();
-                if !nb_connections.contains(&slot) {
-                    if nb_connections.len() < m_max {
-                        self.nodes[nb as usize].connections[layer].push(slot);
-                    } else {
-                        // Prune: keep the m_max closest neighbours.
-                        let nb_vec = self.nodes[nb as usize].vector.clone();
-                        let mut all: Vec<(f32, u32)> = nb_connections
-                            .iter()
-                            .map(|&s| (self.distance_to_slot(&nb_vec, s), s))
-                            .collect();
-                        all.push((self.distance_to_slot(&nb_vec, slot), slot));
-                        all.sort_by(|a, b| {
-                            a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal)
-                        });
-                        self.nodes[nb as usize].connections[layer] =
-                            all.iter().take(m_max).map(|&(_, s)| s).collect();
-                    }
+                linked_back |= self.link_back(nb, slot, layer, m_max, false, &mut adopted);
+            }
+
+            // Reciprocal-link guarantee (#443).  `selected` is sorted
+            // nearest-first by `select_neighbours`, so `selected[0]` is the best
+            // available anchor to force the edge through.
+            if !linked_back {
+                if let Some(&nb0) = selected.first() {
+                    self.link_back(nb0, slot, layer, m_max, true, &mut adopted);
                 }
             }
 
@@ -956,6 +964,321 @@ impl VectorIndex {
                 ep_current = best_slot;
             }
         }
+    }
+
+    /// Add the edge `nb → slot` at `layer`, evicting from `nb`'s adjacency list
+    /// if it is already at `m_max`.  Returns `true` when the edge exists
+    /// afterwards.
+    ///
+    /// `force = false` keeps the original quality rule: `slot` is admitted only
+    /// if it is closer to `nb` than `nb`'s current furthest neighbour, exactly
+    /// as "keep the `m_max` closest of `conns ∪ {slot}`" did.  `force = true`
+    /// admits it regardless — used for the last-resort reciprocal guarantee.
+    ///
+    /// # Why no eviction here can strand a node
+    ///
+    /// Dropping the edge `nb → x` is the step that silently destroys
+    /// reachability: if that was `x`'s only inbound edge, wiring one node in has
+    /// orphaned another, and nothing reports it.  Issue #443 is the accumulated
+    /// result — both the ~1–5% of inserts that end with zero incoming edges and
+    /// the closed islands of nodes that point at each other with no path back.
+    ///
+    /// The invariant restored here: **`slot` must point at whatever `slot`
+    /// displaced.**  Then every path that used `nb → x` reroutes as
+    /// `nb → slot → x`, and `slot` is reachable because `nb` is, so the set of
+    /// reachable nodes never shrinks.  Two cases:
+    ///
+    /// 1. `slot → x` already exists (the common case — `nb` is one of `slot`'s
+    ///    chosen neighbours, so they share neighbours). Nothing else to do.
+    /// 2. Otherwise `slot` adopts `x`.  If `slot`'s own list is full this
+    ///    displaces `slot`'s furthest edge `y`; `slot`'s links at this layer
+    ///    were all (re)assigned moments ago by [`Self::link_slot`], so dropping
+    ///    one cannot remove any inbound edge `y` had before this call.
+    ///
+    /// Cost: one extra adjacency scan on the eviction path.
+    fn link_back(
+        &mut self,
+        nb: u32,
+        slot: u32,
+        layer: usize,
+        m_max: usize,
+        force: bool,
+        adopted: &mut HashSet<u32>,
+    ) -> bool {
+        if nb == slot {
+            return false;
+        }
+        let conns = self.nodes[nb as usize].connections[layer].clone();
+        if conns.contains(&slot) {
+            return true;
+        }
+        if conns.len() < m_max {
+            self.nodes[nb as usize].connections[layer].push(slot);
+            return true;
+        }
+
+        // `nb`'s list is full: `slot` takes the furthest occupant's place, but
+        // only if it beats it (unless forced).
+        let nb_vec = self.nodes[nb as usize].vector.clone();
+        let d_slot = self.distance_to_slot(&nb_vec, slot);
+        let mut furthest: Option<(f32, usize)> = None;
+        for (i, &x) in conns.iter().enumerate() {
+            let d = self.distance_to_slot(&nb_vec, x);
+            if furthest.is_none_or(|(bd, _)| d > bd) {
+                furthest = Some((d, i));
+            }
+        }
+        let Some((d_worst, pos)) = furthest else {
+            return false;
+        };
+        if !force && d_slot >= d_worst {
+            return false; // `slot` lost the contest fairly; nothing changes.
+        }
+
+        // The eviction is only safe if `slot` can take `displaced` on.  When it
+        // cannot, decline rather than strand it — unless forced, where leaving
+        // `slot` itself unreachable is the worse outcome and [`Self::repair`] is
+        // the backstop.
+        // Most evictions are harmless: `displaced` keeps other inbound edges and
+        // needs no help.  Only pay the adoption — which spends one of `slot`'s
+        // own good links on a far node — when the edge being removed is the last
+        // one into `displaced`.
+        let displaced = conns[pos];
+        let needs_adoption = !self.has_other_inbound(displaced, nb, layer);
+        if needs_adoption && !force && !self.can_adopt(slot, displaced, layer, m_max, adopted) {
+            return false;
+        }
+        self.nodes[nb as usize].connections[layer][pos] = slot;
+        if needs_adoption {
+            self.adopt(slot, displaced, layer, m_max, adopted);
+        }
+        true
+    }
+
+    /// Whether `displaced` still has an inbound edge at `layer` from some node
+    /// other than `exclude`.
+    ///
+    /// Only `displaced`'s own out-neighbours are checked for a link back.  That
+    /// is a *sufficient* test, not an exhaustive one — an inbound edge from a
+    /// node `displaced` does not point at is missed and costs an unnecessary
+    /// adoption, never a stranded node.  Because the reciprocal guarantee makes
+    /// links overwhelmingly bidirectional, the first probe almost always hits,
+    /// so this is O(1) in practice and O(m_max²) at worst.
+    ///
+    /// Soundness relies on the induction this whole scheme maintains: every node
+    /// in the index is reachable, so *any* surviving inbound edge is an inbound
+    /// edge from a reachable node.
+    fn has_other_inbound(&self, displaced: u32, exclude: u32, layer: usize) -> bool {
+        for &z in &self.nodes[displaced as usize].connections[layer] {
+            if z != exclude
+                && z != displaced
+                && self.nodes[z as usize]
+                    .connections
+                    .get(layer)
+                    .is_some_and(|c| c.contains(&displaced))
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Whether [`Self::adopt`] can take `displaced` on without evicting a node
+    /// this call already adopted (and therefore may be the last link to).
+    fn can_adopt(
+        &self,
+        slot: u32,
+        displaced: u32,
+        layer: usize,
+        m_max: usize,
+        adopted: &HashSet<u32>,
+    ) -> bool {
+        if slot == displaced {
+            return true;
+        }
+        let conns = &self.nodes[slot as usize].connections[layer];
+        conns.contains(&displaced)
+            || conns.len() < m_max
+            || conns.iter().any(|y| !adopted.contains(y))
+    }
+
+    /// Ensure `slot → displaced` exists at `layer`, so a node that just lost an
+    /// inbound edge to `slot` keeps a path in.  See [`Self::link_back`].
+    fn adopt(
+        &mut self,
+        slot: u32,
+        displaced: u32,
+        layer: usize,
+        m_max: usize,
+        adopted: &mut HashSet<u32>,
+    ) {
+        if slot == displaced {
+            return;
+        }
+        let conns = &self.nodes[slot as usize].connections[layer];
+        if conns.contains(&displaced) {
+            adopted.insert(displaced);
+            return;
+        }
+        if conns.len() < m_max {
+            self.nodes[slot as usize].connections[layer].push(displaced);
+            adopted.insert(displaced);
+            return;
+        }
+        // Evict `slot`'s furthest link, skipping anything adopted earlier in
+        // this call: those are precisely the nodes with no other inbound edge.
+        let slot_vec = self.nodes[slot as usize].vector.clone();
+        let worst = self.nodes[slot as usize].connections[layer]
+            .iter()
+            .enumerate()
+            .filter(|(_, y)| !adopted.contains(y))
+            .max_by(|a, b| {
+                let da = self.distance_to_slot(&slot_vec, *a.1);
+                let db = self.distance_to_slot(&slot_vec, *b.1);
+                da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .map(|(i, _)| i);
+        if let Some(i) = worst {
+            self.nodes[slot as usize].connections[layer][i] = displaced;
+            adopted.insert(displaced);
+        }
+    }
+
+    // ── Reachability ──────────────────────────────────────────────────────────
+
+    /// Mark every slot reachable from `entry_point` by following layer-0
+    /// outgoing edges.
+    ///
+    /// This is the set `search()` can actually return.  Greedy descent through
+    /// the upper layers only ever lands on nodes reachable from the entry point,
+    /// and every node exists at layer 0, so layer-0 reachability from the entry
+    /// point is the necessary condition for a vector to be findable at all.
+    ///
+    /// O(nodes + edges), no distance arithmetic.
+    fn reachable_slots(&self) -> Vec<bool> {
+        let mut seen = vec![false; self.nodes.len()];
+        let Some(ep) = self.entry_point else {
+            return seen;
+        };
+        if (ep as usize) >= self.nodes.len() {
+            return seen;
+        }
+        seen[ep as usize] = true;
+        let mut stack = vec![ep];
+        while let Some(s) = stack.pop() {
+            for &nb in &self.nodes[s as usize].connections[0] {
+                if !seen[nb as usize] {
+                    seen[nb as usize] = true;
+                    stack.push(nb);
+                }
+            }
+        }
+        seen
+    }
+
+    /// `true` when `node_id` has a vector stored in this index.
+    ///
+    /// Answers the question `search()` cannot: "not returned by a search" and
+    /// "absent from the index" are different facts, and before this existed
+    /// callers had no way to tell them apart — which is how issue #443 stayed
+    /// invisible.  O(1).
+    pub fn has_vector(&self, node_id: u64) -> bool {
+        self.id_to_slot.contains_key(&node_id)
+    }
+
+    /// Number of stored vectors that greedy search can actually reach.
+    ///
+    /// Compare against [`Self::len`]: a healthy index has
+    /// `reachable_count() == len()`.  Any gap is silent recall loss.
+    pub fn reachable_count(&self) -> usize {
+        self.reachable_slots().iter().filter(|&&r| r).count()
+    }
+
+    /// The `node_id`s that are stored but unreachable — the ones
+    /// [`Self::has_vector`] reports as present and `search` will never return.
+    pub fn unreachable_ids(&self) -> Vec<u64> {
+        let seen = self.reachable_slots();
+        let mut ids: Vec<u64> = self
+            .nodes
+            .iter()
+            .zip(seen.iter())
+            .filter(|(_, &r)| !r)
+            .map(|(n, _)| n.node_id)
+            .collect();
+        ids.sort_unstable();
+        ids
+    }
+
+    /// Reconnect every stored-but-unreachable vector, returning how many nodes
+    /// were re-linked.
+    ///
+    /// Needed independently of the insert-time guarantee for two reasons: an
+    /// index written by an older build carries its orphans in the file, and a
+    /// group of former sinks can become each other's chosen neighbours and form
+    /// a closed island — non-zero in-degree, still no path from `entry_point`.
+    /// An in-degree check calls those healthy; only a traversal finds them.
+    ///
+    /// Each unreachable node is attached to its nearest *reachable* neighbour
+    /// via [`Self::link_back`], which never strands the edge it
+    /// displaces.  A repaired node makes everything hanging off it reachable
+    /// too, so the loop re-walks until it reaches a fixpoint.
+    ///
+    /// Returns 0 for a healthy index after one O(nodes + edges) walk.
+    pub fn repair(&mut self) -> usize {
+        let mut repaired = 0usize;
+        // Each pass strictly grows the reachable set, so this terminates well
+        // inside the bound; the bound only guards against a pathological index
+        // where `reconnect_slot` cannot find a candidate.
+        for _ in 0..8 {
+            let seen = self.reachable_slots();
+            let todo: Vec<u32> = (0..self.nodes.len() as u32)
+                .filter(|&s| !seen[s as usize])
+                .collect();
+            if todo.is_empty() {
+                break;
+            }
+            let before = repaired;
+            for u in todo {
+                if self.reconnect_slot(u) {
+                    repaired += 1;
+                }
+            }
+            if repaired == before {
+                break;
+            }
+        }
+        repaired
+    }
+
+    /// Attach `u` to its nearest reachable neighbour at layer 0.
+    ///
+    /// `u`'s own outgoing edges are deliberately left alone: they may be the
+    /// only inbound edges of other unreachable nodes in the same island, and
+    /// re-linking `u` makes that whole island reachable for free.
+    fn reconnect_slot(&mut self, u: u32) -> bool {
+        let Some(ep) = self.entry_point else {
+            return false;
+        };
+        if ep == u || (u as usize) >= self.nodes.len() {
+            return false;
+        }
+        let vector = self.nodes[u as usize].vector.clone();
+        let mut ep_current = ep;
+        for l in (1..=self.max_layer).rev() {
+            ep_current = self.greedy_search_layer(&vector, ep_current, l, l - 1);
+        }
+        let mut candidates = self.search_layer(&vector, &[ep_current], self.ef_construction, 0);
+        // `search_layer` walks outgoing edges from a reachable entry point, so
+        // it can only return reachable slots; `u` is unreachable by definition.
+        candidates.retain(|&(_, s)| s != u);
+        let Some(&(_, nb0)) = candidates
+            .iter()
+            .min_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal))
+        else {
+            return false;
+        };
+        self.link_back(nb0, u, 0, self.m_max0, true, &mut HashSet::new());
+        true
     }
 
     /// Search for the `k` approximate nearest neighbours of `query`.
@@ -1357,6 +1680,321 @@ mod tests {
             idx.nodes[ep as usize].connections.len() > idx.max_layer,
             "entry point must exist on the top layer"
         );
+    }
+
+    // ── Issue #443: reachability invariants ───────────────────────────────────
+    //
+    // These reach into private fields on purpose: in-degree and adjacency-list
+    // capacity are exactly the things `search()` cannot show you, and not being
+    // able to see them is why #443 survived for months.
+
+    /// xorshift64 + Box–Muller.  Deterministic, dependency-free, and identical
+    /// on every platform, so these fixtures are reproducible.
+    struct TestRng(u64);
+    impl TestRng {
+        fn new(seed: u64) -> Self {
+            TestRng(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1)
+        }
+        fn next_u64(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            self.0 = x;
+            x
+        }
+        fn unit(&mut self) -> f64 {
+            (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64
+        }
+        fn normal(&mut self) -> f64 {
+            let u1 = self.unit().max(1e-12);
+            let u2 = self.unit();
+            (-2.0 * u1.ln()).sqrt() * (2.0 * std::f64::consts::PI * u2).cos()
+        }
+    }
+
+    fn l2_normalise(v: &mut [f32]) {
+        let n: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if n > 0.0 {
+            for x in v.iter_mut() {
+                *x /= n;
+            }
+        }
+    }
+
+    fn random_direction(rng: &mut TestRng, dims: usize) -> Vec<f32> {
+        let mut v: Vec<f32> = (0..dims).map(|_| rng.normal() as f32).collect();
+        l2_normalise(&mut v);
+        v
+    }
+
+    /// A corpus with the geometry that actually triggers #443.
+    ///
+    /// Every vector is `aniso * mu + centre + noise`, L2-normalised.  The shared
+    /// `mu` term is what real sentence embeddings look like — they are not
+    /// spread over the sphere, they sit in a narrow cone, so *all* pairwise
+    /// distances are compressed and a new node inserted into a mature
+    /// neighbourhood struggles to beat the occupants of its neighbours' lists.
+    /// Isotropic random vectors (the shape most HNSW tests use) never reproduce
+    /// this, which is the other reason the defect stayed hidden.
+    fn cone_corpus(n: usize, dims: usize, clusters: usize, aniso: f32, seed: u64) -> Vec<Vec<f32>> {
+        let mut rng = TestRng::new(seed);
+        let mu = random_direction(&mut rng, dims);
+        let centres: Vec<Vec<f32>> = (0..clusters)
+            .map(|_| random_direction(&mut rng, dims))
+            .collect();
+        (0..n)
+            .map(|i| {
+                // Cluster-by-cluster arrival, i.e. topical batches over time,
+                // not a shuffled stream.
+                let c = &centres[(i * clusters) / n];
+                let mut v: Vec<f32> = (0..dims)
+                    .map(|d| aniso * mu[d] + c[d] + (rng.normal() * 0.35) as f32)
+                    .collect();
+                l2_normalise(&mut v);
+                v
+            })
+            .collect()
+    }
+
+    /// Layer-0 in-degree of every slot.
+    fn layer0_in_degree(idx: &VectorIndex) -> Vec<usize> {
+        let mut deg = vec![0usize; idx.nodes.len()];
+        for node in &idx.nodes {
+            for &nb in &node.connections[0] {
+                deg[nb as usize] += 1;
+            }
+        }
+        deg
+    }
+
+    /// The core invariant of #443: a vector that is stored must be a vector that
+    /// greedy traversal can reach.
+    ///
+    /// Hand-derived expectations:
+    /// - 700 inserts of the distinct ids `0..700` each take the "new id" path,
+    ///   so `len() == 700`.
+    /// - `reachable_count()` counts slots reachable from `entry_point` over
+    ///   layer-0 edges. It can never exceed `len()`. A correct index has them
+    ///   equal, because a node no path leads to can never be returned by
+    ///   `search`, whatever `k` and `ef` are set to.
+    /// - Therefore `unreachable_ids()` must be empty. Not "small" — empty. The
+    ///   pre-fix code produces a non-empty list on this fixture.
+    #[test]
+    fn spa443_every_stored_vector_is_reachable() {
+        const N: usize = 700;
+        const DIMS: usize = 48;
+        let vectors = cone_corpus(N, DIMS, 9, 2.0, 0x5EED);
+
+        let mut idx = VectorIndex::new(DIMS, Metric::Cosine);
+        for (i, v) in vectors.iter().enumerate() {
+            assert_eq!(
+                idx.insert(i as u64, v),
+                InsertOutcome::Inserted,
+                "id {i} is distinct, so it must take the insert path"
+            );
+        }
+        assert_eq!(idx.len(), N, "700 distinct ids were inserted");
+
+        let stranded = idx.unreachable_ids();
+        assert!(
+            stranded.is_empty(),
+            "{} of {N} stored vectors are unreachable from the entry point and can \
+             never be returned by search: {:?}",
+            stranded.len(),
+            &stranded[..stranded.len().min(20)]
+        );
+        assert_eq!(
+            idx.reachable_count(),
+            N,
+            "every stored vector must be reachable"
+        );
+    }
+
+    /// Every node must keep at least one inbound edge at layer 0.
+    ///
+    /// Zero in-degree is the mechanism behind #443: `insert` wires
+    /// `new -> neighbours` unconditionally but `neighbours -> new` only when the
+    /// new node beats an existing occupant on distance, so a node in a saturated
+    /// neighbourhood can end up a pure sink — full outgoing degree, nothing
+    /// pointing at it, invisible to a traversal that only follows outgoing
+    /// edges.
+    ///
+    /// Hand-derived: with N >= 2, every slot other than the entry point must be
+    /// pointed at by something, and the entry point too once the graph has more
+    /// than one node, since `link_slot` always establishes an edge in both
+    /// directions for at least one neighbour. So the minimum in-degree over all
+    /// 700 slots is >= 1.
+    #[test]
+    fn spa443_no_node_has_zero_in_degree() {
+        const N: usize = 700;
+        const DIMS: usize = 48;
+        let vectors = cone_corpus(N, DIMS, 9, 2.0, 0x5EED);
+        let mut idx = VectorIndex::new(DIMS, Metric::Cosine);
+        for (i, v) in vectors.iter().enumerate() {
+            idx.insert(i as u64, v);
+        }
+
+        let deg = layer0_in_degree(&idx);
+        let sinks: Vec<usize> = (0..idx.len()).filter(|&s| deg[s] == 0).collect();
+        assert!(
+            sinks.is_empty(),
+            "{} slots have zero layer-0 in-degree (pure sinks): {:?}",
+            sinks.len(),
+            &sinks[..sinks.len().min(20)]
+        );
+    }
+
+    /// The reciprocal-link guarantee must not be bought by letting adjacency
+    /// lists grow past their cap — an unbounded list would trade a correctness
+    /// bug for a memory and latency one.
+    ///
+    /// Hand-derived from the constructor: `VectorIndex::new` calls
+    /// `with_params(.., m = 16, ..)` and `with_params` sets `m_max0 = m * 2`.
+    /// So layer 0 admits at most 32 links per node and every layer above it at
+    /// most 16.
+    #[test]
+    fn spa443_adjacency_lists_stay_within_capacity() {
+        const N: usize = 700;
+        const DIMS: usize = 48;
+        let vectors = cone_corpus(N, DIMS, 9, 2.0, 0x5EED);
+        let mut idx = VectorIndex::new(DIMS, Metric::Cosine);
+        for (i, v) in vectors.iter().enumerate() {
+            idx.insert(i as u64, v);
+        }
+        assert_eq!(idx.m, 16, "default M");
+        assert_eq!(idx.m_max0, 32, "m_max0 = 2 * M");
+
+        for (slot, node) in idx.nodes.iter().enumerate() {
+            for (layer, conns) in node.connections.iter().enumerate() {
+                let cap = if layer == 0 { idx.m_max0 } else { idx.m };
+                assert!(
+                    conns.len() <= cap,
+                    "slot {slot} layer {layer} holds {} links, cap is {cap}",
+                    conns.len()
+                );
+                // A self-link would make the node trivially "reachable" from
+                // itself while still being unreachable from the entry point.
+                assert!(
+                    !conns.contains(&(slot as u32)),
+                    "slot {slot} links to itself at layer {layer}"
+                );
+            }
+        }
+    }
+
+    /// `repair()` must reconnect a genuinely marooned node, including one that
+    /// still has inbound edges.
+    ///
+    /// This is the case an in-degree check reports as healthy and misses: a
+    /// group of former sinks that became each other's chosen neighbours forms a
+    /// closed island — non-zero in-degree, no path from `entry_point`. The live
+    /// store had 7 such nodes alongside 33 pure sinks.
+    ///
+    /// The fixture builds a healthy 200-node index, then severs every inbound
+    /// edge of slots 150 and 151 while leaving the edge between them in place.
+    /// Hand-derived expectations:
+    /// - before severing: `reachable_count() == 200`.
+    /// - after severing: slots 150 and 151 point at each other but nothing else
+    ///   points at either, so no path from the entry point reaches them —
+    ///   `reachable_count() == 198`, and in-degree is 1 for both, i.e. non-zero.
+    /// - after `repair()`: `reachable_count() == 200` again and the return value
+    ///   is the number of nodes it had to re-link, which is at least 1 (linking
+    ///   one member of the island makes the other reachable through it).
+    #[test]
+    fn spa443_repair_reconnects_a_marooned_island() {
+        const N: usize = 200;
+        const DIMS: usize = 32;
+        let vectors = cone_corpus(N, DIMS, 6, 1.5, 0xBEEF);
+        let mut idx = VectorIndex::new(DIMS, Metric::Cosine);
+        for (i, v) in vectors.iter().enumerate() {
+            idx.insert(i as u64, v);
+        }
+        assert_eq!(idx.reachable_count(), N, "fixture must start healthy");
+
+        let (a, b) = (150u32, 151u32);
+        assert_ne!(idx.entry_point, Some(a));
+        assert_ne!(idx.entry_point, Some(b));
+        // Sever every inbound edge of `a` and `b` at every layer.
+        for slot in 0..idx.nodes.len() {
+            if slot as u32 == a || slot as u32 == b {
+                continue;
+            }
+            for conns in idx.nodes[slot].connections.iter_mut() {
+                conns.retain(|&x| x != a && x != b);
+            }
+        }
+        // Leave exactly the island: a -> b and b -> a at layer 0.
+        idx.nodes[a as usize].connections[0] = vec![b];
+        idx.nodes[b as usize].connections[0] = vec![a];
+
+        let deg = layer0_in_degree(&idx);
+        assert_eq!(
+            deg[a as usize], 1,
+            "island member keeps a non-zero in-degree"
+        );
+        assert_eq!(
+            deg[b as usize], 1,
+            "island member keeps a non-zero in-degree"
+        );
+        assert_eq!(
+            idx.reachable_count(),
+            N - 2,
+            "the two island members must now be unreachable despite in-degree 1"
+        );
+
+        let repaired = idx.repair();
+        assert!(
+            repaired >= 1,
+            "repair must re-link at least one island member, re-linked {repaired}"
+        );
+        assert_eq!(
+            idx.reachable_count(),
+            N,
+            "repair must restore full reachability"
+        );
+        assert!(idx.unreachable_ids().is_empty());
+    }
+
+    /// `repair()` on a healthy index changes nothing and reports nothing.
+    /// Hand-derived: a freshly built index satisfies the invariant, so the first
+    /// walk finds no unreachable slots and the function returns 0 without
+    /// touching an edge.
+    #[test]
+    fn spa443_repair_is_a_noop_on_a_healthy_index() {
+        const N: usize = 300;
+        const DIMS: usize = 32;
+        let vectors = cone_corpus(N, DIMS, 6, 1.5, 0xF00D);
+        let mut idx = VectorIndex::new(DIMS, Metric::Cosine);
+        for (i, v) in vectors.iter().enumerate() {
+            idx.insert(i as u64, v);
+        }
+        let before: Vec<Vec<Vec<u32>>> = idx.nodes.iter().map(|n| n.connections.clone()).collect();
+        assert_eq!(idx.repair(), 0, "healthy index needs no repair");
+        let after: Vec<Vec<Vec<u32>>> = idx.nodes.iter().map(|n| n.connections.clone()).collect();
+        assert_eq!(before, after, "repair must not rewire a healthy index");
+    }
+
+    /// `has_vector` must answer from `id_to_slot`, independently of whether a
+    /// search can find the node.
+    ///
+    /// Hand-derived: ids 0..50 are inserted, so `has_vector` is true for each of
+    /// them and false for 50..60, which were never inserted.
+    #[test]
+    fn spa443_has_vector_reports_storage_not_findability() {
+        let mut idx = VectorIndex::new(8, Metric::Cosine);
+        let mut rng = TestRng::new(1);
+        for i in 0u64..50 {
+            let v = random_direction(&mut rng, 8);
+            idx.insert(i, &v);
+        }
+        for i in 0u64..50 {
+            assert!(idx.has_vector(i), "id {i} was inserted");
+        }
+        for i in 50u64..60 {
+            assert!(!idx.has_vector(i), "id {i} was never inserted");
+        }
+        assert!(!idx.has_vector(u64::MAX));
     }
 
     #[test]

--- a/crates/sparrowdb/tests/regression_443.rs
+++ b/crates/sparrowdb/tests/regression_443.rs
@@ -1,0 +1,395 @@
+//! Reachability guards for the HNSW vector index (issue #443).
+//!
+//! # The defect
+//!
+//! `insert` wired `new -> neighbours` unconditionally, but the reciprocal step
+//! `neighbours -> new` only landed when the new node beat an existing occupant
+//! of that neighbour's adjacency list on distance. A node inserted into a
+//! saturated neighbourhood could lose all 32 of those contests and end up a
+//! pure sink: full outgoing degree, present in `id_to_slot`, nothing pointing at
+//! it. Greedy descent only follows *outgoing* edges from the entry point, so
+//! such a node is invisible to `search` at any `k` and any `ef`.
+//!
+//! On the live store that surfaced this: 1347 vectors stored, 1307 reachable,
+//! 40 stranded — 33 of them with zero in-degree and 7 forming a closed island
+//! that pointed at each other with no path back to the main component. Nothing
+//! repaired it and nothing reported it; re-inserting a stranded node takes the
+//! "already present" path, so even a full backfill could not heal it.
+//!
+//! # What these tests assert
+//!
+//! Reachability, not in-degree. An in-degree check calls the 7 island members
+//! healthy. Only a traversal from the entry point finds them.
+//!
+//! Every expected value below is derived by hand from the fixture the test
+//! itself builds. Nothing here is a recording of what the code returns — see
+//! `regression_406.rs` for what that mistake costs: a guard that passes against
+//! the unfixed code guards nothing.
+
+use sparrowdb_storage::vector_index::{InsertOutcome, Metric, VectorIndex};
+
+// ── Deterministic fixture ─────────────────────────────────────────────────────
+
+/// xorshift64 + Box–Muller. Dependency-free and identical on every platform, so
+/// these fixtures reproduce exactly.
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Rng(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1)
+    }
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+    fn unit(&mut self) -> f64 {
+        (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64
+    }
+    fn normal(&mut self) -> f64 {
+        let u1 = self.unit().max(1e-12);
+        let u2 = self.unit();
+        (-2.0 * u1.ln()).sqrt() * (2.0 * std::f64::consts::PI * u2).cos()
+    }
+}
+
+fn l2_normalise(v: &mut [f32]) {
+    let n: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if n > 0.0 {
+        for x in v.iter_mut() {
+            *x /= n;
+        }
+    }
+}
+
+fn random_direction(rng: &mut Rng, dims: usize) -> Vec<f32> {
+    let mut v: Vec<f32> = (0..dims).map(|_| rng.normal() as f32).collect();
+    l2_normalise(&mut v);
+    v
+}
+
+/// A corpus with the geometry that actually triggers #443.
+///
+/// Each vector is `aniso * mu + centre + noise`, L2-normalised, and vectors
+/// arrive cluster by cluster rather than shuffled — topical batches over time,
+/// which is how a memory store fills up.
+///
+/// The shared `mu` term matters. Real sentence embeddings do not spread over the
+/// sphere; they occupy a narrow cone, so pairwise distances are compressed and a
+/// new node has to squeeze into neighbour lists whose occupants are all at
+/// similar range. Isotropic random vectors — the shape most HNSW tests use —
+/// never reproduce this, which is a large part of why the defect survived so
+/// long. Neither do near-duplicates of an already-indexed vector, which land
+/// beside a node the graph already reaches and are trivially findable.
+fn cone_corpus(n: usize, dims: usize, clusters: usize, aniso: f32, seed: u64) -> Vec<Vec<f32>> {
+    let mut rng = Rng::new(seed);
+    let mu = random_direction(&mut rng, dims);
+    let centres: Vec<Vec<f32>> = (0..clusters)
+        .map(|_| random_direction(&mut rng, dims))
+        .collect();
+    (0..n)
+        .map(|i| {
+            let c = &centres[(i * clusters) / n];
+            let mut v: Vec<f32> = (0..dims)
+                .map(|d| aniso * mu[d] + c[d] + (rng.normal() * 0.35) as f32)
+                .collect();
+            l2_normalise(&mut v);
+            v
+        })
+        .collect()
+}
+
+fn build(
+    n: usize,
+    dims: usize,
+    clusters: usize,
+    aniso: f32,
+    seed: u64,
+) -> (VectorIndex, Vec<Vec<f32>>) {
+    let vectors = cone_corpus(n, dims, clusters, aniso, seed);
+    let mut idx = VectorIndex::new(dims, Metric::Cosine);
+    for (i, v) in vectors.iter().enumerate() {
+        assert_eq!(
+            idx.insert(i as u64, v),
+            InsertOutcome::Inserted,
+            "id {i} is distinct, so it must take the insert path"
+        );
+    }
+    (idx, vectors)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// No stored vector may be unreachable.
+///
+/// Hand-derived expectations:
+/// - 700 inserts of the distinct ids `0..700` each take the "new id" path (the
+///   `InsertOutcome::Inserted` assertion in `build` proves it), so `len() == 700`.
+/// - `reachable_count()` walks layer-0 edges from `entry_point`. It can never
+///   exceed `len()`. A correct index has them equal, because a node no path
+///   leads to cannot be returned by `search` for any `k` or `ef`.
+/// - So `unreachable_ids()` must be *empty*, not merely short.
+#[test]
+fn spa443_no_stored_vector_is_unreachable() {
+    const N: usize = 700;
+    let (idx, _) = build(N, 48, 9, 2.0, 0x5EED);
+
+    assert_eq!(idx.len(), N, "700 distinct ids were inserted");
+    let stranded = idx.unreachable_ids();
+    assert!(
+        stranded.is_empty(),
+        "{} of {N} stored vectors are unreachable from the entry point and can never \
+         be returned by search: {:?}",
+        stranded.len(),
+        &stranded[..stranded.len().min(20)]
+    );
+    assert_eq!(idx.reachable_count(), N);
+}
+
+/// The user-visible form of the same invariant: every inserted vector is
+/// returned by a search for *itself*, once the search budget is large enough to
+/// stop being the limiting factor.
+///
+/// Hand-derived expectations:
+/// - `cosine_similarity(v, v) = (v·v) / (|v| · |v|) = 1.0` for any non-zero `v`,
+///   and `search` reports cosine similarity directly as the score. So a query
+///   with a stored vector must return that vector's own id with a score of
+///   exactly 1.0; `> 0.999` allows only for f32 rounding in the accumulation.
+///   No other id can score higher, so it must occupy the top of the window
+///   whenever the traversal visits it at all.
+/// - `ef = N` makes the candidate window as large as the index, so the window
+///   never evicts and best-first search degenerates into a full traversal of the
+///   reachable component. Under that budget "returned by search" and "reachable
+///   from the entry point" are the same predicate.
+/// - Therefore the expected number of vectors that fail to retrieve themselves
+///   is exactly 0 — and, crucially, no budget whatsoever rescues a node with no
+///   path in, which is what makes this the user-facing statement of #443 rather
+///   than a statement about search tuning.
+#[test]
+fn spa443_every_vector_retrieves_itself_given_full_budget() {
+    const N: usize = 700;
+    let (idx, vectors) = build(N, 48, 9, 2.0, 0x5EED);
+
+    let mut missing: Vec<usize> = Vec::new();
+    for (i, v) in vectors.iter().enumerate() {
+        let hits = idx.search(v, 10, N);
+        if !hits
+            .iter()
+            .any(|&(id, score)| id == i as u64 && score > 0.999)
+        {
+            missing.push(i);
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "{} of {N} vectors are not returned by a search for their own embedding even \
+         with the candidate window opened to the size of the whole index — they have \
+         no path from the entry point: {:?}",
+        missing.len(),
+        &missing[..missing.len().min(20)]
+    );
+}
+
+/// Self-retrieval at the *default* search budget, on a corpus without extreme
+/// outliers.
+///
+/// This one is a forward guard, not a reproduction: it passes against the
+/// pre-fix code too, and is recorded as such rather than dressed up as
+/// evidence. It exists to catch a future change that degrades ordinary
+/// retrieval.
+///
+/// # A real limitation this test is deliberately scoped around
+///
+/// Reachability is necessary for retrieval but not sufficient. `select_neighbours`
+/// takes the nearest `m_max` candidates with no diversity heuristic (HNSW's
+/// Algorithm 4), so the graph carries few long-range links. A strong outlier can
+/// be reachable through a single inbound edge and still be missed at `ef = 50`,
+/// because greedy descent never brings the node holding that edge into the
+/// candidate window. Measured on the harsher `aniso = 2.0` corpus at N = 700:
+/// 2 nodes, both with in-degree 1, retrievable at `ef = 800` but not at `ef` up
+/// to 200. That is a navigability limit in neighbour *selection*, present before
+/// and after this fix and unchanged by it — a separate problem from #443, which
+/// is about nodes with no path at all. Fixing it means redesigning neighbour
+/// selection and re-validating recall, which does not belong in this change.
+///
+/// Hand-derived: same 1.0-self-similarity argument as above; the expected number
+/// of vectors that fail to retrieve themselves is 0.
+#[test]
+fn spa443_every_vector_retrieves_itself_at_default_ef() {
+    const N: usize = 700;
+    // aniso = 1.0: a realistic embedding cone, without the pathological
+    // outliers that the 2.0 corpus generates to stress connectivity.
+    let (idx, vectors) = build(N, 48, 9, 1.0, 0x5EED);
+
+    let mut missing: Vec<usize> = Vec::new();
+    for (i, v) in vectors.iter().enumerate() {
+        let hits = idx.search(v, 10, 50);
+        if !hits
+            .iter()
+            .any(|&(id, score)| id == i as u64 && score > 0.999)
+        {
+            missing.push(i);
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "{} of {N} vectors are not returned by a search for their own embedding at the \
+         default ef: {:?}",
+        missing.len(),
+        &missing[..missing.len().min(20)]
+    );
+}
+
+/// A whole class of defect in this codebase only appears after the index has
+/// been through a save/load cycle, so the invariant is re-checked on the far
+/// side of one — and inserts that arrive *after* the reload must preserve it
+/// too, since that is exactly the state a long-running daemon is in.
+///
+/// Hand-derived expectations:
+/// - 500 vectors are inserted, saved and reloaded. `save`/`load` round-trip the
+///   node array and `id_to_slot` verbatim, so the reloaded index has
+///   `len() == 500` and `reachable_count() == 500`.
+/// - 200 further vectors are then inserted into the reloaded handle, using ids
+///   `500..700` which the reloaded index has never seen, so each is `Inserted`
+///   and `len() == 700`.
+/// - The reachability invariant is not a property of a freshly built graph, it
+///   is a property of the graph at all times, so `reachable_count() == 700`.
+#[test]
+fn spa443_reachability_survives_save_and_reload() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let vectors = cone_corpus(700, 48, 9, 2.0, 0xC0FFEE);
+
+    let mut idx = VectorIndex::new(48, Metric::Cosine);
+    for (i, v) in vectors.iter().enumerate().take(500) {
+        idx.insert(i as u64, v);
+    }
+    idx.save(dir.path(), "Memory", "embedding")
+        .expect("save must succeed");
+
+    let mut reloaded = VectorIndex::load(dir.path(), "Memory", "embedding")
+        .expect("load must succeed")
+        .expect("the index file was just written, so it exists");
+    assert_eq!(reloaded.len(), 500, "500 vectors were saved");
+    assert_eq!(
+        reloaded.reachable_count(),
+        500,
+        "reload must not strand anything"
+    );
+
+    for (i, v) in vectors.iter().enumerate().skip(500) {
+        assert_eq!(
+            reloaded.insert(i as u64, v),
+            InsertOutcome::Inserted,
+            "id {i} is new to the reloaded index"
+        );
+    }
+    assert_eq!(reloaded.len(), 700);
+    let stranded = reloaded.unreachable_ids();
+    assert!(
+        stranded.is_empty(),
+        "{} vectors inserted after a reload are unreachable: {:?}",
+        stranded.len(),
+        &stranded[..stranded.len().min(20)]
+    );
+
+    // And the invariant must still hold once *that* state is persisted too.
+    reloaded
+        .save(dir.path(), "Memory", "embedding")
+        .expect("second save must succeed");
+    let twice = VectorIndex::load(dir.path(), "Memory", "embedding")
+        .expect("load must succeed")
+        .expect("file exists");
+    assert_eq!(twice.len(), 700);
+    assert_eq!(twice.reachable_count(), 700);
+}
+
+/// `has_vector` answers the question `search` cannot.
+///
+/// "Not returned by `vectorSearch`" and "absent from the index" are different
+/// facts, and with only `vectorSearch` to probe with there was no way to tell
+/// them apart — which is how an investigation twice concluded that writes were
+/// failing when the vectors were stored and merely unreachable.
+///
+/// Hand-derived: ids `0..700` are inserted and nothing else is, so `has_vector`
+/// is true for exactly those 700 ids and false for every id at or above 700.
+#[test]
+fn spa443_has_vector_reports_storage_independently_of_search() {
+    const N: usize = 700;
+    let (idx, _) = build(N, 48, 9, 2.0, 0x5EED);
+
+    for i in 0..N as u64 {
+        assert!(idx.has_vector(i), "id {i} was inserted");
+    }
+    for i in N as u64..N as u64 + 25 {
+        assert!(!idx.has_vector(i), "id {i} was never inserted");
+    }
+    assert!(!idx.has_vector(u64::MAX));
+
+    // The two counts a monitoring caller needs, and their relationship.
+    assert_eq!(idx.len(), N);
+    assert_eq!(idx.reachable_count(), N);
+    assert!(
+        idx.reachable_count() <= idx.len(),
+        "reachable can never exceed stored"
+    );
+}
+
+/// `repair()` must be safe to call unconditionally: a no-op on a healthy index,
+/// reporting 0 and rewiring nothing.
+///
+/// Hand-derived: the index built above satisfies the invariant, so the first
+/// traversal finds no unreachable slots, and the function returns before
+/// touching an edge. Search results must therefore be bit-identical either side
+/// of the call.
+#[test]
+fn spa443_repair_is_safe_to_call_on_a_healthy_index() {
+    const N: usize = 400;
+    let (mut idx, vectors) = build(N, 48, 8, 2.0, 0xD00D);
+
+    let before: Vec<Vec<(u64, f32)>> = vectors.iter().map(|v| idx.search(v, 5, 50)).collect();
+    assert_eq!(idx.repair(), 0, "a healthy index needs no repair");
+    let after: Vec<Vec<(u64, f32)>> = vectors.iter().map(|v| idx.search(v, 5, 50)).collect();
+
+    assert_eq!(
+        before, after,
+        "repair must not change what a healthy index returns"
+    );
+    assert_eq!(idx.reachable_count(), N);
+}
+
+/// Replacing a vector for an existing id must leave the index fully reachable.
+///
+/// The update path rewires the node's outgoing links wholesale, which is another
+/// opportunity to strand whatever those links were the last route to.
+///
+/// Hand-derived expectations:
+/// - 400 ids are inserted, then ids `0..100` are re-inserted with fresh vectors.
+///   Each of those 100 must report `InsertOutcome::Updated`, because the id is
+///   already mapped, and `len()` must stay at 400 — an update takes no new slot.
+/// - Reachability is an always-invariant, so `reachable_count() == 400` after.
+#[test]
+fn spa443_updates_do_not_strand_vectors() {
+    const N: usize = 400;
+    let (mut idx, _) = build(N, 48, 8, 2.0, 0xABBA);
+
+    let replacements = cone_corpus(100, 48, 4, 2.0, 0x1234);
+    for (i, v) in replacements.iter().enumerate() {
+        assert_eq!(
+            idx.insert(i as u64, v),
+            InsertOutcome::Updated,
+            "id {i} already has a vector, so this is a replacement"
+        );
+    }
+    assert_eq!(idx.len(), N, "an update must not allocate a new slot");
+
+    let stranded = idx.unreachable_ids();
+    assert!(
+        stranded.is_empty(),
+        "{} vectors were stranded by in-place updates: {:?}",
+        stranded.len(),
+        &stranded[..stranded.len().min(20)]
+    );
+}

--- a/npm/sparrowdb/index.d.ts
+++ b/npm/sparrowdb/index.d.ts
@@ -42,6 +42,29 @@ export interface NodeResult {
   score: number
 }
 /**
+ * Coverage report for an HNSW index — see `SparrowDB.vectorIndexHealth`.
+ *
+ * ```typescript
+ * interface VectorIndexHealth {
+ *   stored: number;       // vectors stored in the index
+ *   reachable: number;    // vectors `vectorSearch` can actually reach
+ *   unreachable: number;  // stored - reachable; must be 0 when healthy
+ * }
+ * ```
+ *
+ * Note the `//` comments above rather than nested doc comments: a `*\/` inside
+ * a generated JSDoc block closes it early, which is why the checked-in
+ * `npm/sparrowdb/index.d.ts` does not currently parse as TypeScript.
+ */
+export interface VectorIndexHealth {
+  /** Vectors stored in the index. */
+  stored: number
+  /** Vectors reachable by greedy traversal from the entry point. */
+  reachable: number
+  /** `stored - reachable`. Non-zero means silent recall loss. */
+  unreachable: number
+}
+/**
  * Top-level database handle.
  *
  * ```typescript
@@ -163,6 +186,60 @@ export declare class SparrowDB {
    * ```
    */
   addToVectorIndex(label: string, property: string, nodeId: string, vector: Float32Array): void
+  /**
+   * Whether `node_id` currently has a vector in the `(label, property)`
+   * index.
+   *
+   * This answers the question `vectorSearch` cannot.  "Not returned by
+   * `vectorSearch`" and "absent from the index" are different facts, and
+   * with only `vectorSearch` to probe with there was no way to tell them
+   * apart — which is how issue #443 stayed invisible, and how an
+   * investigation twice concluded that writes were failing when the vectors
+   * were in fact stored and merely unreachable.
+   *
+   * Returns `false` when the node has no vector, and also when no node with
+   * that id exists.  Throws `RangeError` only if the index itself is absent.
+   *
+   * ```typescript
+   * db.hasVector('Memory', 'embedding', 'node-uuid-here')  // => true
+   * ```
+   */
+  hasVector(label: string, property: string, nodeId: string): boolean
+  /**
+   * Coverage of the `(label, property)` index: how many vectors are stored
+   * versus how many `vectorSearch` can actually reach.
+   *
+   * `stored === reachable` on a healthy index.  Any gap is silent recall
+   * loss: those vectors are in the file, `hasVector` reports them present,
+   * and no search will ever return them.  Issue #443 went unnoticed for
+   * months because this number was not observable — the live store sat at
+   * 1347 stored / 1307 reachable with nothing to surface it.
+   *
+   * Cheap: one graph walk, no distance arithmetic.
+   *
+   * ```typescript
+   * const h = db.vectorIndexHealth('Memory', 'embedding')
+   * // { stored: 1347, reachable: 1307, unreachable: 40 }
+   * ```
+   */
+  vectorIndexHealth(label: string, property: string): VectorIndexHealth
+  /**
+   * Reconnect every stored-but-unreachable vector and persist the result.
+   * Returns the number of vectors re-linked.
+   *
+   * Needed for any index written before the reciprocal-link guarantee
+   * shipped: those orphans live in the file, and nothing else repairs them —
+   * re-inserting the same node takes the "already present" path, so a
+   * backfill cannot heal it either.
+   *
+   * A no-op (returns 0) on a healthy index, so it is safe to call on
+   * startup.
+   *
+   * ```typescript
+   * const n = db.repairVectorIndex('Memory', 'embedding')  // => 40
+   * ```
+   */
+  repairVectorIndex(label: string, property: string): number
   /**
    * Search the HNSW vector index for `k` nearest neighbours.
    *


### PR DESCRIPTION
Closes #443.

Based on `fix/vector-index-durability` (#442) — review that first; this PR is the diff on top of it.

## Root cause — confirmed, and it is the reciprocal-link theory

`insert` wires `new -> neighbours` unconditionally. The reciprocal step, `neighbours -> new`, only lands if the new node beats an existing occupant of that neighbour's list on distance:

```rust
if nb_connections.len() < m_max { push(slot) }
else { /* keep the m_max closest of conns ∪ {slot} */ }
```

Lose all 32 contests — which is what happens in a saturated neighbourhood — and the node has **zero incoming edges**. Greedy descent only follows *outgoing* edges from `entry_point`, so it is invisible to `search` at any `k` and any `ef`. Stored, reported present by every available API, never returned.

The same eviction strands **existing** nodes: the prune drops an edge, and if it was the last edge into that node, it is gone from the reachable set permanently. Nothing repaired it — re-inserting takes the "already present" path, so not even a full backfill could heal it.

Live store: **1347 stored, 1307 reachable, 40 stranded** — 33 pure sinks and 7 forming a closed island with non-zero in-degree and no path back.

**Reachability, not in-degree, is the property that matters.** An in-degree check calls those 7 healthy. Every assertion here uses a traversal.

## Reproduced locally

Neither of the two probes in the issue reproduces this. Random orthogonal vectors are near-orthogonal to everything; near-duplicates land beside a node the graph already reaches. What reproduces it is **anisotropic** geometry — real sentence embeddings sit in a narrow cone, not spread over the sphere, so pairwise distances are compressed and a new node must squeeze into lists whose occupants are all at similar range — plus **cluster-by-cluster arrival** rather than a shuffled stream.

| fixture | pre-fix unreachable | post-fix |
|---|---|---|
| 700 vectors, 48-d, aniso 2.0, batched (the test fixture) | 2 (both zero in-degree) | **0** |
| 1400 vectors, 128-d, aniso 4.0 | 14 | **0** |
| 1400 vectors, 128-d, aniso 2.0, batched | 7 | **0** |
| 1300 clustered + 100 novel outliers | 74 | **0** |

## The fix — one invariant at every edge eviction

> A node that displaces an edge `nb -> x` must itself point at `x`.

Then any path through `nb -> x` reroutes as `nb -> slot -> x`; `slot` is reachable because `nb` is; the reachable set can never shrink. Three parts:

- **`link_back`** replaces the inline prune. It keeps the original quality rule — a candidate is admitted only if it beats the furthest occupant — but adopts whatever it displaces *when that edge was the last one in*. `has_other_inbound` makes adoption conditional, so the common harmless eviction costs nothing and graph quality is untouched. (An unconditional version cost 7 points of recall on clean data; that is why it is conditional.)
- **A last-resort forced link** when a new node loses every contest, so no insert can end at zero in-degree.
- **`adopted`** guards the second-order failure that survived my first draft: adopted nodes are by construction far from `slot`, so without the set the *next* adoption evicts the previous one. Concretely, inserting node 368 removed the last inbound edge of node 194. Worth knowing about if you review this logic.

**`repair()`** reconnects anything already stranded — necessary regardless, because the insert-time guarantee does nothing for an index written by an older build, and existing stores do not self-heal.

## Recall — measured, not assumed

recall@10 vs brute force on a **held-out** query set, 10 fixtures:

| | pre-fix | post-fix |
|---|---|---|
| unchanged | 8 fixtures | — |
| 128-d aniso 4.0 | 0.7042 | 0.7025 (−0.002) |
| 1300 + 100 outliers | 0.5983 | 0.6808 (+0.083) |
| **mean** | **0.8518** | **0.8598** |

Connectivity is not bought with recall.

## Observability — the reason this survived months

`vectorSearch` answers a different question than "is this vector stored", and there was no way to ask the right one. Three states looked identical: inserted / skipped-as-present / stored-but-unreachable.

- `VectorIndex::has_vector`, `reachable_count`, `unreachable_ids`, `repair`
- Node: `hasVector`, `vectorIndexHealth` → `{stored, reachable, unreachable}`, `repairVectorIndex`

`stored != reachable` is the single number that would have caught this.

## Tests

`crates/sparrowdb/tests/regression_443.rs` (7) + 6 unit tests in `vector_index.rs` reaching private fields for in-degree and capacity. Every expected value is hand-derived in a comment; nothing is a recording of program output.

**Pre-fix failure proof** — measured by reverting only `link_slot` and keeping the new accessors so the tests still compile. **6 of 7 fail** with the reported symptom:

| test | pre-fix result |
|---|---|
| `spa443_no_stored_vector_is_unreachable` | 2 of 700 unreachable: `[234, 244]` |
| `spa443_every_vector_retrieves_itself_given_full_budget` | 1 of 700 missing at `ef = N`: `[244]` |
| `spa443_reachability_survives_save_and_reload` | reachable 498, expected 500 |
| `spa443_has_vector_reports_storage_independently_of_search` | reachable 698, expected 700 |
| `spa443_repair_is_safe_to_call_on_a_healthy_index` | `repair()` returned 1, expected 0 |
| `spa443_updates_do_not_strand_vectors` | 1 stranded by in-place update: `[344]` |
| `spa443_every_vector_retrieves_itself_at_default_ef` | **passes pre-fix** |
| `spa443_every_stored_vector_is_reachable` (unit) | 2 of 700 unreachable |
| `spa443_no_node_has_zero_in_degree` (unit) | 2 pure sinks: `[234, 244]` |

The one that passes pre-fix is labelled **in-file** as a forward guard, not presented as evidence — `regression_406.rs` is the cautionary example.

Includes a save/reload case, and inserts *after* reload, since a class of defect here only shows up on the far side of persistence.

## Known limitation — not in scope, should be filed

Reachability is necessary for retrieval but **not sufficient**. `select_neighbours` takes the nearest `m_max` with no diversity heuristic (HNSW Algorithm 4), so the graph carries few long-range links. A strong outlier reachable through a single inbound edge can still be missed at `ef = 50` because greedy descent never brings the edge's holder into the candidate window. Measured on the harsher fixture: **2 of 700**, in-degree 1, retrievable at `ef = 800` but not at `ef ≤ 200`.

This is present before and after this change and is unaffected by it. I prototyped Algorithm 4 with `keepPrunedConnections` and A/B'd it: **+0.01–0.02 recall, and it did not close the gap** — so it is not the lever, and swapping neighbour selection is a design change that needs its own recall validation. Filing separately rather than folding it in here.

## Note on the issue's framing

The "~60% of novel embeddings" headline in #443 is a sampling artefact (five consecutive internal ids competing in one saturated neighbourhood). The real rate is **1–5%**. The severity argument is unchanged and arguably stronger: nothing repaired it, so the loss was unbounded over time.

## Verification

- `cargo test -p sparrowdb-storage --no-fail-fast` — 167 passed, 0 failed
- `cargo test -p sparrowdb --test regression_443 --no-fail-fast` — 7 passed
- `cargo fmt --all -- --check` — clean, re-verified in a fresh clone of the pushed branch
- `cargo clippy --workspace --exclude sparrowdb-ruby --all-targets --keep-going -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE
