### PR TITLE
fix(vector): serialise HNSW save() and give each writer its own staging file (closes #452)

### DIFF
--- a/crates/sparrowdb-storage/src/vector_index.rs
+++ b/crates/sparrowdb-storage/src/vector_index.rs
@@ -365,8 +365,8 @@ impl VectorIndex {
     /// 2. Write `header || payload` to `<path>.tmp.<pid>.<nonce>` and `fsync`
     ///    it, so the bytes are on stable storage before anything else changes.
     /// 3. `rename(<staging>, <path>)` — atomic within a filesystem, so a
-    ///    reader ever sees either the complete old file or the complete new
-    ///    one, never a partial one.
+    ///    reader only ever sees either the complete old file or the complete
+    ///    new one, never a partial one.
     /// 4. `fsync` the containing directory so the rename itself survives a
     ///    power loss (a renamed file whose directory entry was never flushed
     ///    can revert after a crash).

--- a/crates/sparrowdb-storage/src/vector_index.rs
+++ b/crates/sparrowdb-storage/src/vector_index.rs
@@ -58,6 +58,16 @@ const HNSW_CRC_OFFSET: usize = 32;
 /// it; see [`VectorIndex::is_lost_update`].
 const LOST_UPDATE_PREFIX: &str = "HNSW index generation conflict";
 
+/// Suffix shared by every staging file written by [`VectorIndex::save`].
+///
+/// The full name is `<index>.tmp.<pid>.<nonce>`; this constant is the fixed
+/// part, and is also the name a pre-#452 build used on its own (with nothing
+/// after it), which is why [`VectorIndex::sweep_staging_files`] matches both.
+const TEMP_SUFFIX: &str = ".tmp";
+
+/// Suffix of the advisory-lock file that serialises writers of one index file.
+const LOCK_SUFFIX: &str = ".lock";
+
 /// On-disk generation counter, held out of the serialised payload.
 ///
 /// Wrapped in a newtype so `VectorIndex` can keep deriving `Clone` (an
@@ -79,6 +89,83 @@ impl Generation {
 impl Clone for Generation {
     fn clone(&self) -> Self {
         Generation(std::sync::atomic::AtomicU64::new(self.get()))
+    }
+}
+
+/// An exclusive advisory lock over one index file, held for the whole of
+/// [`VectorIndex::save`].
+///
+/// # Why a lock and not a tighter check
+///
+/// `save()` reads the on-disk generation, serialises, writes a staging file and
+/// renames it.  Without exclusion, two writers that both read generation `N`
+/// both pass the check, both write, and the second rename silently discards the
+/// first writer's vectors — issue #441's failure mode, narrowed to the width of
+/// the serialise-and-write window rather than eliminated.  Re-reading the
+/// generation just before the rename shrinks that window again but never closes
+/// it: there is no way to make "check, then rename" a single atomic step in the
+/// filesystem API.  Only mutual exclusion across the whole read-modify-write
+/// removes it, and then the generation check becomes what it should have been
+/// all along — the mechanism that *reports* the conflict to the loser.
+///
+/// # Why `flock` and not an `O_EXCL` lock file
+///
+/// An `O_EXCL` lock file has to answer "what if the holder died?", and every
+/// answer is a heuristic: a pid liveness probe races with pid reuse, an age
+/// threshold either wedges the index after a crash or breaks the lock out from
+/// under a slow-but-live writer, and a broken lock is exactly the data loss the
+/// lock exists to prevent.  A `flock`-style advisory lock is released by the
+/// kernel when the file descriptor closes — including when the process is
+/// `SIGKILL`ed — so a crashed writer leaves nothing to reclaim.
+///
+/// [`std::fs::File::lock`] is `flock(2)` on Unix and `LockFileEx` on Windows.
+/// On Unix the lock belongs to the *open file description*, so two threads of
+/// one process that each open the lock file exclude each other just as two
+/// processes do; a process-wide `Mutex` would not cover the cross-process case
+/// and a `flock` alone covers both.
+///
+/// The lock file is created next to the index and is never unlinked by `save()`
+/// — unlinking a lock file is how two holders end up inside the same critical
+/// section, because the next writer creates a *new* inode and locks that.
+struct SaveLock(std::fs::File);
+
+impl SaveLock {
+    /// Block until this process owns the write lock for `index_path`.
+    ///
+    /// Blocking (rather than `try_lock`) is deliberate: a caller that is merely
+    /// second in line should be made to wait and then get a truthful answer
+    /// from the generation check, not a spurious "busy" error it would have to
+    /// interpret.  Saves are short — one serialise and one `fsync`.
+    fn acquire(index_path: &Path) -> std::io::Result<Self> {
+        let path = VectorIndex::lock_path(index_path);
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .map_err(|e| {
+                std::io::Error::new(
+                    e.kind(),
+                    format!("cannot open HNSW save lock {}: {e}", path.display()),
+                )
+            })?;
+        file.lock().map_err(|e| {
+            std::io::Error::new(
+                e.kind(),
+                format!("cannot acquire HNSW save lock {}: {e}", path.display()),
+            )
+        })?;
+        Ok(SaveLock(file))
+    }
+}
+
+impl Drop for SaveLock {
+    fn drop(&mut self) {
+        // Closing the descriptor releases the lock on its own; unlocking first
+        // keeps the release explicit and independent of when the `File` is
+        // actually dropped.
+        let _ = self.0.unlock();
     }
 }
 
@@ -275,9 +362,9 @@ impl VectorIndex {
     /// # Crash-safety protocol
     ///
     /// 1. Serialise into memory and compute the CRC32C of the payload.
-    /// 2. Write `header || payload` to `<path>.tmp` and `fsync` it, so the
-    ///    bytes are on stable storage before anything else changes.
-    /// 3. `rename(<path>.tmp, <path>)` — atomic within a filesystem, so a
+    /// 2. Write `header || payload` to `<path>.tmp.<pid>.<nonce>` and `fsync`
+    ///    it, so the bytes are on stable storage before anything else changes.
+    /// 3. `rename(<staging>, <path>)` — atomic within a filesystem, so a
     ///    reader ever sees either the complete old file or the complete new
     ///    one, never a partial one.
     /// 4. `fsync` the containing directory so the rename itself survives a
@@ -285,7 +372,25 @@ impl VectorIndex {
     ///    can revert after a crash).
     ///
     /// If any step fails, `<path>` still holds the previous index and the
-    /// partial temp file is removed.
+    /// partial staging file is removed.
+    ///
+    /// The staging name carries a pid and a per-process nonce.  A fixed
+    /// `<path>.tmp` — what this function used between #442 and #452 — is a
+    /// shared mutable file: two writers both `File::create` it, the first to
+    /// rename vacates it, and the loser's rename fails with `ENOENT` and drops
+    /// its vectors on the floor.  Worse, `ENOENT` is indistinguishable from a
+    /// real disk fault, so a caller following the lost-update contract below
+    /// would not retry.  See issue #452.
+    ///
+    /// # Exclusion
+    ///
+    /// The whole read-generation → serialise → write → rename sequence runs
+    /// under an exclusive advisory lock on `<path>.lock` (see `SaveLock`).
+    /// Without it the generation check is a time-of-check/time-of-use race:
+    /// two writers that both read generation `N` both pass it.  With it, the
+    /// second writer blocks, then observes generation `N + 1` and is refused —
+    /// so a concurrent conflict surfaces as the *same* lost-update error a
+    /// sequential one does, and [`Self::is_lost_update`] recognises both.
     ///
     /// # Lost-update refusal
     ///
@@ -309,7 +414,11 @@ impl VectorIndex {
     pub fn save(&self, dir: &Path, label: &str, prop: &str) -> std::io::Result<()> {
         std::fs::create_dir_all(dir)?;
         let path = Self::index_path(dir, label, prop);
-        let tmp = Self::temp_path(&path);
+
+        // Held until this function returns.  Everything below — the generation
+        // read, the staging write and the rename — is one critical section; see
+        // `SaveLock` for why nothing narrower is sufficient.
+        let _lock = SaveLock::acquire(&path)?;
 
         // ── Lost-update check ────────────────────────────────────────────────
         let expected = self.disk_generation.get();
@@ -341,6 +450,12 @@ impl VectorIndex {
         let crc = crc32c::crc32c_append(crate::crc32_of(&header), &payload);
         header.extend_from_slice(&crc.to_le_bytes());
         debug_assert_eq!(header.len(), HNSW_HEADER_LEN);
+
+        // Debris from a save that was killed between `File::create` and
+        // `rename`.  Safe to delete unconditionally: the lock is held, so no
+        // other writer can own a staging file for this index right now.
+        Self::sweep_staging_files(dir, &path);
+        let tmp = Self::temp_path(&path);
 
         // Write + fsync the temp file, then rename.  Any failure removes the
         // temp file and leaves the previous index untouched.
@@ -378,6 +493,16 @@ impl VectorIndex {
 
     /// `true` when `err` is a lost-update refusal from [`Self::save`] rather
     /// than an ordinary I/O failure.
+    ///
+    /// This is the whole recovery contract: `true` means *reload the index and
+    /// retry*, `false` means the storage itself is unhappy and retrying will
+    /// not help.  It must therefore cover **every** way `save()` can refuse
+    /// because someone else got there first — including the concurrent case.
+    /// Between #442 and #452 it did not: two overlapping saves collided on a
+    /// shared staging path and the loser got `ENOENT`, which this returns
+    /// `false` for, so a correct caller read data loss as a disk fault and did
+    /// not retry.  `save()` now serialises writers, so a concurrent conflict
+    /// produces the same generation-conflict error a sequential one does.
     pub fn is_lost_update(err: &std::io::Error) -> bool {
         err.to_string().starts_with(LOST_UPDATE_PREFIX)
     }
@@ -612,10 +737,17 @@ impl VectorIndex {
         }
     }
 
-    /// Delete the persisted index file (and any leftover temp file), if any.
+    /// Delete the persisted index file, its staging files and its lock file.
+    ///
+    /// This is a teardown: it unlinks the lock file, so it must not run
+    /// concurrently with a `save()` of the same index (a new lock file would be
+    /// a different inode, and two writers could then both hold "the" lock).
+    /// Dropping an index while something is still writing to it is undefined
+    /// regardless.
     pub fn remove(dir: &Path, label: &str, prop: &str) {
         let path = Self::index_path(dir, label, prop);
-        let _ = std::fs::remove_file(Self::temp_path(&path));
+        Self::sweep_staging_files(dir, &path);
+        let _ = std::fs::remove_file(Self::lock_path(&path));
         let _ = std::fs::remove_file(path);
     }
 
@@ -663,13 +795,68 @@ impl VectorIndex {
         dir.join(format!("hnsw_{safe_label}_{safe_prop}.bin"))
     }
 
-    /// Staging path used by `save()`.  Appending (rather than replacing) the
-    /// extension keeps the temp file next to the real one so `rename` stays
-    /// within the same filesystem, where it is atomic.
+    /// Staging path used by `save()`: `<path>.tmp.<pid>.<nonce>`.
+    ///
+    /// Appending (rather than replacing) the extension keeps the staging file
+    /// next to the real one so `rename` stays within the same filesystem, where
+    /// it is atomic.
+    ///
+    /// The pid and nonce make the name unique to one in-flight save.  `save()`
+    /// already holds an exclusive lock, so under normal operation no two writers
+    /// are staging at once; uniqueness is what keeps the failure *contained*
+    /// when that assumption does not hold — an older build that predates the
+    /// lock, or a filesystem whose advisory locks are a no-op.  In those cases
+    /// the writers still collide on the destination, but each one's bytes reach
+    /// `rename` intact instead of one of them being deleted out from under the
+    /// other and reported as `ENOENT`.  See issue #452.
     fn temp_path(path: &Path) -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static NONCE: AtomicU64 = AtomicU64::new(0);
+        let nonce = NONCE.fetch_add(1, Ordering::Relaxed);
         let mut s = path.to_path_buf().into_os_string();
-        s.push(".tmp");
+        s.push(format!("{TEMP_SUFFIX}.{}.{nonce}", std::process::id()));
         PathBuf::from(s)
+    }
+
+    /// Path of the advisory lock that serialises writers of `path`.
+    fn lock_path(path: &Path) -> PathBuf {
+        let mut s = path.to_path_buf().into_os_string();
+        s.push(LOCK_SUFFIX);
+        PathBuf::from(s)
+    }
+
+    /// Delete every staging file belonging to `index_path`.
+    ///
+    /// Per-pid staging names mean there is no single name to look for, so this
+    /// matches the whole family: the pre-#452 fixed `<index>.tmp` as well as
+    /// `<index>.tmp.<pid>.<nonce>`.  A crashed process leaves its staging file
+    /// behind for good — nothing else ever removes it — and on a large index
+    /// each one is megabytes.
+    ///
+    /// Callers must hold the save lock (or be tearing the index down), because
+    /// a staging file that belongs to a *live* save is exactly the file whose
+    /// deletion causes the `ENOENT` data loss this sweep is cleaning up after.
+    fn sweep_staging_files(dir: &Path, index_path: &Path) {
+        let Some(index_name) = index_path.file_name().and_then(|n| n.to_str()) else {
+            return;
+        };
+        let prefix = format!("{index_name}{TEMP_SUFFIX}");
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else { continue };
+            // `""` is the legacy fixed name; `".<pid>.<nonce>"` is the current
+            // one.  Anything else that merely starts with the same characters
+            // (say `hnsw_L_p.bin.tmpfoo`) is left alone.
+            match name.strip_prefix(&prefix) {
+                Some(rest) if rest.is_empty() || rest.starts_with('.') => {
+                    let _ = std::fs::remove_file(entry.path());
+                }
+                _ => {}
+            }
+        }
     }
 
     // ── Internal helpers ──────────────────────────────────────────────────────

--- a/crates/sparrowdb/tests/regression_452.rs
+++ b/crates/sparrowdb/tests/regression_452.rs
@@ -244,8 +244,18 @@ fn await_flag(flag: &Path, who: &str) {
 #[test]
 #[ignore = "worker process for two_processes_saving_at_once_leave_one_winner"]
 fn child_writer() {
+    // Return rather than panic: `cargo test -- --ignored` is a standard way to
+    // sweep ignored tests, and in that run the parent never sets CHILD_DIR_ENV.
+    // Panicking there fails the job even though nothing is wrong.  The guard's
+    // purpose — do nothing useful when invoked directly — is preserved, and
+    // `two_processes_saving_at_once_leave_one_winner` still fails loudly if the
+    // child never writes its ready flag.
     let Ok(scratch) = std::env::var(CHILD_DIR_ENV) else {
-        panic!("child_writer is the worker half of a multi-process test and is not run directly");
+        eprintln!(
+            "child_writer is the worker half of \
+             two_processes_saving_at_once_leave_one_winner and does nothing when run directly"
+        );
+        return;
     };
     let base: u64 = std::env::var(CHILD_BASE_ENV)
         .expect("base id")

--- a/crates/sparrowdb/tests/regression_452.rs
+++ b/crates/sparrowdb/tests/regression_452.rs
@@ -1,0 +1,517 @@
+//! Regression guards for issue #452 — concurrent `VectorIndex::save`.
+//!
+//! #442 made `save()` crash-safe by staging into a temp file and renaming it,
+//! and added a generation counter so a stale handle cannot silently replace a
+//! newer index.  Both mechanisms were verified only *sequentially*: the guard
+//! test `concurrent_handles_cannot_silently_overwrite_each_other` lets `a.save()`
+//! return before `b.save()` begins, so no two writers are ever inside `save()`
+//! at the same time and neither defect below can occur in it.
+//!
+//! Two defects live in that overlap.
+//!
+//! 1. The staging path was a deterministic `<index>.tmp`.  Two writers both
+//!    `File::create` it; the first to `rename` vacates it; the loser's `rename`
+//!    fails with `ENOENT` and its vectors are gone.  `is_lost_update()` matches
+//!    on the generation-conflict message, so `ENOENT` reads as a disk fault and
+//!    a caller following the documented recovery contract does not retry.
+//!
+//! 2. `save()` read the on-disk generation, then serialised, then wrote and
+//!    renamed, with nothing held across that window.  Two writers that both
+//!    read generation `N` both pass the check, both return `Ok`, and the second
+//!    silently discards the first's vectors — issue #441's failure mode again,
+//!    narrowed to milliseconds rather than removed.
+//!
+//! Every expected value below is derived by hand from the fixture the test
+//! itself builds.  Nothing here records what the code happens to return.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Barrier};
+
+use sparrowdb_storage::vector_index::{Metric, VectorIndex};
+
+/// Vector width used throughout.  Eight dimensions is wide enough that the
+/// serialised payload is a few kilobytes — the write and `fsync` a racing pair
+/// must overlap in — and narrow enough to stay fast.
+const DIMS: usize = 8;
+
+/// Deterministic unit vector: all zeros except dimension `hot % DIMS`, which is
+/// 1.0.  Only used to give each node id *some* distinct content; the assertions
+/// below are about which ids are on disk, not about distances.
+fn unit(hot: usize) -> Vec<f32> {
+    let mut v = vec![0.0f32; DIMS];
+    v[hot % DIMS] = 1.0;
+    v
+}
+
+/// Path of the on-disk index file, mirroring the private `index_path`.
+fn index_file(dir: &Path, label: &str, prop: &str) -> PathBuf {
+    dir.join(format!("hnsw_{label}_{prop}.bin"))
+}
+
+/// Every staging-file sibling of the index currently on disk.
+fn staging_debris(dir: &Path, label: &str, prop: &str) -> Vec<PathBuf> {
+    let prefix = format!("hnsw_{label}_{prop}.bin.tmp");
+    std::fs::read_dir(dir)
+        .expect("read_dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|n| n.starts_with(&prefix))
+        })
+        .map(|e| e.path())
+        .collect()
+}
+
+// ── Defect 1 + 2: two writers genuinely inside save() at the same time ───────
+
+/// Number of barrier-synchronised rounds.
+///
+/// The reporter reproduced the `ENOENT` collision in 27 of 27 barrier-
+/// synchronised runs, so a single round already fails against the pre-fix code
+/// with high probability.  Forty rounds is chosen so the test would still fail
+/// pre-fix even if the per-round collision probability on some other machine
+/// were as low as 10%: 1 − 0.9^40 ≈ 0.985.  It costs well under a second.
+const ROUNDS: usize = 40;
+
+/// Two handles loaded from the same generation, both saving at once.
+///
+/// Hand-derivation, per round:
+///
+/// * the seed index is built from node ids `0..64`, one `insert` each, all
+///   distinct → the file holds **64** vectors at generation 1;
+/// * handle A and handle B both `load()` that file, so both hold 64 vectors and
+///   both believe they are at generation 1;
+/// * A inserts ids 100, 101, 102 → A holds 64 + 3 = **67**;
+/// * B inserts ids 200, 201, 202 → B holds 64 + 3 = **67**;
+/// * both call `save()` from separate threads released by one `Barrier(2)`.
+///
+/// Exactly one of the two can be allowed to land, because each carries a whole
+/// index image and neither contains the other's ids.  Therefore:
+///
+/// * exactly **one** `save()` returns `Ok`;
+/// * the other returns `Err`, and that error must satisfy `is_lost_update()` —
+///   "you lost, reload and retry" — not an `ENOENT` a caller must read as a
+///   broken disk;
+/// * reloading the file from disk must yield exactly **67** vectors: the 64
+///   seeds plus the winner's 3.  Not 70 (the two writes cannot both be there,
+///   they are whole-file replacements), not 64 (the winner's write must have
+///   landed), and not an error;
+/// * the winner's three ids are present and the loser's three are absent —
+///   `len()` alone cannot tell 64 + A from 64 + B apart.
+#[test]
+fn overlapping_saves_leave_one_winner_and_a_retryable_loser() {
+    for round in 0..ROUNDS {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().to_path_buf();
+
+        let mut seed = VectorIndex::new(DIMS, Metric::Cosine);
+        for i in 0u64..64 {
+            seed.insert(i, &unit(i as usize));
+        }
+        assert_eq!(
+            seed.len(),
+            64,
+            "round {round}: 64 distinct ids were inserted"
+        );
+        seed.save(&path, "L", "p").expect("seed save");
+
+        let mut a = VectorIndex::load(&path, "L", "p")
+            .expect("load a")
+            .expect("seed file exists");
+        let mut b = VectorIndex::load(&path, "L", "p")
+            .expect("load b")
+            .expect("seed file exists");
+        for i in 0u64..3 {
+            a.insert(100 + i, &unit(i as usize));
+            b.insert(200 + i, &unit(i as usize));
+        }
+        assert_eq!(a.len(), 67, "round {round}: 64 seeds + A's 3 new ids");
+        assert_eq!(b.len(), 67, "round {round}: 64 seeds + B's 3 new ids");
+
+        let barrier = Arc::new(Barrier::new(2));
+        let handles: Vec<_> = [a, b]
+            .into_iter()
+            .map(|idx| {
+                let barrier = Arc::clone(&barrier);
+                let path = path.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    idx.save(&path, "L", "p")
+                })
+            })
+            .collect();
+        let results: Vec<std::io::Result<()>> = handles
+            .into_iter()
+            .map(|h| h.join().expect("save thread must not panic"))
+            .collect();
+
+        let winners = results.iter().filter(|r| r.is_ok()).count();
+        assert_eq!(
+            winners, 1,
+            "round {round}: exactly one of two overlapping saves may land, got {winners} \
+             (results: {results:?})"
+        );
+
+        let loser = results
+            .iter()
+            .find_map(|r| r.as_ref().err())
+            .expect("one save must have been refused");
+        assert!(
+            VectorIndex::is_lost_update(loser),
+            "round {round}: the fenced-out writer must get a lost-update refusal it can act on \
+             by reloading and retrying, got: {loser} (kind {:?})",
+            loser.kind()
+        );
+
+        let on_disk = VectorIndex::load(&path, "L", "p")
+            .expect("the winner's index must still load")
+            .expect("index file must exist");
+        assert_eq!(
+            on_disk.len(),
+            67,
+            "round {round}: 64 seeded ids plus the winning writer's 3 = 67"
+        );
+
+        // A won iff the first result is Ok — the threads were spawned in [a, b]
+        // order and `results` preserves it.
+        let (present, absent): ([u64; 3], [u64; 3]) = if results[0].is_ok() {
+            ([100, 101, 102], [200, 201, 202])
+        } else {
+            ([200, 201, 202], [100, 101, 102])
+        };
+        for id in present {
+            assert!(
+                on_disk.has_vector(id),
+                "round {round}: id {id} belongs to the writer whose save returned Ok and must be \
+                 on disk"
+            );
+        }
+        for id in absent {
+            assert!(
+                !on_disk.has_vector(id),
+                "round {round}: id {id} belongs to the writer whose save was refused; a refused \
+                 save must not have written anything"
+            );
+        }
+
+        assert!(
+            staging_debris(&path, "L", "p").is_empty(),
+            "round {round}: staging files outlived the saves: {:?}",
+            staging_debris(&path, "L", "p")
+        );
+    }
+}
+
+// ── The same race across two real processes ──────────────────────────────────
+
+/// Set on a child process to turn `child_writer` into a worker.  Its value is
+/// the scratch directory; `CHILD_BASE_ENV` carries the first node id the child
+/// should write.
+const CHILD_DIR_ENV: &str = "SPARROWDB_452_CHILD_DIR";
+const CHILD_BASE_ENV: &str = "SPARROWDB_452_CHILD_BASE";
+
+/// Exit codes the child uses to report what `save()` did.  Anything else is a
+/// panic or an unexpected `io::Error`, which the parent reports verbatim.
+const EXIT_SAVED: i32 = 10;
+const EXIT_LOST_UPDATE: i32 = 11;
+const EXIT_OTHER_ERROR: i32 = 12;
+
+/// Deadline for the cross-process rendezvous.  Generous — it only has to cover
+/// process startup on a loaded CI box, and a miss fails the test rather than
+/// hanging it.
+const RENDEZVOUS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Spin until `flag` appears, or fail.
+fn await_flag(flag: &Path, who: &str) {
+    let deadline = std::time::Instant::now() + RENDEZVOUS_TIMEOUT;
+    while !flag.exists() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "{who}: {} never appeared within {RENDEZVOUS_TIMEOUT:?}",
+            flag.display()
+        );
+        std::thread::yield_now();
+    }
+}
+
+/// Worker half of `two_processes_saving_at_once_leave_one_winner`.
+///
+/// Inert unless `CHILD_DIR_ENV` is set, and `#[ignore]`d so an ordinary
+/// `cargo test` run never invokes it; the parent re-executes this same test
+/// binary with `--ignored --exact` to reach it.
+#[test]
+#[ignore = "worker process for two_processes_saving_at_once_leave_one_winner"]
+fn child_writer() {
+    let Ok(scratch) = std::env::var(CHILD_DIR_ENV) else {
+        panic!("child_writer is the worker half of a multi-process test and is not run directly");
+    };
+    let base: u64 = std::env::var(CHILD_BASE_ENV)
+        .expect("base id")
+        .parse()
+        .expect("base id is a number");
+    let scratch = PathBuf::from(scratch);
+    let idx_dir = scratch.join("idx");
+    let rdv = scratch.join("rdv");
+
+    let mut idx = VectorIndex::load(&idx_dir, "L", "p")
+        .expect("child load")
+        .expect("seed index must exist");
+    for i in 0..3 {
+        idx.insert(base + i, &unit((base + i) as usize));
+    }
+
+    // Announce readiness, then spin on the start flag so both children leave
+    // the gate within microseconds of each other.
+    std::fs::write(rdv.join(format!("ready_{base}")), b"1").expect("write ready flag");
+    await_flag(&rdv.join("go"), "child");
+
+    let code = match idx.save(&idx_dir, "L", "p") {
+        Ok(()) => EXIT_SAVED,
+        Err(e) if VectorIndex::is_lost_update(&e) => EXIT_LOST_UPDATE,
+        Err(e) => {
+            eprintln!(
+                "child {base}: unexpected save error: {e} (kind {:?})",
+                e.kind()
+            );
+            EXIT_OTHER_ERROR
+        }
+    };
+    std::process::exit(code);
+}
+
+/// The production shape of this bug is two *processes* — a long-lived daemon
+/// and a backfill script — not two threads.  Threads and processes exercise the
+/// staging-path collision identically, but only separate processes show that
+/// the exclusion mechanism is genuinely inter-process rather than a
+/// process-local mutex that happens to pass a threaded test.
+///
+/// Hand-derivation, identical to the threaded case:
+///
+/// * the seed index holds node ids `0..64` → **64** vectors at generation 1;
+/// * child A loads it and adds ids 100, 101, 102; child B adds 200, 201, 202;
+///   each child therefore holds 64 + 3 = **67**;
+/// * both block on a file flag the parent creates only after both report ready,
+///   then call `save()`;
+/// * exactly one child must exit `EXIT_SAVED` and the other `EXIT_LOST_UPDATE`
+///   — never `EXIT_OTHER_ERROR`, which is what an `ENOENT` staging collision
+///   produces;
+/// * the file must then hold exactly **67** vectors, with the winner's three
+///   ids present and the loser's three absent.
+#[test]
+fn two_processes_saving_at_once_leave_one_winner() {
+    let scratch = tempfile::tempdir().expect("tempdir");
+    let idx_dir = scratch.path().join("idx");
+    let rdv = scratch.path().join("rdv");
+    std::fs::create_dir_all(&idx_dir).expect("mkdir idx");
+    std::fs::create_dir_all(&rdv).expect("mkdir rdv");
+
+    let mut seed = VectorIndex::new(DIMS, Metric::Cosine);
+    for i in 0u64..64 {
+        seed.insert(i, &unit(i as usize));
+    }
+    assert_eq!(seed.len(), 64, "64 distinct ids were inserted");
+    seed.save(&idx_dir, "L", "p").expect("seed save");
+
+    let exe = std::env::current_exe().expect("current_exe");
+    let bases = [100u64, 200];
+    let children: Vec<std::process::Child> = bases
+        .iter()
+        .map(|base| {
+            std::process::Command::new(&exe)
+                .args(["child_writer", "--exact", "--ignored", "--nocapture"])
+                .env(CHILD_DIR_ENV, scratch.path())
+                .env(CHILD_BASE_ENV, base.to_string())
+                .spawn()
+                .expect("spawn child writer")
+        })
+        .collect();
+
+    for base in bases {
+        await_flag(&rdv.join(format!("ready_{base}")), "parent");
+    }
+    std::fs::write(rdv.join("go"), b"1").expect("write go flag");
+
+    let codes: Vec<i32> = children
+        .into_iter()
+        .map(|mut c| {
+            c.wait()
+                .expect("child must exit")
+                .code()
+                .expect("child must not be killed by a signal")
+        })
+        .collect();
+
+    assert_eq!(
+        codes.iter().filter(|&&c| c == EXIT_OTHER_ERROR).count(),
+        0,
+        "a save was refused with an error the lost-update contract cannot act on \
+         (see the child's stderr above); exit codes: {codes:?}"
+    );
+    assert_eq!(
+        codes.iter().filter(|&&c| c == EXIT_SAVED).count(),
+        1,
+        "exactly one of two overlapping processes may land its save; exit codes: {codes:?} \
+         ({EXIT_SAVED} = saved, {EXIT_LOST_UPDATE} = refused, {EXIT_OTHER_ERROR} = other error)"
+    );
+    assert_eq!(
+        codes.iter().filter(|&&c| c == EXIT_LOST_UPDATE).count(),
+        1,
+        "the process that lost must be told it lost; exit codes: {codes:?}"
+    );
+
+    let on_disk = VectorIndex::load(&idx_dir, "L", "p")
+        .expect("the winner's index must still load")
+        .expect("index file must exist");
+    assert_eq!(
+        on_disk.len(),
+        67,
+        "64 seeded ids plus the winning process's 3 = 67"
+    );
+    let (present, absent): ([u64; 3], [u64; 3]) = if codes[0] == EXIT_SAVED {
+        ([100, 101, 102], [200, 201, 202])
+    } else {
+        ([200, 201, 202], [100, 101, 102])
+    };
+    for id in present {
+        assert!(
+            on_disk.has_vector(id),
+            "the winner's id {id} must be on disk"
+        );
+    }
+    for id in absent {
+        assert!(
+            !on_disk.has_vector(id),
+            "id {id} belongs to the refused process and must not be on disk"
+        );
+    }
+    assert!(
+        staging_debris(&idx_dir, "L", "p").is_empty(),
+        "staging files outlived the processes: {:?}",
+        staging_debris(&idx_dir, "L", "p")
+    );
+}
+
+// ── Defect 2: the documented recovery contract must actually converge ────────
+
+/// Number of concurrent writers in the retry test.
+const WRITERS: u64 = 3;
+/// Vectors each writer adds, one `save()` per vector.
+const PER_WRITER: u64 = 10;
+/// Cap on retries for a single vector, so a livelock fails the test instead of
+/// hanging CI.  Far above anything three writers should need: each accepted
+/// save advances the generation exactly once, so a writer can only be forced to
+/// retry once per *other* writer's success, i.e. at most
+/// `(WRITERS - 1) * PER_WRITER = 20` times in the worst interleaving.
+const MAX_ATTEMPTS: usize = 200;
+
+/// Three writers each add ten vectors, one `save()` per vector, following the
+/// contract `is_lost_update()` documents: on refusal, reload from disk and
+/// retry.  Nothing may be lost.
+///
+/// This is the shape of the backfill in the incident behind #441 — every
+/// `insert` is followed by a `save`, so a thousand-vector backfill opens the
+/// read-modify-write window a thousand times.
+///
+/// Hand-derivation:
+///
+/// * the seed index holds one vector, node id 90000 → **1** vector on disk;
+/// * writer `t` (t = 0, 1, 2) writes ids `1000·t + 0 … 1000·t + 9`, i.e.
+///   0…9, 1000…1009 and 2000…2009 — thirty ids, all distinct from one another
+///   and from 90000, by construction;
+/// * every `save()` either lands or is refused; a refusal reloads the current
+///   file, re-applies that writer's one `insert`, and saves again, so no
+///   accepted image can be missing an earlier accepted id;
+/// * therefore the file must end with exactly 1 + 3 × 10 = **31** vectors, and
+///   every one of the thirty-one ids must be individually present.
+///
+/// Against the pre-fix code both failure modes show up here: a colliding
+/// staging path surfaces as an `ENOENT` the retry loop refuses to swallow, and
+/// a lost update surfaces as a final count below 31.
+#[test]
+fn concurrent_writers_that_retry_on_refusal_lose_no_vectors() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().to_path_buf();
+
+    let mut seed = VectorIndex::new(DIMS, Metric::Cosine);
+    seed.insert(90000, &unit(0));
+    seed.save(&path, "L", "p").expect("seed save");
+
+    let barrier = Arc::new(Barrier::new(WRITERS as usize));
+    let handles: Vec<_> = (0..WRITERS)
+        .map(|t| {
+            let barrier = Arc::clone(&barrier);
+            let path = path.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                for k in 0..PER_WRITER {
+                    let id = 1000 * t + k;
+                    let mut attempts = 0usize;
+                    loop {
+                        attempts += 1;
+                        assert!(
+                            attempts <= MAX_ATTEMPTS,
+                            "writer {t} could not place id {id} in {MAX_ATTEMPTS} attempts"
+                        );
+                        let mut idx = VectorIndex::load(&path, "L", "p")
+                            .expect("reload must succeed")
+                            .expect("the index file must exist");
+                        idx.insert(id, &unit(id as usize));
+                        match idx.save(&path, "L", "p") {
+                            Ok(()) => break,
+                            Err(e) if VectorIndex::is_lost_update(&e) => continue,
+                            Err(e) => panic!(
+                                "writer {t}, id {id}: save failed with something the documented \
+                                 recovery contract cannot act on — a caller sees this as a broken \
+                                 disk and stops retrying, losing the vector: {e} (kind {:?})",
+                                e.kind()
+                            ),
+                        }
+                    }
+                }
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().expect("writer thread must not panic");
+    }
+
+    let on_disk = VectorIndex::load(&path, "L", "p")
+        .expect("the final index must load")
+        .expect("index file must exist");
+    assert_eq!(
+        on_disk.len(),
+        31,
+        "1 seeded vector + 3 writers × 10 vectors = 31; a smaller number means an accepted save \
+         discarded another writer's work"
+    );
+
+    let expected: BTreeSet<u64> = std::iter::once(90000)
+        .chain((0..WRITERS).flat_map(|t| (0..PER_WRITER).map(move |k| 1000 * t + k)))
+        .collect();
+    assert_eq!(
+        expected.len(),
+        31,
+        "the fixture must define 31 distinct ids"
+    );
+    let missing: Vec<u64> = expected
+        .iter()
+        .copied()
+        .filter(|&id| !on_disk.has_vector(id))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "these ids were written and acknowledged but are not on disk: {missing:?}"
+    );
+
+    assert!(
+        staging_debris(&path, "L", "p").is_empty(),
+        "staging files outlived the writers: {:?}",
+        staging_debris(&path, "L", "p")
+    );
+    assert!(
+        index_file(&path, "L", "p").exists(),
+        "the index file itself must exist at the end"
+    );
+}

--- a/crates/sparrowdb/tests/vector_index_durability.rs
+++ b/crates/sparrowdb/tests/vector_index_durability.rs
@@ -199,18 +199,28 @@ fn truncated_index_file_never_loads_as_fewer_vectors() {
 /// replacement exists.
 ///
 /// The failure is injected deterministically — no timing, no signals, no
-/// flakiness — by creating a *directory* at the staging path `<file>.bin.tmp`.
-/// `File::create` on a directory fails with `EISDIR` on every Unix, so the save
-/// aborts at exactly the point a crash would: after serialisation, before the
-/// destination is touched.
+/// flakiness — by removing write permission from the directory that holds the
+/// index.  Creating a *new* file in a directory requires write permission on
+/// the directory, so `File::create(<staging path>)` fails with `EACCES`, while
+/// re-opening files that already exist (the index itself, the save lock) still
+/// succeeds.  The save therefore aborts at exactly the point a crash would:
+/// after serialisation, before the destination is touched.
+///
+/// This used to be injected by creating a directory at the fixed staging path
+/// `<file>.bin.tmp`.  Since #452 the staging name carries a pid and a nonce, so
+/// no single path can be blocked ahead of time; permissions are the remaining
+/// deterministic lever.
 ///
 /// Hand-derived expectations:
 /// * before: 10 vectors on disk (ids 0..10, one `insert` each);
 /// * the aborted save carries 30 vectors (ids 0..30);
 /// * after: `save()` returns `Err`, and `load()` returns **10**, not 30 and not
 ///   an error — the old index is untouched.
+#[cfg(unix)]
 #[test]
 fn failed_save_leaves_the_previous_index_intact() {
+    use std::os::unix::fs::PermissionsExt;
+
     let dir = tempfile::tempdir().expect("tempdir");
 
     let mut small = VectorIndex::new(4, Metric::Cosine);
@@ -222,11 +232,23 @@ fn failed_save_leaves_the_previous_index_intact() {
     let path = index_file(dir.path(), "L", "p");
     let good_bytes = std::fs::read(&path).expect("read good");
 
-    // Block the staging path so the next save cannot complete.
-    let mut tmp = path.clone().into_os_string();
-    tmp.push(".tmp");
-    let tmp = std::path::PathBuf::from(tmp);
-    std::fs::create_dir(&tmp).expect("occupy the staging path");
+    // Block creation of any new file in the directory.
+    let original = std::fs::metadata(dir.path()).expect("stat").permissions();
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555))
+        .expect("make the index directory read-only");
+
+    // Directory permissions do not apply to a superuser, so confirm the
+    // injection actually took before asserting on it.
+    let probe = dir.path().join(".write_probe");
+    if std::fs::File::create(&probe).is_ok() {
+        let _ = std::fs::remove_file(&probe);
+        std::fs::set_permissions(dir.path(), original).expect("restore");
+        eprintln!(
+            "skipping failed_save_leaves_the_previous_index_intact: this process can write to a \
+             read-only directory (running as root?), so the failure cannot be injected"
+        );
+        return;
+    }
 
     let mut big = VectorIndex::new(4, Metric::Cosine);
     for i in 0u64..30 {
@@ -245,7 +267,7 @@ fn failed_save_leaves_the_previous_index_intact() {
     );
 
     // Unblock and confirm the survivor is a real, loadable, 10-vector index.
-    std::fs::remove_dir(&tmp).expect("unblock");
+    std::fs::set_permissions(dir.path(), original).expect("restore permissions");
     let reloaded = VectorIndex::load(dir.path(), "L", "p")
         .expect("the surviving index must still load")
         .expect("the surviving index file must exist");
@@ -257,7 +279,22 @@ fn failed_save_leaves_the_previous_index_intact() {
 }
 
 /// A leftover staging file from a crashed save must never be mistaken for the
-/// index, and `save()` must overwrite it rather than fail.
+/// index, and `save()` must reclaim it rather than leave it to accumulate.
+///
+/// Since #452 staging names are `<index>.tmp.<pid>.<nonce>`, so a crashed
+/// process leaves behind a name no later run will ever choose again: reclaiming
+/// cannot be "overwrite the one fixed name", it has to sweep the whole family.
+/// The fixture therefore plants three shapes at once:
+///
+/// * `<index>.tmp` — the fixed name a pre-#452 build wrote, still on disk in
+///   any deployment that crashed before upgrading;
+/// * `<index>.tmp.999999.0` — a per-pid staging file from a process that is
+///   long gone (pid 999999 is not this test);
+/// * `<index>.tmp.999999.1` — a second one from the same dead process.
+///
+/// All three must be gone after one save, and the unrelated sibling
+/// `<index>.tmpfoo` — which is not a staging file, it just starts with the same
+/// characters — must survive, or the sweep is deleting things it does not own.
 #[test]
 fn leftover_staging_file_is_ignored_and_reclaimed() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -268,10 +305,21 @@ fn leftover_staging_file_is_ignored_and_reclaimed() {
     idx.save(dir.path(), "L", "p").expect("save");
 
     let path = index_file(dir.path(), "L", "p");
-    let mut tmp = path.clone().into_os_string();
-    tmp.push(".tmp");
-    let tmp = std::path::PathBuf::from(tmp);
-    std::fs::write(&tmp, b"garbage from a crashed save").expect("write leftover");
+    let sibling = |suffix: &str| {
+        let mut s = path.clone().into_os_string();
+        s.push(suffix);
+        std::path::PathBuf::from(s)
+    };
+    let leftovers = [
+        sibling(".tmp"),
+        sibling(".tmp.999999.0"),
+        sibling(".tmp.999999.1"),
+    ];
+    for p in &leftovers {
+        std::fs::write(p, b"garbage from a crashed save").expect("write leftover");
+    }
+    let bystander = sibling(".tmpfoo");
+    std::fs::write(&bystander, b"not a staging file").expect("write bystander");
 
     let loaded = VectorIndex::load(dir.path(), "L", "p")
         .expect("leftover staging file must not affect load")
@@ -280,7 +328,29 @@ fn leftover_staging_file_is_ignored_and_reclaimed() {
 
     idx.save(dir.path(), "L", "p")
         .expect("save must reclaim a stale staging file");
-    assert!(!tmp.exists(), "the staging file must not outlive a save");
+    for p in &leftovers {
+        assert!(
+            !p.exists(),
+            "{} outlived a save; per-pid staging files from crashed processes are never \
+             reused, so nothing else will ever clean them up",
+            p.display()
+        );
+    }
+    assert!(
+        bystander.exists(),
+        "the sweep removed {}, which is not a staging file",
+        bystander.display()
+    );
+
+    // And the save itself still produced a good index.
+    assert_eq!(
+        VectorIndex::load(dir.path(), "L", "p")
+            .expect("load after reclaim")
+            .expect("index must exist")
+            .len(),
+        6,
+        "6 vectors were saved; 6 must survive the reclaim"
+    );
 }
 
 // ── 3. Re-inserting an existing node id must be observable ───────────────────


### PR DESCRIPTION
Closes #452.

`VectorIndex::save()` had two defects in the overlap between writers, both
opened or left open by #442, both reported by the KMSmcp consumer from
execution rather than code reading.

## Defect 1 — deterministic staging path (a regression #442 introduced)

Before #442 there was no temp file: `save()` was a bare `fs::write`. #442 added
temp + fsync + rename for crash safety, and staged into a fixed `<index>.tmp`
with no pid and no nonce. Two writers both `File::create` that path; the first
to `rename` vacates it; the loser's `rename` fails with **ENOENT** and its
vectors are gone.

Worse, `is_lost_update()` string-matches the generation-conflict prefix, so the
ENOENT variant cannot satisfy it. A consumer following the documented recovery
contract — catch lost-update, reopen, retry — reads a data-loss event as a disk
fault and does not retry. #442's own error contract was unreachable on the path
that actually fires.

**Fix:** `<index>.tmp.<pid>.<nonce>`.

## Defect 2 — unguarded read-modify-write

`save()` read the on-disk generation, then serialised, then wrote and renamed,
with nothing held across that window. Two writers that both read generation `N`
both pass the check. Unique staging paths remove the ENOENT but leave this:
both saves return `Ok` and the second silently clobbers the first — #441's
failure mode narrowed from unbounded to milliseconds, not eliminated. Every
`insert()` on a backfill path calls `save()`, so a multi-thousand-vector
backfill opens that window thousands of times.

**Fix:** the whole read-generation → serialise → write → rename sequence runs
under an exclusive advisory lock on `<index>.lock`, via `std::fs::File::lock`
(stable since 1.89; `flock(2)` on Unix, `LockFileEx` on Windows — no new
dependency).

### Why flock, and what was rejected

| Option | Verdict |
|---|---|
| **Advisory file lock (chosen)** | The kernel releases it when the descriptor closes, including on `SIGKILL`, so a crashed writer leaves nothing to reclaim. On Unix the lock belongs to the *open file description*, so it excludes two threads of one process as well as two processes — a `Mutex` would cover only the first case. |
| `O_EXCL` lock file with stale recovery | Rejected. Every stale-lock policy is a heuristic: a pid probe races with pid reuse; an age threshold either wedges the index after a crash or breaks the lock out from under a slow-but-live writer. A broken lock *is* the data loss the lock exists to prevent. |
| Re-read the generation just before the rename | Rejected, and it is the weakest of the three: "check, then rename" cannot be made a single atomic filesystem step, so it narrows the window again without closing it. Same class of bug, smaller. |

The lock is blocking rather than `try_lock`: a caller that is merely second in
line should wait and then get a truthful answer from the generation check, not a
"busy" error it has to interpret. Saves are one serialise plus one fsync.

## Error contract

A fenced-out writer blocks on the lock, then observes generation `N+1` and gets
the ordinary `"HNSW index generation conflict: …"` error — so
`is_lost_update()` now returns `true` for the concurrent case as well as the
sequential one, and "you lost, reopen and retry" is distinguishable from "the
disk is broken" on the path that actually fires. Lock-acquisition failures are
reported as themselves (`cannot open/acquire HNSW save lock …`) and correctly
classify as I/O errors, not lost updates.

## Stale staging files

Per-pid names mean there is no single name to reclaim, so `save()` sweeps every
`<index>.tmp*` sibling — the pre-#452 fixed `<index>.tmp` included — while
holding the lock, which is precisely when no live writer can own one. An
unrelated sibling such as `<index>.tmpfoo` is left alone. `remove()` sweeps the
same family plus the lock file.

## Tests — the deliverable for a concurrency fix

The existing `concurrent_handles_cannot_silently_overwrite_each_other` is fully
sequential (`a.save()` returns before `b.save()` runs) and cannot reach either
defect. New file `crates/sparrowdb/tests/regression_452.rs`, every expectation
derived by hand in a comment:

* **`overlapping_saves_leave_one_winner_and_a_retryable_loser`** — 40
  barrier-synchronised rounds, two threads genuinely inside `save()` together.
  Seed 64 ids; A adds 100/101/102, B adds 200/201/202. Asserts exactly one
  `Ok`; the loser's error satisfies `is_lost_update()`; and the file **reloaded
  from disk** holds exactly 64 + 3 = 67 vectors with the winner's three ids
  present and the loser's three absent.
* **`two_processes_saving_at_once_leave_one_winner`** — the production shape: a
  daemon and a backfill, i.e. two real child processes rendezvousing on a file
  flag. Only separate processes show the exclusion is genuinely inter-process
  rather than a process-local mutex that happens to pass a threaded test.
* **`concurrent_writers_that_retry_on_refusal_lose_no_vectors`** — 3 threads ×
  10 vectors, one `save()` per vector, following the documented contract
  (refused → reload → retry). Asserts exactly 1 + 30 = 31 ids on disk, each
  checked individually. This is the shape of the #441 backfill.

### Pre-fix proof (measured)

With `crates/sparrowdb-storage/src/vector_index.rs` reverted to `origin/main`
and the tests unchanged, each test run 20 times in isolation:

| Test | Pre-fix | Post-fix |
|---|---|---|
| `overlapping_saves_leave_one_winner_and_a_retryable_loser` | **20/20 FAILED** | 20/20 ok |
| `two_processes_saving_at_once_leave_one_winner` | **20/20 FAILED** | 20/20 ok |
| `concurrent_writers_that_retry_on_refusal_lose_no_vectors` | **20/20 FAILED** | 20/20 ok |

Pre-fix symptom in every case, matching the report: `No such file or directory
(os error 2)` (kind `NotFound`) — the threaded tests on round 0, the
multi-process test as child exit codes `[10, 12]` (one saved, one hit an error
the lost-update contract cannot act on).

Two existing tests in `vector_index_durability.rs` are adapted to the new
naming:

* `leftover_staging_file_is_ignored_and_reclaimed` now plants the legacy fixed
  name **and** two per-pid leftovers **and** an unrelated `.tmpfoo` bystander.
  It fails against pre-fix code (the per-pid leftovers survive).
* `failed_save_leaves_the_previous_index_intact` injected its failure by
  creating a directory at the fixed staging path; no single path can be blocked
  ahead of time any more, so it now removes write permission from the index
  directory (with a probe that skips rather than false-fails if running as
  root). Same injection point: after serialisation, before the destination is
  touched.

## Verification

Target dir isolated to `/Volumes/Dev/target-452*` throughout.

* `cargo test -p sparrowdb-storage --no-fail-fast` — 167 passed, 0 failed, 1 ignored
* `cargo test -p sparrowdb --no-fail-fast` — 1057 passed, 0 failed, 12 ignored (171 binaries)
* `cargo fmt --all -- --check` — clean, re-verified in a fresh clone of the pushed branch
* `cargo clippy --workspace --exclude sparrowdb-ruby --all-targets --keep-going -- -D warnings` — clean

## Review note

#442, #446 and #447 all merged without independent review (CodeRabbit rate-limited
and skipping non-default bases, Gemini sunset, CodeAnt unsubscribed). Assume this
PR gets the same, and read it accordingly. Known limits are listed below rather
than left for someone to find:

* Advisory locks are advisory. On a filesystem where `flock` is a no-op (some
  NFS/CIFS mounts) the exclusion degrades to the pre-fix behaviour. The per-pid
  staging path still contains that case — writers collide on the destination
  rather than deleting each other's staging file — but the generation TOCTOU
  returns. Not tested; no such mount available here.
* A writer that hangs while holding the lock blocks other writers indefinitely;
  the lock is blocking with no timeout. A crashed writer does not, since the
  kernel releases on close.
* `remove()` unlinks the lock file, so a `DROP INDEX` concurrent with a `save()`
  of the same index can put two writers in the same critical section. Dropping
  an index while something writes to it is already undefined; documented on the
  function.
* Windows path (`LockFileEx`) is not exercised — CI is ubuntu + macOS only.
* The sweep does one `read_dir` per save. The directory holds a handful of index
  files, so this is negligible against an fsync, but it is a per-save cost that
  did not exist before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple processes or threads save vector indexes concurrently.
  * Prevented temporary-file conflicts and standardized conflict handling for stale writers.
  * Added cleanup for leftover temporary files and persistent lock files when indexes are removed.
  * Improved recovery from interrupted or failed saves while preserving valid index data.

* **Tests**
  * Added coverage for concurrent saves, retries, persistence outcomes, and temporary-file cleanup.
  * Expanded durability testing for failed saves and stale temporary-file recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->