### PR TITLE
feat(node): expose vectorIndexLoadFailures as a static napi binding (#446, #451)

### DIFF
--- a/crates/sparrowdb-node/src/lib.rs
+++ b/crates/sparrowdb-node/src/lib.rs
@@ -280,6 +280,43 @@ pub struct VectorIndexHealth {
     pub unreachable: u32,
 }
 
+// ── VectorIndexLoadFailure ───────────────────────────────────────────────────
+
+/// One damaged HNSW index file — see `SparrowDB.vectorIndexLoadFailures`.
+///
+/// ```typescript
+/// interface VectorIndexLoadFailure {
+///   label: string;   // node label the index was built on
+///   prop: string;    // vector property the index was built on
+///   path: string;    // exact file on disk; the machine-readable field
+///   reason: string;  // human-readable; see the caveat below
+/// }
+/// ```
+///
+/// `path` is exact and is the field to key alerts and remediation on. `reason`
+/// is a message for a human to read: for a quarantine artifact it is
+/// RECONSTRUCTED rather than recovered, because #442 reports the original
+/// decode failure only in the error it returns at quarantine time and writes no
+/// sidecar. Do not parse it and do not present it as the authoritative cause.
+///
+/// The `//` comments above are deliberate rather than nested doc comments: a
+/// close-comment marker inside a generated JSDoc block ends it early, which is
+/// part of why the checked-in `npm/sparrowdb/index.d.ts` does not currently
+/// parse as TypeScript (issue #449).
+#[napi(object)]
+pub struct VectorIndexLoadFailure {
+    /// Node label the damaged index was built on.
+    pub label: String,
+    /// Vector property the damaged index was built on.
+    pub prop: String,
+    /// Exact path of the damaged bytes on disk — live `.bin` or
+    /// `.bin.corrupt.<millis>` quarantine artifact.
+    pub path: String,
+    /// Human-readable description. Reconstructed for quarantine artifacts;
+    /// not authoritative and not machine-parseable.
+    pub reason: String,
+}
+
 // ── SparrowDB ─────────────────────────────────────────────────────────────────
 
 /// Top-level database handle.
@@ -317,6 +354,60 @@ impl SparrowDB {
     pub fn open(path: String) -> napi::Result<Self> {
         let db = ::sparrowdb::GraphDb::open(std::path::Path::new(&path)).map_err(to_napi)?;
         Ok(SparrowDB { inner: db })
+    }
+
+    /// Report every vector index at `path` whose bytes are damaged.
+    ///
+    /// **Static**, and deliberately so: the database this diagnoses is usually
+    /// one that will not open. `open` fails with a `Corruption` error when a
+    /// live index file cannot be loaded, and this is the call that answers
+    /// *which* files caused it — so requiring an instance would make it
+    /// unreachable in the exact situation it exists for.
+    ///
+    /// **Never throws.** An unreadable or absent directory yields `[]`; there
+    /// is no configuration of the filesystem that turns the diagnostic itself
+    /// into a second failure to diagnose. An empty array therefore means "no
+    /// damage found", which includes the ordinary case of a database with no
+    /// vector indexes at all.
+    ///
+    /// Two kinds of damage are reported:
+    ///
+    /// - **live but unloadable** — `hnsw_<label>_<prop>.bin` is present and
+    ///   rejected; `open` fails on these;
+    /// - **already quarantined** — `hnsw_<label>_<prop>.bin.corrupt.<millis>`,
+    ///   bytes a previous load attempt moved aside (#442).
+    ///
+    /// The second arm is why this is the only usable health signal for #451:
+    /// once a damaged file has been quarantined, the *first* `open` has already
+    /// thrown and every later `open` succeeds with the index silently absent,
+    /// so vector writes for that pair are dropped and searches return nothing.
+    /// Nothing else distinguishes that store from a healthy one.
+    ///
+    /// Not read-only when composed with #442: probing a live entry may
+    /// quarantine it. The observable result is unchanged — a file quarantined
+    /// during one call is reported as a quarantine artifact by the next.
+    ///
+    /// ```typescript
+    /// const failures = SparrowDB.vectorIndexLoadFailures('/path/to/my.db')
+    /// // [{ label: 'Memory', prop: 'embedding',
+    /// //    path: '/path/to/my.db/vector_indexes/hnsw_Memory_embedding.bin',
+    /// //    reason: 'HNSW index ... is corrupt ...' }]
+    /// if (failures.length > 0) alert(failures.map(f => f.path))
+    /// ```
+    #[napi]
+    pub fn vector_index_load_failures(path: String) -> Vec<VectorIndexLoadFailure> {
+        ::sparrowdb::GraphDb::vector_index_load_failures(std::path::Path::new(&path))
+            .into_iter()
+            .map(|(label, prop, file, reason)| VectorIndexLoadFailure {
+                label,
+                prop,
+                // `to_string_lossy` rather than a fallible conversion: a path
+                // that is not valid UTF-8 must still be reported, and this
+                // function has no error channel by design.
+                path: file.to_string_lossy().into_owned(),
+                reason,
+            })
+            .collect()
     }
 
     /// Execute a Cypher query and return `{ columns, rows }`.

--- a/npm/sparrowdb/index.d.ts
+++ b/npm/sparrowdb/index.d.ts
@@ -65,6 +65,45 @@ export interface VectorIndexHealth {
   unreachable: number
 }
 /**
+ * One damaged HNSW index file — see `SparrowDB.vectorIndexLoadFailures`.
+ *
+ * ```typescript
+ * interface VectorIndexLoadFailure {
+ *   label: string;   // node label the index was built on
+ *   prop: string;    // vector property the index was built on
+ *   path: string;    // exact file on disk; the machine-readable field
+ *   reason: string;  // human-readable; see the caveat below
+ * }
+ * ```
+ *
+ * `path` is exact and is the field to key alerts and remediation on. `reason`
+ * is a message for a human to read: for a quarantine artifact it is
+ * RECONSTRUCTED rather than recovered, because #442 reports the original
+ * decode failure only in the error it returns at quarantine time and writes no
+ * sidecar. Do not parse it and do not present it as the authoritative cause.
+ *
+ * The `//` comments above are deliberate rather than nested doc comments: a
+ * close-comment marker inside a generated JSDoc block ends it early, which is
+ * part of why the checked-in `npm/sparrowdb/index.d.ts` does not currently
+ * parse as TypeScript (issue #449).
+ */
+export interface VectorIndexLoadFailure {
+  /** Node label the damaged index was built on. */
+  label: string
+  /** Vector property the damaged index was built on. */
+  prop: string
+  /**
+   * Exact path of the damaged bytes on disk — live `.bin` or
+   * `.bin.corrupt.<millis>` quarantine artifact.
+   */
+  path: string
+  /**
+   * Human-readable description. Reconstructed for quarantine artifacts;
+   * not authoritative and not machine-parseable.
+   */
+  reason: string
+}
+/**
  * Top-level database handle.
  *
  * ```typescript
@@ -85,6 +124,47 @@ export declare class SparrowDB {
    * Throws if the path cannot be created or the database files are corrupt.
    */
   static open(path: string): SparrowDB
+  /**
+   * Report every vector index at `path` whose bytes are damaged.
+   *
+   * **Static**, and deliberately so: the database this diagnoses is usually
+   * one that will not open. `open` fails with a `Corruption` error when a
+   * live index file cannot be loaded, and this is the call that answers
+   * *which* files caused it — so requiring an instance would make it
+   * unreachable in the exact situation it exists for.
+   *
+   * **Never throws.** An unreadable or absent directory yields `[]`; there
+   * is no configuration of the filesystem that turns the diagnostic itself
+   * into a second failure to diagnose. An empty array therefore means "no
+   * damage found", which includes the ordinary case of a database with no
+   * vector indexes at all.
+   *
+   * Two kinds of damage are reported:
+   *
+   * - **live but unloadable** — `hnsw_<label>_<prop>.bin` is present and
+   *   rejected; `open` fails on these;
+   * - **already quarantined** — `hnsw_<label>_<prop>.bin.corrupt.<millis>`,
+   *   bytes a previous load attempt moved aside (#442).
+   *
+   * The second arm is why this is the only usable health signal for #451:
+   * once a damaged file has been quarantined, the *first* `open` has already
+   * thrown and every later `open` succeeds with the index silently absent,
+   * so vector writes for that pair are dropped and searches return nothing.
+   * Nothing else distinguishes that store from a healthy one.
+   *
+   * Not read-only when composed with #442: probing a live entry may
+   * quarantine it. The observable result is unchanged — a file quarantined
+   * during one call is reported as a quarantine artifact by the next.
+   *
+   * ```typescript
+   * const failures = SparrowDB.vectorIndexLoadFailures('/path/to/my.db')
+   * // [{ label: 'Memory', prop: 'embedding',
+   * //    path: '/path/to/my.db/vector_indexes/hnsw_Memory_embedding.bin',
+   * //    reason: 'HNSW index ... is corrupt ...' }]
+   * if (failures.length > 0) alert(failures.map(f => f.path))
+   * ```
+   */
+  static vectorIndexLoadFailures(path: string): Array<VectorIndexLoadFailure>
   /**
    * Execute a Cypher query and return `{ columns, rows }`.
    *

--- a/npm/sparrowdb/test/integration.test.js
+++ b/npm/sparrowdb/test/integration.test.js
@@ -35,6 +35,10 @@ function removeDir(dir) {
   fs.rmSync(dir, { recursive: true, force: true })
 }
 
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 // ── Test suites ──────────────────────────────────────────────────────────────
 
 describe('SparrowDB.open', () => {
@@ -617,6 +621,303 @@ describe('anonymous relationship patterns — issue #406 regression', () => {
     assert.equal(r.rows.length, EXPECTED_DIRECTED_EDGES)
     for (const row of r.rows) {
       assert.equal(row['r'].$type, 'edge', 'each row must carry an edge handle')
+    }
+  })
+})
+
+describe('SparrowDB.vectorIndexLoadFailures — issues #446 / #451', () => {
+  // #446 made a damaged HNSW index fail `open()` loudly instead of silently
+  // degrading to "no index configured", and added
+  // `GraphDb::vector_index_load_failures(path)` as the call an operator makes
+  // to find out WHICH files are the problem.  It had no napi binding, so the
+  // documented remediation was unreachable from JavaScript.
+  //
+  // #451 is why this is the only usable health signal: once a damaged file has
+  // been quarantined to `<name>.bin.corrupt.<millis>`, the FIRST `open()` has
+  // already thrown and every subsequent `open()` succeeds with the index
+  // silently absent.  Vector writes for that (label, prop) are dropped and
+  // every search returns nothing, and nothing else on the API surface
+  // distinguishes that store from a healthy one.
+  //
+  // ── Hand-derived fixture facts (from the on-disk format, not from output) ──
+  //
+  // File name: `VectorIndex::index_path` formats `hnsw_{label}_{prop}.bin`
+  //   under `<db_root>/vector_indexes/`.  With label `Memory` and prop
+  //   `embedding` that is
+  //   `<dbPath>/vector_indexes/hnsw_Memory_embedding.bin`.
+  //
+  // Damage: the file is truncated to 4 bytes.  A v2 file carries a 36-byte
+  //   header (8 magic + 4 version + 4 reserved + 8 payload_len + 8 generation
+  //   + 4 crc32c), so a 4-byte file is too short to be read as v2 and falls to
+  //   the legacy bincode path.  bincode encodes the struct's first field,
+  //   `nodes: Vec<HnswNode>`, as an 8-byte little-endian length prefix — 4
+  //   bytes cannot even supply that prefix, so decoding hits end-of-input.
+  //   There is no 4-byte string that decodes to a VectorIndex, so this does
+  //   not depend on which 4 bytes survive or on any field values.
+  //
+  // Count: exactly one index is created, for exactly one (label, prop), so
+  //   exactly ONE entry must be reported — 1, not 0 and not 2.  It reaches 1
+  //   by two different routes (live-unloadable before anything probes it,
+  //   quarantine artifact afterwards); asserting the count and the pair rather
+  //   than which route produced it is what makes this hold across #442.
+
+  const LABEL = 'Memory'
+  const PROP = 'embedding'
+  const DIMENSIONS = 3
+  const EXPECTED_FAILURES = 1
+  const TRUNCATE_TO_BYTES = 4
+
+  // Build a database whose one persisted vector index has been truncated to 4
+  // bytes.  Nothing has probed the damaged file yet, so it is still LIVE.
+  function makeDamagedDb() {
+    const dir = makeTempDir()
+    const dbPath = path.join(dir, 'graph.db')
+
+    const seed = SparrowDB.open(dbPath)
+    seed.createVectorIndex(LABEL, PROP, DIMENSIONS, 'cosine')
+
+    const indexFile = path.join(
+      dbPath, 'vector_indexes', `hnsw_${LABEL}_${PROP}.bin`
+    )
+    assert.ok(
+      fs.existsSync(indexFile),
+      `fixture precondition: createVectorIndex must persist ${indexFile}`
+    )
+    const size = fs.statSync(indexFile).size
+    assert.ok(
+      size > TRUNCATE_TO_BYTES,
+      `fixture precondition: a persisted index must be longer than the ` +
+      `${TRUNCATE_TO_BYTES}-byte truncation point, got ${size} bytes`
+    )
+    fs.truncateSync(indexFile, TRUNCATE_TO_BYTES)
+    assert.equal(
+      fs.statSync(indexFile).size,
+      TRUNCATE_TO_BYTES,
+      'fixture precondition: truncation must have taken effect'
+    )
+
+    return { dir, dbPath, indexFile }
+  }
+
+  function assertFailureShape(entry, indexFile) {
+    // Named fields, not tuple positions — a consumer building an alert needs
+    // to read `entry.path`, not `entry[2]`.
+    assert.deepEqual(
+      Object.keys(entry).sort(),
+      ['label', 'path', 'prop', 'reason'],
+      'entry must expose exactly { label, prop, path, reason }'
+    )
+    for (const field of ['label', 'prop', 'path', 'reason']) {
+      assert.equal(
+        typeof entry[field], 'string',
+        `${field} must be a string, got ${typeof entry[field]}`
+      )
+      assert.ok(entry[field].length > 0, `${field} must not be empty`)
+    }
+    assert.equal(entry.label, LABEL, 'must name the damaged label')
+    assert.equal(entry.prop, PROP, 'must name the damaged property')
+    // The path must belong to the index we damaged: either the live .bin or
+    // its quarantine artifact.
+    assert.ok(
+      entry.path === indexFile || entry.path.startsWith(`${indexFile}.corrupt.`),
+      `path must name the damaged index (${indexFile} or its .corrupt.* ` +
+      `artifact); got ${entry.path}`
+    )
+  }
+
+  it('is a static method on the class, not an instance method', () => {
+    // Non-negotiable: the database this diagnoses is the one that will not
+    // open, so an instance method would be unreachable exactly when it is
+    // needed.  `SparrowDB.prototype` must NOT carry it.
+    assert.equal(
+      typeof SparrowDB.vectorIndexLoadFailures, 'function',
+      'vectorIndexLoadFailures must exist as a static on SparrowDB'
+    )
+    assert.equal(
+      typeof SparrowDB.prototype.vectorIndexLoadFailures, 'undefined',
+      'vectorIndexLoadFailures must NOT be an instance method'
+    )
+  })
+
+  it('never throws: unreadable / absent / invalid paths return []', () => {
+    // The diagnostic must not itself become a failure path.  Each of these is
+    // hand-derived as "no vector_indexes/ directory can be listed", therefore
+    // "no damage found", therefore an empty array — never an exception.
+    const dir = makeTempDir()
+    try {
+      for (const p of [
+        path.join(dir, 'does-not-exist'),   // absent directory
+        dir,                                // a directory that is not a db
+        '/tmp/sparrowdb-\0-bad-path',       // invalid at the OS path layer
+        '',                                 // empty string
+      ]) {
+        let out
+        assert.doesNotThrow(
+          () => { out = SparrowDB.vectorIndexLoadFailures(p) },
+          `vectorIndexLoadFailures(${JSON.stringify(p)}) must not throw`
+        )
+        assert.ok(Array.isArray(out), 'must return an array')
+        assert.equal(
+          out.length, 0,
+          `expected 0 failures for ${JSON.stringify(p)}, got ${JSON.stringify(out)}`
+        )
+      }
+    } finally {
+      removeDir(dir)
+    }
+  })
+
+  it('returns [] for a healthy database with a healthy vector index', () => {
+    // Control.  One index is created and left intact, so the hand-derived
+    // expectation is 0 failures — an always-non-empty report would be useless
+    // as a health check.
+    const dir = makeTempDir()
+    try {
+      const dbPath = path.join(dir, 'graph.db')
+      const db = SparrowDB.open(dbPath)
+      db.createVectorIndex(LABEL, PROP, DIMENSIONS, 'cosine')
+      db.execute(`CREATE (n:${LABEL} {id: 'ok-1'})`)
+      db.addToVectorIndex(
+        LABEL, PROP, 'ok-1', new Float32Array([0.1, 0.2, 0.3])
+      )
+
+      const failures = SparrowDB.vectorIndexLoadFailures(dbPath)
+      assert.ok(Array.isArray(failures))
+      assert.equal(
+        failures.length, 0,
+        `a healthy index must report no failures, got ${JSON.stringify(failures)}`
+      )
+    } finally {
+      removeDir(dir)
+    }
+  })
+
+  it('reports live damage on an index nothing has probed yet', () => {
+    // First observer of the damage.  The file is still in place, so the
+    // reported (label, prop) is the live entry.
+    const { dir, indexFile, dbPath } = makeDamagedDb()
+    try {
+      const failures = SparrowDB.vectorIndexLoadFailures(dbPath)
+      assert.equal(
+        failures.length, EXPECTED_FAILURES,
+        `expected exactly ${EXPECTED_FAILURES} damaged index, got ` +
+        JSON.stringify(failures)
+      )
+      assertFailureShape(failures[0], indexFile)
+      assert.equal(
+        failures[0].path, indexFile,
+        'the live arm reports the .bin path it scanned'
+      )
+      // Caveat worth encoding: probing a live entry is not read-only when
+      // composed with #442 — `VectorIndex::load` quarantines the bytes it
+      // rejects, so by the time this call returns the .bin has been renamed
+      // aside and the reported .bin path no longer resolves.  The surviving
+      // bytes are named in `reason`, and the NEXT call reports the artifact
+      // path (see the following test).  Asserting this rather than glossing
+      // it is the point: a consumer must not assume `path` is still there
+      // after a live-arm report.
+      assert.ok(
+        /corrupt/i.test(failures[0].reason),
+        `reason must describe the damage, got: ${failures[0].reason}`
+      )
+      const artifacts = fs
+        .readdirSync(path.join(dbPath, 'vector_indexes'))
+        .filter(n => n.startsWith(`hnsw_${LABEL}_${PROP}.bin.corrupt.`))
+      assert.equal(
+        artifacts.length, 1,
+        `#442 must have quarantined the probed file exactly once, got ` +
+        JSON.stringify(artifacts)
+      )
+    } finally {
+      removeDir(dir)
+    }
+  })
+
+  it('is callable on a database that refuses to open, and keeps reporting after it starts opening "clean" (#451)', () => {
+    const { dir, dbPath, indexFile } = makeDamagedDb()
+    try {
+      // ── Phase 1: the state #446 created. `open()` refuses. ───────────────
+      assert.throws(
+        () => SparrowDB.open(dbPath),
+        err => {
+          assert.ok(
+            new RegExp(`${LABEL}`).test(err.message) &&
+            new RegExp(`${PROP}`).test(err.message),
+            `open() must name the (label, prop) pair, got: ${err.message}`
+          )
+          return true
+        },
+        'a live damaged index must make open() fail'
+      )
+
+      // The whole reason this is static: there is no instance to hang it off.
+      const duringOutage = SparrowDB.vectorIndexLoadFailures(dbPath)
+      assert.equal(
+        duringOutage.length, EXPECTED_FAILURES,
+        `expected exactly ${EXPECTED_FAILURES} damaged index while open() is ` +
+        `failing, got ${JSON.stringify(duringOutage)}`
+      )
+      assertFailureShape(duringOutage[0], indexFile)
+
+      // The failed open() quarantined the bytes, so the reported path is now
+      // the artifact: `<indexFile>.corrupt.<unix_millis>`.  The stem is
+      // hand-derived; only the millisecond stamp is matched loosely because it
+      // is a wall-clock value and cannot be derived.
+      const artifactPattern = new RegExp(
+        `^${escapeRegExp(indexFile)}\\.corrupt\\.\\d+$`
+      )
+      assert.match(
+        duringOutage[0].path, artifactPattern,
+        'the reported path must be the quarantine artifact'
+      )
+      // A report naming a file that is not on disk is not actionable.
+      assert.ok(
+        fs.existsSync(duringOutage[0].path),
+        `reported path ${duringOutage[0].path} must exist on disk`
+      )
+      assert.ok(
+        fs.statSync(duringOutage[0].path).isFile(),
+        'the reported path must be a regular file'
+      )
+      assert.ok(
+        /quarantine/i.test(duringOutage[0].reason),
+        `reason must identify this as a quarantine artifact, got: ` +
+        duringOutage[0].reason
+      )
+
+      // ── Phase 2: #451. The .bin is gone, so this is now the "absent" case
+      //    and open() succeeds — with the index silently missing. ───────────
+      const db = SparrowDB.open(dbPath)
+      assert.ok(
+        db instanceof SparrowDB,
+        'after quarantine the second open() succeeds — that is #451'
+      )
+      // Confirm the index really is absent from the reopened database: the
+      // vectors are gone and nothing on the instance API says so.
+      assert.throws(
+        () => db.vectorIndexHealth(LABEL, PROP),
+        /RangeError/,
+        'the quarantined index must be absent from the reopened database'
+      )
+
+      // ── Phase 3: the diagnostic is the ONLY remaining signal. ────────────
+      const afterReopen = SparrowDB.vectorIndexLoadFailures(dbPath)
+      assert.equal(
+        afterReopen.length, EXPECTED_FAILURES,
+        `the quarantine must remain visible after the database reopens ` +
+        `"clean"; got ${JSON.stringify(afterReopen)}`
+      )
+      assertFailureShape(afterReopen[0], indexFile)
+      assert.equal(
+        afterReopen[0].path, duringOutage[0].path,
+        'the artifact path must be stable across calls'
+      )
+      assert.ok(
+        fs.existsSync(afterReopen[0].path),
+        `reported path ${afterReopen[0].path} must exist on disk`
+      )
+    } finally {
+      removeDir(dir)
     }
   })
 })


### PR DESCRIPTION
## Why

`GraphDb::vector_index_load_failures(path)` landed in **#446** as the diagnostic that #446's own documentation tells operators to call when `open()` throws `Corruption`. It had **no napi binding**, so the documented remediation was unreachable from JavaScript — the only language the affected consumer can call it from. This PR unblocks a production consumer's vector-index health check, which cannot be built any other way.

It is also the only way to learn a quarantine ever happened. Per **#451**, after a damaged index is quarantined the **first** `open()` errors loudly and every subsequent `open()` **succeeds with the index silently absent**: vector writes for that `(label, prop)` are dropped and every search returns nothing. Nothing else on the API surface distinguishes that store from a healthy one.

## API

```typescript
SparrowDB.vectorIndexLoadFailures(path: string):
    Array<{ label: string; prop: string; path: string; reason: string }>
```

- **Static, not an instance method.** The database this diagnoses is usually the one that will not open, so an instance method would be unreachable exactly when it is needed. Verified from JS that it lives on `SparrowDB` and *not* on `SparrowDB.prototype`.
- **Never throws.** The Rust surface returns `Vec`, not `Result`; the binding mirrors that with `Vec<VectorIndexLoadFailure>` rather than `napi::Result<..>`. Absent, unreadable, NUL-byte and empty paths all yield `[]`. Making the diagnostic itself a failure path would defeat its purpose.
- **Named fields, not tuples.** A consumer building an alert reads `f.path`, not `f[2]`. `path` is the machine-readable field. `reason` is **reconstructed** for quarantine artifacts (#442 records the original decode failure only in the error it returns at quarantine time and writes no sidecar), and is documented as non-authoritative and non-parseable.
- Named `vectorIndexLoadFailures` to match the existing camelCase convention (`hasVector`, `vectorIndexHealth`, `repairVectorIndex`).

## Tests

5 new tests in `npm/sparrowdb/test/integration.test.js`, **executed against a freshly built `.node`** — not merely `cargo check`ed:

1. static-not-instance guard (`SparrowDB.prototype.vectorIndexLoadFailures === undefined`);
2. never-throws across absent dir / non-db dir / NUL-byte path / empty string, all `[]`;
3. healthy database with a healthy index reports `[]` (control — an always-non-empty report is useless as a health check);
4. live damage on an index nothing has probed yet;
5. the full #451 sequence: `open()` throws naming `(label, prop)` → the diagnostic reports the quarantine artifact with all four named fields and a `path` that **exists on disk** → the second `open()` now **succeeds** with the index silently absent (`vectorIndexHealth` throws `RangeError`) → the diagnostic **still** reports it.

### Hand-derived expectations (not captured from output)

- **File name** — `VectorIndex::index_path` formats `hnsw_{label}_{prop}.bin` under `<db_root>/vector_indexes/`, so `Memory`/`embedding` gives `hnsw_Memory_embedding.bin`.
- **Damage** — the persisted index is truncated to 4 bytes. A v2 file carries a 36-byte header (8 magic + 4 version + 4 reserved + 8 payload_len + 8 generation + 4 crc32c), so a 4-byte file cannot be read as v2 and falls to the legacy `bincode` path, where the struct's first field `nodes: Vec<HnswNode>` needs an 8-byte little-endian length prefix that 4 bytes cannot supply. No 4-byte string decodes to a `VectorIndex`, so this does not depend on which bytes survive.
- **Count** — one index is created for one `(label, prop)`, so exactly **1** entry must be reported. It reaches 1 by two routes (live-unloadable, then quarantine artifact); asserting the count and the pair rather than the route is what makes it hold across #442.
- **Artifact path** — `<indexFile>.corrupt.<unix_millis>`; the stem is asserted exactly, only the wall-clock stamp is matched as `\d+`.

### Pre-change failure proof (measured)

`crates/sparrowdb-node/src/lib.rs` was reverted to `origin/main`, the `.node` rebuilt, and the **new** test file run:

```
# tests 45   # pass 40   # fail 5
TypeError: SparrowDB.vectorIndexLoadFailures is not a function
```

then restored byte-exact (sha256 `ab0d1643…` before and after) and re-run: **45 pass / 0 fail**.

Being honest about what this proves: an **additive** API can only fail at *resolution*, not behaviourally. There is no pre-change state in which the method exists and returns the wrong thing. Test 5 is the strongest of the five — it got past `open()` throwing (confirming the fixture is genuinely damaged pre-change) and failed only on the missing method.

## index.d.ts and #449

Added cleanly. `tsc --noEmit --skipLibCheck npm/sparrowdb/index.d.ts` reports **35 errors before and 35 after**, first error unchanged at line 32 (`NodeResult`). The pre-existing #449 breakage is untouched and not made worse; all insertions are below the broken region. The new doc comments use `//` inside the ` ```typescript ` fences rather than nested `/** */`, so by construction they cannot add to that count.

## Verification

| Command | Result |
|---|---|
| `cargo build --release -p sparrowdb-node` | ok |
| `node --test npm/sparrowdb/test/integration.test.js` | 45 pass / 0 fail (5 new) |
| `cargo fmt --all -- --check` | clean (also re-run in a fresh clone of the pushed branch) |
| `cargo clippy -p sparrowdb-node --all-targets -- -D warnings` | clean |
| `cargo check -p sparrowdb` | clean |

## Note for reviewers (not fixed here — out of scope, different owner)

`crates/sparrowdb/src/helpers.rs::vector_index_load_failures` reports, for the **live** arm, the `.bin` path it scanned — but `VectorIndex::load` quarantines the file during that same probe, so the reported `.bin` path has already been renamed away by the time the call returns. The surviving bytes are named in `reason`, and the *next* call reports the artifact path correctly. The doc says "the path is exact", which holds for the quarantine arm and for the `validate_invariants` arm, but not for the live-and-quarantined arm. Test 4 encodes this behaviour explicitly rather than glossing it, so a consumer does not assume `path` is still there after a live-arm report. Worth a follow-up issue against `crates/sparrowdb/src/helpers.rs`.

Refs #446, #451. Does not touch `crates/sparrowdb-storage/**` or `crates/sparrowdb/src/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE
