### PR TITLE
fix(vector): make VectorIndex::load non-destructive (closes #456, closes #455)

### DIFF
--- a/crates/sparrowdb-execution/src/engine/expr.rs
+++ b/crates/sparrowdb-execution/src/engine/expr.rs
@@ -162,13 +162,26 @@ impl Engine {
     /// same write lock that mutates it, a matching fingerprint means the cached
     /// copy is byte-identical to what the current writer would hand us.
     ///
-    /// Returns `None` when the index does not exist or fails to load; the
-    /// caller then falls back to full-text-only results, exactly as before.
+    /// # Absent is not damaged (#456)
+    ///
+    /// `Ok(None)` means no index is configured for the pair — a legitimate
+    /// state, and the caller degrades to full-text-only results exactly as
+    /// before.  `Err(reason)` means a file *is* there and cannot be served.
+    ///
+    /// Collapsing those two into `None` is what made this a data-loss path: the
+    /// loader used to be `VectorIndex::load(..).ok().flatten()?`, and since #442
+    /// had moved the quarantine rename inside `load`, a plain read query
+    /// renamed the last live copy of the index aside, then reported success
+    /// with zero vector hits.  This function now calls the non-destructive
+    /// `load` and keeps the two outcomes apart.
     fn hybrid_vector_index(
         vec_dir: &std::path::Path,
         label: &str,
         prop: &str,
-    ) -> Option<std::sync::Arc<sparrowdb_storage::vector_index::VectorIndex>> {
+    ) -> std::result::Result<
+        Option<std::sync::Arc<sparrowdb_storage::vector_index::VectorIndex>>,
+        String,
+    > {
         type Key = (std::path::PathBuf, String, String);
         type Entry = (
             (u64, u64),
@@ -177,35 +190,71 @@ impl Engine {
         static CACHE: std::sync::OnceLock<std::sync::Mutex<HashMap<Key, Entry>>> =
             std::sync::OnceLock::new();
 
-        // Missing file / unreadable header → nothing to search.
+        // The fingerprint is a cache-validity token, not an existence test.
+        // `fingerprint` opens the path, so a dangling symlink reports NotFound
+        // and a damaged header reports an error — neither of which means "no
+        // index here".  When it yields nothing we fall through to `load`, which
+        // is the one place that distinguishes absent from unreadable.  That
+        // costs two extra syscalls per row in the no-index-configured case,
+        // against the full `FtsIndex::open` the same row already performs.
         let fingerprint =
             sparrowdb_storage::vector_index::VectorIndex::fingerprint(vec_dir, label, prop)
-                .ok()
-                .flatten()?;
+                .unwrap_or_default();
 
-        let cache = CACHE.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
-        let mut guard = cache.lock().ok()?;
         let key: Key = (vec_dir.to_path_buf(), label.to_owned(), prop.to_owned());
+        let cache = CACHE.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
+        let mut guard = match cache.lock() {
+            Ok(g) => g,
+            // A poisoned cache mutex is not evidence about the index file.
+            // Skip the cache rather than claim the index is missing.
+            Err(_) => {
+                return match sparrowdb_storage::vector_index::VectorIndex::load(
+                    vec_dir, label, prop,
+                ) {
+                    Ok(idx) => Ok(idx.map(std::sync::Arc::new)),
+                    Err(e) => Err(e.to_string()),
+                }
+            }
+        };
 
-        if let Some((cached_fp, idx)) = guard.get(&key) {
-            if *cached_fp == fingerprint {
-                return Some(std::sync::Arc::clone(idx));
+        if let Some(fp) = fingerprint {
+            if let Some((cached_fp, idx)) = guard.get(&key) {
+                if *cached_fp == fp {
+                    return Ok(Some(std::sync::Arc::clone(idx)));
+                }
             }
         }
 
-        let loaded = sparrowdb_storage::vector_index::VectorIndex::load(vec_dir, label, prop)
-            .ok()
-            .flatten()?;
+        let loaded = match sparrowdb_storage::vector_index::VectorIndex::load(vec_dir, label, prop)
+        {
+            Ok(Some(idx)) => idx,
+            // The pair no longer has a usable index.  Drop any cached copy
+            // rather than keeping an 8 MB deserialised graph alive for a key
+            // that can no longer be served.
+            Ok(None) => {
+                guard.remove(&key);
+                return Ok(None);
+            }
+            Err(e) => {
+                guard.remove(&key);
+                return Err(e.to_string());
+            }
+        };
         let idx = std::sync::Arc::new(loaded);
 
-        // Bound the cache: a process that opens many databases should not
-        // retain every index it has ever queried.
-        const MAX_CACHED_INDEXES: usize = 8;
-        if guard.len() >= MAX_CACHED_INDEXES && !guard.contains_key(&key) {
-            guard.clear();
+        // Only a fingerprinted index is cacheable: without one there is no
+        // token to invalidate the entry against, and a stale copy would be
+        // served forever.
+        if let Some(fp) = fingerprint {
+            // Bound the cache: a process that opens many databases should not
+            // retain every index it has ever queried.
+            const MAX_CACHED_INDEXES: usize = 8;
+            if guard.len() >= MAX_CACHED_INDEXES && !guard.contains_key(&key) {
+                guard.clear();
+            }
+            guard.insert(key, (fp, std::sync::Arc::clone(&idx)));
         }
-        guard.insert(key, (fingerprint, std::sync::Arc::clone(&idx)));
-        Some(idx)
+        Ok(Some(idx))
     }
 
     /// Evaluate `hybrid_search(label, emb_prop, text_prop, query_vec, query_text, k[, alpha])`.
@@ -273,12 +322,43 @@ impl Engine {
         };
 
         // ── 1. Vector search ────────────────────────────────────────────────
+        //
+        // A damaged index does NOT degrade to full-text-only here (#456).
+        //
+        // The three candidate behaviours were: return an error, quietly fall
+        // back to FTS, or refuse to answer.  Returning an error is not
+        // reachable from a scalar function — `eval_expr_graph` and every
+        // function it dispatches are infallible by signature, and making them
+        // fallible is an engine-wide change well outside this fix.  That leaves
+        // fall-back or refusal, and fall-back is the wrong one: it produces the
+        // *same* observable as a legitimately absent index, which is precisely
+        // the absent-vs-damaged confusion #445 exists to eliminate.  A caller
+        // who asked for a fusion of vector and text results, and silently got
+        // text only, has been told the store is healthy by a store that is not.
+        //
+        // So: absent → FTS-only, unchanged.  Damaged → `Value::Null`, which is
+        // already this function's failure signal (bad arity, bad argument
+        // types, fusion failure), plus a warning naming the file and the
+        // decode reason.  Null is a shape the caller cannot mistake for an
+        // empty result list.
         let vec_dir = self.snapshot.db_root.join("vector_indexes");
         let vec_results: Vec<(u64, f32)> =
             match Self::hybrid_vector_index(&vec_dir, &label, &emb_prop) {
                 // ef = max(k*2, 50) gives a reasonable exploration budget.
-                Some(idx) => idx.search(&query_vec, k * 2, (k * 2).max(50)),
-                None => vec![],
+                Ok(Some(idx)) => idx.search(&query_vec, k * 2, (k * 2).max(50)),
+                // No index configured for this pair: full-text-only is the
+                // honest answer and always has been.
+                Ok(None) => vec![],
+                Err(reason) => {
+                    tracing::warn!(
+                        label = %label,
+                        property = %emb_prop,
+                        reason = %reason,
+                        "hybrid_search: the vector index for this pair is present but unusable; \
+                         returning NULL rather than silently degrading to full-text-only results"
+                    );
+                    return Value::Null;
+                }
             };
 
         // ── 2. Full-text (BM25) search ───────────────────────────────────────

--- a/crates/sparrowdb-execution/src/engine/expr.rs
+++ b/crates/sparrowdb-execution/src/engine/expr.rs
@@ -1,6 +1,70 @@
 //! Auto-generated submodule — see engine/mod.rs for context.
 use super::*;
 
+/// Key of the process-global `hybrid_search` index cache: which database
+/// directory, which `(label, prop)` pair.
+type HybridCacheKey = (std::path::PathBuf, String, String);
+
+/// A cached verdict about one on-disk HNSW index, together with the fingerprint
+/// it was derived from.
+type HybridCacheEntry = ((u64, u64), CachedIndex);
+
+/// What the last look at an index file concluded — valid for exactly as long as
+/// that file's fingerprint is unchanged.
+enum CachedIndex {
+    /// The file loaded; this is the shared deserialised copy.
+    Ready(std::sync::Arc<sparrowdb_storage::vector_index::VectorIndex>),
+    /// The file is present and cannot be served, for this reason.
+    ///
+    /// # Why the negative is cached too (#456)
+    ///
+    /// `hybrid_search` is a scalar function: it is evaluated once per candidate
+    /// row.  Caching only the success meant a damaged index was re-read and
+    /// re-decoded on *every* row — for KMSmcp's 8 MB `Knowledge.embedding`
+    /// index that is N x 8 MB of I/O for an N-row scan, and a file that decodes
+    /// cleanly but then fails `validate_invariants` paid a full `bincode`
+    /// decode each time.  It also emitted one identical warning per row.
+    ///
+    /// Both arrive at the moment the store is already degraded and someone is
+    /// reading the logs to find out why, which is the worst possible time to
+    /// add an I/O storm and bury the signal.  A fix whose purpose is "behave
+    /// well when the index is damaged" must not amplify the incident.
+    Damaged(String),
+}
+
+/// A damaged-index verdict handed back to the caller.
+struct HybridIndexDamage {
+    /// The loader's own error text.
+    reason: String,
+    /// True only on the evaluation that first observed this damage for the
+    /// current fingerprint.  Every later row reuses the cached verdict and sets
+    /// this to `false`, so one damaged index produces one log line rather than
+    /// one per row.
+    first_observation: bool,
+}
+
+/// Insert into the `hybrid_search` index cache, keeping it bounded.
+///
+/// The cache is process-global and keyed by `(dir, label, prop)`, so without a
+/// bound a long-running process — an MCP server that opens many databases over
+/// its lifetime is the realistic case — would retain one entry for every pair it
+/// had ever queried, and each `Ready` entry pins a fully deserialised index that
+/// can be megabytes.  Eight is chosen to comfortably cover the pairs one query
+/// touches while keeping the retained set small; the eviction is a wholesale
+/// clear rather than an LRU because there is no access-recency information worth
+/// tracking here and a cleared cache costs one reload, not a wrong answer.
+fn hybrid_cache_insert(
+    map: &mut HashMap<HybridCacheKey, HybridCacheEntry>,
+    key: HybridCacheKey,
+    entry: HybridCacheEntry,
+) {
+    const MAX_CACHED_INDEXES: usize = 8;
+    if map.len() >= MAX_CACHED_INDEXES && !map.contains_key(&key) {
+        map.clear();
+    }
+    map.insert(key, entry);
+}
+
 impl Engine {
     // ── FTS scalar functions ──────────────────────────────────────────────────
 
@@ -166,7 +230,7 @@ impl Engine {
     ///
     /// `Ok(None)` means no index is configured for the pair — a legitimate
     /// state, and the caller degrades to full-text-only results exactly as
-    /// before.  `Err(reason)` means a file *is* there and cannot be served.
+    /// before.  `Err(..)` means a file *is* there and cannot be served.
     ///
     /// Collapsing those two into `None` is what made this a data-loss path: the
     /// loader used to be `VectorIndex::load(..).ok().flatten()?`, and since #442
@@ -174,21 +238,37 @@ impl Engine {
     /// renamed the last live copy of the index aside, then reported success
     /// with zero vector hits.  This function now calls the non-destructive
     /// `load` and keeps the two outcomes apart.
+    ///
+    /// # Both verdicts are cached, under the same token
+    ///
+    /// A damaged file is remembered as [`CachedIndex::Damaged`] against the same
+    /// fingerprint the successful load is cached against, so an N-row scan reads
+    /// and decodes it once rather than N times, and warns once rather than N
+    /// times.
+    ///
+    /// The invalidation is therefore identical for both: rebuild the index and
+    /// its fingerprint changes, the cached entry stops matching, and the next
+    /// row re-probes and sees the repair.  A negative verdict that outlived its
+    /// repair would recreate, one layer down, exactly the "fixed but still
+    /// reports broken" failure this PR removes from the diagnostic.
+    ///
+    /// A verdict is only cached when a fingerprint exists, because the
+    /// fingerprint *is* the invalidation token and there is nothing safe to do
+    /// without one.  That costs nothing in practice: `fingerprint` fails only
+    /// when the file cannot be opened at all (a dangling symlink, a permission
+    /// block), and those re-probe for one failed `open` plus one `lstat` with no
+    /// payload read — never the full decode this cache exists to avoid.
     fn hybrid_vector_index(
         vec_dir: &std::path::Path,
         label: &str,
         prop: &str,
     ) -> std::result::Result<
         Option<std::sync::Arc<sparrowdb_storage::vector_index::VectorIndex>>,
-        String,
+        HybridIndexDamage,
     > {
-        type Key = (std::path::PathBuf, String, String);
-        type Entry = (
-            (u64, u64),
-            std::sync::Arc<sparrowdb_storage::vector_index::VectorIndex>,
-        );
-        static CACHE: std::sync::OnceLock<std::sync::Mutex<HashMap<Key, Entry>>> =
-            std::sync::OnceLock::new();
+        static CACHE: std::sync::OnceLock<
+            std::sync::Mutex<HashMap<HybridCacheKey, HybridCacheEntry>>,
+        > = std::sync::OnceLock::new();
 
         // The fingerprint is a cache-validity token, not an existence test.
         // `fingerprint` opens the path, so a dangling symlink reports NotFound
@@ -201,26 +281,36 @@ impl Engine {
             sparrowdb_storage::vector_index::VectorIndex::fingerprint(vec_dir, label, prop)
                 .unwrap_or_default();
 
-        let key: Key = (vec_dir.to_path_buf(), label.to_owned(), prop.to_owned());
+        let key: HybridCacheKey = (vec_dir.to_path_buf(), label.to_owned(), prop.to_owned());
         let cache = CACHE.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
         let mut guard = match cache.lock() {
             Ok(g) => g,
             // A poisoned cache mutex is not evidence about the index file.
-            // Skip the cache rather than claim the index is missing.
+            // Skip the cache rather than claim the index is missing; with no
+            // cache to consult, every evaluation is a first observation.
             Err(_) => {
                 return match sparrowdb_storage::vector_index::VectorIndex::load(
                     vec_dir, label, prop,
                 ) {
                     Ok(idx) => Ok(idx.map(std::sync::Arc::new)),
-                    Err(e) => Err(e.to_string()),
+                    Err(e) => Err(HybridIndexDamage {
+                        reason: e.to_string(),
+                        first_observation: true,
+                    }),
                 }
             }
         };
 
         if let Some(fp) = fingerprint {
-            if let Some((cached_fp, idx)) = guard.get(&key) {
+            if let Some((cached_fp, verdict)) = guard.get(&key) {
                 if *cached_fp == fp {
-                    return Ok(Some(std::sync::Arc::clone(idx)));
+                    return match verdict {
+                        CachedIndex::Ready(idx) => Ok(Some(std::sync::Arc::clone(idx))),
+                        CachedIndex::Damaged(reason) => Err(HybridIndexDamage {
+                            reason: reason.clone(),
+                            first_observation: false,
+                        }),
+                    };
                 }
             }
         }
@@ -229,30 +319,40 @@ impl Engine {
         {
             Ok(Some(idx)) => idx,
             // The pair no longer has a usable index.  Drop any cached copy
-            // rather than keeping an 8 MB deserialised graph alive for a key
-            // that can no longer be served.
+            // rather than keeping an 8 MB deserialised graph — or a stale
+            // damage verdict — alive for a key that is now simply absent.
             Ok(None) => {
                 guard.remove(&key);
                 return Ok(None);
             }
             Err(e) => {
-                guard.remove(&key);
-                return Err(e.to_string());
+                let reason = e.to_string();
+                match fingerprint {
+                    Some(fp) => hybrid_cache_insert(
+                        &mut guard,
+                        key,
+                        (fp, CachedIndex::Damaged(reason.clone())),
+                    ),
+                    // No token to invalidate against, so nothing may be
+                    // remembered.  See the note on this function.
+                    None => {
+                        guard.remove(&key);
+                    }
+                }
+                return Err(HybridIndexDamage {
+                    reason,
+                    first_observation: true,
+                });
             }
         };
         let idx = std::sync::Arc::new(loaded);
 
-        // Only a fingerprinted index is cacheable: without one there is no
-        // token to invalidate the entry against, and a stale copy would be
-        // served forever.
         if let Some(fp) = fingerprint {
-            // Bound the cache: a process that opens many databases should not
-            // retain every index it has ever queried.
-            const MAX_CACHED_INDEXES: usize = 8;
-            if guard.len() >= MAX_CACHED_INDEXES && !guard.contains_key(&key) {
-                guard.clear();
-            }
-            guard.insert(key, (fp, std::sync::Arc::clone(&idx)));
+            hybrid_cache_insert(
+                &mut guard,
+                key,
+                (fp, CachedIndex::Ready(std::sync::Arc::clone(&idx))),
+            );
         }
         Ok(Some(idx))
     }
@@ -342,24 +442,31 @@ impl Engine {
         // decode reason.  Null is a shape the caller cannot mistake for an
         // empty result list.
         let vec_dir = self.snapshot.db_root.join("vector_indexes");
-        let vec_results: Vec<(u64, f32)> =
-            match Self::hybrid_vector_index(&vec_dir, &label, &emb_prop) {
-                // ef = max(k*2, 50) gives a reasonable exploration budget.
-                Ok(Some(idx)) => idx.search(&query_vec, k * 2, (k * 2).max(50)),
-                // No index configured for this pair: full-text-only is the
-                // honest answer and always has been.
-                Ok(None) => vec![],
-                Err(reason) => {
+        let vec_results: Vec<(u64, f32)> = match Self::hybrid_vector_index(
+            &vec_dir, &label, &emb_prop,
+        ) {
+            // ef = max(k*2, 50) gives a reasonable exploration budget.
+            Ok(Some(idx)) => idx.search(&query_vec, k * 2, (k * 2).max(50)),
+            // No index configured for this pair: full-text-only is the
+            // honest answer and always has been.
+            Ok(None) => vec![],
+            Err(damage) => {
+                // Once per damaged index, not once per row.  An N-row scan
+                // against a damaged index used to emit N identical lines,
+                // burying the signal at the exact moment someone is reading
+                // the logs to find out what broke.
+                if damage.first_observation {
                     tracing::warn!(
                         label = %label,
                         property = %emb_prop,
-                        reason = %reason,
+                        reason = %damage.reason,
                         "hybrid_search: the vector index for this pair is present but unusable; \
                          returning NULL rather than silently degrading to full-text-only results"
                     );
-                    return Value::Null;
                 }
-            };
+                return Value::Null;
+            }
+        };
 
         // ── 2. Full-text (BM25) search ───────────────────────────────────────
         let fts_results: Vec<(u64, f32)> = match sparrowdb_storage::fts_index::FtsIndex::open(

--- a/crates/sparrowdb-node/src/lib.rs
+++ b/crates/sparrowdb-node/src/lib.rs
@@ -317,6 +317,92 @@ pub struct VectorIndexLoadFailure {
     pub reason: String,
 }
 
+/// Convert the crate-level health report into its napi shape.
+///
+/// `to_string_lossy` rather than a fallible conversion: a path that is not
+/// valid UTF-8 must still be reported, and these functions have no error
+/// channel by design.
+fn to_damage_report(health: ::sparrowdb::VectorIndexHealth) -> VectorIndexDamageReport {
+    fn convert(v: Vec<::sparrowdb::VectorIndexFailure>) -> Vec<VectorIndexLoadFailure> {
+        v.into_iter()
+            .map(|f| VectorIndexLoadFailure {
+                label: f.label,
+                prop: f.prop,
+                path: f.path.to_string_lossy().into_owned(),
+                reason: f.reason,
+            })
+            .collect()
+    }
+    VectorIndexDamageReport {
+        healthy: health.is_healthy(),
+        unscannable: health.unscannable,
+        active: convert(health.active),
+        historical: convert(health.historical),
+    }
+}
+
+// ── VectorIndexDamageReport ──────────────────────────────────────────────────
+
+/// What an inspection of a database's `vector_indexes/` observed — see
+/// `SparrowDB.vectorIndexLoadFailures` and `SparrowDB.vectorIndexDamageScan`.
+///
+/// ```typescript
+/// interface VectorIndexDamageReport {
+///   unscannable?: string;                  // present when the directory could not be listed
+///   active: VectorIndexLoadFailure[];      // unrecovered damage — alert on this
+///   historical: VectorIndexLoadFailure[];  // recovered-from damage — forensics only
+///   healthy: boolean;                      // !unscannable && active.length === 0
+/// }
+/// ```
+///
+/// Not to be confused with the **instance** method `db.vectorIndexHealth(label,
+/// prop)`, which returns per-index vector reachability counts. This type is
+/// about which index *files* are in service; that one is about how many vectors
+/// inside one healthy file a search can reach.
+///
+/// # Three fields, because a report has three things to say (#456)
+///
+/// Before #456 this was a bare `VectorIndexLoadFailure[]`, and `[]` meant three
+/// different things at once. Each collapse cost something:
+///
+/// - **`unscannable`** — `[]` also meant "I could not read the directory". A
+///   `chmod 000` on `vector_indexes/`, a bad mount during a poll, or a
+///   misconfigured service account produced output byte-identical to a healthy
+///   store. A monitor could not tell green from blind. When this is non-null,
+///   `active` and `historical` are empty *for lack of observation, not lack of
+///   damage* — check it before concluding anything.
+/// - **`historical`** — a quarantine artifact whose `(label, prop)` is served
+///   again by a working index. It used to stay in the one array forever,
+///   because #442 never cleans artifacts up, so a store that had been repaired
+///   could go green → red and never back. An alert that will not clear after
+///   the problem is fixed gets muted, and a muted alert is worse than none.
+///   These are reported rather than suppressed because #442 records no reason
+///   at quarantine time and writes no sidecar: the artifact file is the only
+///   surviving evidence the incident happened.
+/// - **`healthy`** — computed in Rust as `unscannable.is_none() &&
+///   active.is_empty()`, so a JS caller cannot get the composition wrong. Note
+///   that an unscannable report is **not** healthy: not knowing is not the same
+///   as being fine.
+#[napi(object)]
+pub struct VectorIndexDamageReport {
+    /// Set when `vector_indexes/` could not be listed; the string says why.
+    /// `None` becomes an **absent** JS property rather than `null`, so JS
+    /// callers should test it for truthiness.
+    ///
+    /// While set, `active` and `historical` are empty because nothing was
+    /// observed — not because nothing is wrong.
+    pub unscannable: Option<String>,
+    /// Damage that is still unrecovered. The vectors for these pairs are not in
+    /// service and writes to them are being dropped. This is the alert.
+    pub active: Vec<VectorIndexLoadFailure>,
+    /// Quarantine artifacts whose `(label, prop)` a working index now serves.
+    /// Forensics for an operator; a monitor ignores this.
+    pub historical: Vec<VectorIndexLoadFailure>,
+    /// `!unscannable && active.length === 0`. Computed in Rust so a JS
+    /// caller cannot get the composition wrong.
+    pub healthy: bool,
+}
+
 // ── SparrowDB ─────────────────────────────────────────────────────────────────
 
 /// Top-level database handle.
@@ -356,7 +442,8 @@ impl SparrowDB {
         Ok(SparrowDB { inner: db })
     }
 
-    /// Report every vector index at `path` whose bytes are damaged.
+    /// Deep damage report for the vector indexes at `path`: reads and
+    /// validates every live index file.
     ///
     /// **Static**, and deliberately so: the database this diagnoses is usually
     /// one that will not open. `open` fails with a `Corruption` error when a
@@ -364,16 +451,20 @@ impl SparrowDB {
     /// *which* files caused it — so requiring an instance would make it
     /// unreachable in the exact situation it exists for.
     ///
-    /// **Never throws.** An unreadable or absent directory yields `[]`; there
-    /// is no configuration of the filesystem that turns the diagnostic itself
-    /// into a second failure to diagnose. An empty array therefore means "no
-    /// damage found", which includes the ordinary case of a database with no
-    /// vector indexes at all.
+    /// **Never throws.** There is no configuration of the filesystem that turns
+    /// the diagnostic itself into a second failure to diagnose. A directory it
+    /// cannot list is reported in `unscannable` rather than raised.
     ///
-    /// Two kinds of damage are reported:
+    /// **Not for a poll loop.** This deserialises every *healthy* index it
+    /// finds — for an 8 MB `Knowledge.embedding` index polled hourly, 8 MB of
+    /// I/O and a complete HNSW graph rebuild an hour, spent confirming that
+    /// nothing is wrong. Use `SparrowDB.vectorIndexDamageScan` for monitoring
+    /// and this for "why will my database not open?".
     ///
-    /// - **live but unloadable** — `hnsw_<label>_<prop>.bin` is present and
-    ///   rejected; `open` fails on these;
+    /// Damage is reported in both places it can live:
+    ///
+    /// - **live but not serving** — `hnsw_<label>_<prop>.bin` is present and
+    ///   either does not resolve or does not load; `open` fails on these;
     /// - **already quarantined** — `hnsw_<label>_<prop>.bin.corrupt.<millis>`,
     ///   bytes a previous load attempt moved aside (#442).
     ///
@@ -383,31 +474,61 @@ impl SparrowDB {
     /// so vector writes for that pair are dropped and searches return nothing.
     /// Nothing else distinguishes that store from a healthy one.
     ///
-    /// Not read-only when composed with #442: probing a live entry may
-    /// quarantine it. The observable result is unchanged — a file quarantined
-    /// during one call is reported as a quarantine artifact by the next.
+    /// **Read-only since #456.** It used to quarantine the live entries it
+    /// probed, so a second call answered differently from the first and the
+    /// `path` it reported had already been renamed away by the time you read
+    /// it. Both are fixed: run it as often as you like, and `path` resolves.
     ///
     /// ```typescript
-    /// const failures = SparrowDB.vectorIndexLoadFailures('/path/to/my.db')
-    /// // [{ label: 'Memory', prop: 'embedding',
-    /// //    path: '/path/to/my.db/vector_indexes/hnsw_Memory_embedding.bin',
-    /// //    reason: 'HNSW index ... is corrupt ...' }]
-    /// if (failures.length > 0) alert(failures.map(f => f.path))
+    /// const report = SparrowDB.vectorIndexLoadFailures('/path/to/my.db')
+    /// if (report.unscannable) throw new Error(`cannot inspect: ${report.unscannable}`)
+    /// if (!report.healthy) alert(report.active.map(f => f.path))
+    /// // report.historical — damage already recovered from; do not alert
     /// ```
     #[napi]
-    pub fn vector_index_load_failures(path: String) -> Vec<VectorIndexLoadFailure> {
-        ::sparrowdb::GraphDb::vector_index_load_failures(std::path::Path::new(&path))
-            .into_iter()
-            .map(|(label, prop, file, reason)| VectorIndexLoadFailure {
-                label,
-                prop,
-                // `to_string_lossy` rather than a fallible conversion: a path
-                // that is not valid UTF-8 must still be reported, and this
-                // function has no error channel by design.
-                path: file.to_string_lossy().into_owned(),
-                reason,
-            })
-            .collect()
+    pub fn vector_index_load_failures(path: String) -> VectorIndexDamageReport {
+        to_damage_report(::sparrowdb::GraphDb::vector_index_load_failures(
+            std::path::Path::new(&path),
+        ))
+    }
+
+    /// Cheap damage report for the vector indexes at `path`: directory metadata
+    /// only, no index file contents read.
+    ///
+    /// **This is the call for a monitor.** Its cost is one directory listing
+    /// plus one `stat` per live index, independent of index size, so it is safe
+    /// at any poll frequency. `SparrowDB.vectorIndexLoadFailures` is the deep
+    /// counterpart and deserialises every healthy index on every call.
+    ///
+    /// **Static** and **never throws**, for the same reasons.
+    ///
+    /// What it sees: quarantine artifacts, split into `active` and `historical`
+    /// by whether a live index now serves the pair, and live entries that do
+    /// not resolve. What it does not: whether a live index still *decodes*.
+    ///
+    /// That is sound for a **running** store, and the reason is structural
+    /// rather than convenient: `open` loads and validates every live index and
+    /// refuses to start when one fails, so a store that is up has had every
+    /// live file verified already. The question a monitor is left asking is
+    /// "did we quarantine something and lose vectors?", which is exactly what
+    /// this answers without reading a payload byte.
+    ///
+    /// It cannot tell you why a database refuses to *open*. Use
+    /// `SparrowDB.vectorIndexLoadFailures` for that.
+    ///
+    /// Not to be confused with the instance method `db.vectorIndexHealth(label,
+    /// prop)`, which counts reachable vectors inside one healthy index.
+    ///
+    /// ```typescript
+    /// const report = SparrowDB.vectorIndexDamageScan('/path/to/my.db')
+    /// if (report.unscannable) page('cannot read the index directory')
+    /// else if (!report.healthy) page(report.active.map(f => `${f.label}.${f.prop}`))
+    /// ```
+    #[napi]
+    pub fn vector_index_damage_scan(path: String) -> VectorIndexDamageReport {
+        to_damage_report(::sparrowdb::GraphDb::vector_index_health(
+            std::path::Path::new(&path),
+        ))
     }
 
     /// Execute a Cypher query and return `{ columns, rows }`.

--- a/crates/sparrowdb-storage/src/vector_index.rs
+++ b/crates/sparrowdb-storage/src/vector_index.rs
@@ -269,6 +269,30 @@ pub enum InsertOutcome {
     Updated,
 }
 
+/// What reading an index file found, before any policy is applied to it.
+///
+/// Private on purpose: the public surface is [`VectorIndex::load`] and
+/// [`VectorIndex::load_and_quarantine`], which agree on how a file is judged and
+/// differ only in whether a rejected file is moved aside.  Keeping the judgement
+/// in one place is what stops the two from drifting apart — before #456 there
+/// was only one function and the side effect was welded to the judgement.
+enum LoadOutcome {
+    /// Nothing exists at the path.  The only case that is not an error.
+    Absent,
+    /// A well-formed index, fully restored.  Boxed to keep the enum small.
+    Loaded(Box<VectorIndex>),
+    /// The directory entry exists but its bytes are not reachable — a dangling
+    /// symlink.  Never quarantined: there are no bytes to preserve.
+    Unreadable(String),
+    /// Bytes are present and do not decode.  Quarantine-eligible: these are the
+    /// only surviving copy of the vectors.
+    Undecodable(String),
+    /// The bytes decoded but the graph is internally inconsistent.  Never
+    /// quarantined: a hand repair is plausible and `save()`'s generation check
+    /// already stops an empty index from replacing it.
+    Inconsistent(String),
+}
+
 // ── HNSW index ────────────────────────────────────────────────────────────────
 
 /// HNSW vector similarity index.
@@ -528,9 +552,12 @@ impl VectorIndex {
         )))
     }
 
-    /// Load the index from `<dir>/hnsw_<label>_<prop>.bin`.
+    /// Load the index from `<dir>/hnsw_<label>_<prop>.bin` **without modifying
+    /// anything on disk**.
     ///
-    /// Returns `Ok(None)` when the file does not exist.
+    /// Returns `Ok(None)` only when nothing exists at that path.  A file that is
+    /// present but unusable produces `Err`, and is left exactly where it was
+    /// found.
     ///
     /// # Integrity
     ///
@@ -542,33 +569,67 @@ impl VectorIndex {
     /// accept silently by ignoring the trailing bytes and returning an index
     /// with *fewer vectors than the caller wrote*.
     ///
-    /// A file that fails any of these checks is **quarantined**: it is renamed
-    /// to `<path>.corrupt.<unix_millis>` and an error is returned.  Quarantine
-    /// exists because the damaged bytes are the only surviving copy of the
-    /// vectors, and callers that treat a load failure as "no index here" would
-    /// otherwise let the next `save()` overwrite them.
+    /// # Why this is not the quarantining variant (#456)
+    ///
+    /// #442 put the quarantine rename *inside* `load`, which made every reader
+    /// destructive by inheritance — including the `hybrid_search` query path and
+    /// the read-only `vector_index_load_failures` diagnostic.  A read query
+    /// renamed the last live copy of an index aside and reported zero hits.
+    ///
+    /// Quarantine is now opt-in: callers that are about to take ownership of the
+    /// `(label, prop)` slot — i.e. the open path, which is the only place a
+    /// later `save()` could overwrite the damaged bytes — call
+    /// [`VectorIndex::load_and_quarantine`] and say so.  Every other caller uses
+    /// this method and gets the error without the side effect.
     pub fn load(dir: &Path, label: &str, prop: &str) -> std::io::Result<Option<Self>> {
         let path = Self::index_path(dir, label, prop);
-        if !path.exists() {
-            return Ok(None);
+        match Self::read_index(&path)? {
+            LoadOutcome::Absent => Ok(None),
+            LoadOutcome::Loaded(idx) => Ok(Some(*idx)),
+            LoadOutcome::Undecodable(reason) => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "HNSW index {} is corrupt ({reason}); the file has been left in place \
+                     for inspection.",
+                    path.display()
+                ),
+            )),
+            LoadOutcome::Inconsistent(reason) => Err(Self::inconsistent_error(&path, &reason)),
+            LoadOutcome::Unreadable(reason) => Err(Self::unreadable_error(&path, &reason)),
         }
-        let bytes = std::fs::read(&path)?;
+    }
 
-        let decoded = if bytes.len() >= HNSW_HEADER_LEN && &bytes[..8] == HNSW_MAGIC {
-            Self::decode_v2(&bytes)
-        } else {
-            Self::decode_legacy(&bytes).map(|idx| (idx, 0u64))
-        };
-
-        let (mut idx, generation) = match decoded {
-            Ok(v) => v,
-            Err(reason) => {
-                // The bytes themselves are damaged.  Move them aside: they are
-                // the only surviving copy of the vectors, and a caller that
-                // reads a load failure as "no index here" would otherwise let
-                // the next save() replace them with an empty index.
+    /// Load the index, **quarantining** bytes that fail to decode: the file is
+    /// renamed to `<path>.corrupt.<unix_millis>` before the error is returned.
+    ///
+    /// Quarantine exists because the damaged bytes are the only surviving copy
+    /// of the vectors — an HNSW index is not derived state and cannot be rebuilt
+    /// from column data — and a caller that reads a load failure as "no index
+    /// here" would otherwise let the next `save()` replace them with an empty
+    /// index.
+    ///
+    /// This is therefore for the **open path only**.  Readers and diagnostics
+    /// must use [`VectorIndex::load`]; see #456 for what happens when they do
+    /// not.
+    ///
+    /// Only *undecodable* bytes are moved.  A file that decodes cleanly and then
+    /// fails the structural check is left in place: it may well be repairable by
+    /// hand, and the generation check in `save()` already stops an empty index
+    /// from replacing it.  A directory entry whose contents cannot be read at
+    /// all (a dangling symlink) is also left alone — there are no bytes to
+    /// preserve, so renaming it would destroy evidence and protect nothing.
+    pub fn load_and_quarantine(
+        dir: &Path,
+        label: &str,
+        prop: &str,
+    ) -> std::io::Result<Option<Self>> {
+        let path = Self::index_path(dir, label, prop);
+        match Self::read_index(&path)? {
+            LoadOutcome::Absent => Ok(None),
+            LoadOutcome::Loaded(idx) => Ok(Some(*idx)),
+            LoadOutcome::Undecodable(reason) => {
                 let quarantined = Self::quarantine(&path);
-                return Err(std::io::Error::new(
+                Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
                     format!(
                         "HNSW index {} is corrupt ({reason}); the damaged file was preserved as {}",
@@ -578,29 +639,83 @@ impl VectorIndex {
                             .map(|p| p.display().to_string())
                             .unwrap_or_else(|| "<quarantine failed>".to_owned()),
                     ),
-                ));
+                ))
             }
+            LoadOutcome::Inconsistent(reason) => Err(Self::inconsistent_error(&path, &reason)),
+            LoadOutcome::Unreadable(reason) => Err(Self::unreadable_error(&path, &reason)),
+        }
+    }
+
+    fn inconsistent_error(path: &Path, reason: &str) -> std::io::Error {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "HNSW index {} decoded but is internally inconsistent ({reason}); \
+                 refusing to serve it. The file has been left in place for inspection.",
+                path.display()
+            ),
+        )
+    }
+
+    fn unreadable_error(path: &Path, reason: &str) -> std::io::Error {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "HNSW index {} is present but its bytes could not be read ({reason}); \
+                 refusing to treat it as absent. The entry has been left in place \
+                 for inspection.",
+                path.display()
+            ),
+        )
+    }
+
+    /// Read, decode and validate the file at `path`, touching nothing.
+    ///
+    /// The single place that knows how to turn bytes into an index; `load` and
+    /// `load_and_quarantine` differ only in what they do with the rejecting
+    /// outcomes.
+    fn read_index(path: &Path) -> std::io::Result<LoadOutcome> {
+        let bytes = match std::fs::read(path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // `read` follows symlinks, so a symlink whose target is gone
+                // reports NotFound even though the directory entry is sitting
+                // right there.  `symlink_metadata` does not follow, so it still
+                // sees it.  Reporting that as "absent" is exactly the
+                // present-but-treated-as-absent failure #445 exists to kill
+                // (#456, third sub-finding): the pair silently becomes "no
+                // index configured" and every write for it is dropped.
+                return Ok(match std::fs::symlink_metadata(path) {
+                    Ok(_) => LoadOutcome::Unreadable(
+                        "the directory entry exists but resolving it failed — most likely a \
+                         symbolic link whose target has been removed"
+                            .to_owned(),
+                    ),
+                    Err(_) => LoadOutcome::Absent,
+                });
+            }
+            Err(e) => return Err(e),
         };
 
-        // Structural validation.  Unlike a checksum failure this is *not*
-        // quarantined: the bytes decoded cleanly, so the file may well be
-        // recoverable by hand, and the generation check in `save()` already
-        // stops an empty index from replacing it.
+        let decoded = if bytes.len() >= HNSW_HEADER_LEN && &bytes[..8] == HNSW_MAGIC {
+            Self::decode_v2(&bytes)
+        } else {
+            Self::decode_legacy(&bytes).map(|idx| (idx, 0u64))
+        };
+
+        let (mut idx, generation) = match decoded {
+            Ok(v) => v,
+            Err(reason) => return Ok(LoadOutcome::Undecodable(reason)),
+        };
+
         if let Err(reason) = idx.validate_invariants() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!(
-                    "HNSW index {} decoded but is internally inconsistent ({reason}); \
-                     refusing to serve it. The file has been left in place for inspection.",
-                    path.display()
-                ),
-            ));
+            return Ok(LoadOutcome::Inconsistent(reason));
         }
 
         // Restore derived field `ml` that was skipped during serialization.
         idx.ml = 1.0 / (idx.m as f64).ln();
         idx.disk_generation.set(generation);
-        Ok(Some(idx))
+        Ok(LoadOutcome::Loaded(Box::new(idx)))
     }
 
     /// Check the structural invariants every well-formed index satisfies.
@@ -723,6 +838,8 @@ impl VectorIndex {
 
     /// Move a damaged index file aside so the bytes are not lost to the next
     /// `save()`.  Returns the quarantine path on success.
+    ///
+    /// Reached only from [`VectorIndex::load_and_quarantine`] (#456).
     fn quarantine(path: &Path) -> Option<PathBuf> {
         let stamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/crates/sparrowdb/Cargo.toml
+++ b/crates/sparrowdb/Cargo.toml
@@ -31,6 +31,9 @@ serde_json      = { workspace = true }
 criterion       = { workspace = true }
 crc32fast       = { workspace = true }
 sparrowdb-bench = { path = "../sparrowdb-bench" }
+# Test-only: regression_456 counts `tracing::warn!` events to prove a damaged
+# index warns once per incident rather than once per scanned row.
+tracing-subscriber = { workspace = true }
 
 [[bin]]
 name = "sparrowdb-mcp"

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -9,7 +9,7 @@ use crate::helpers::{
     build_label_row_counts_from_disk, collect_maintenance_params, dir_size_bytes, eval_expr_merge,
     expr_to_value, expr_to_value_with_params, fnv1a_col_id, is_edge_delete_mutation,
     is_reserved_label, literal_to_value, load_constraints, load_vector_indexes, open_csr_map,
-    save_constraints, storage_value_to_exec, try_open_csr_map,
+    save_constraints, storage_value_to_exec, try_open_csr_map, VectorIndexHealth,
 };
 use crate::read_tx::ReadTx;
 use crate::types::{DbInner, NodeVersions, PendingOp, VersionStore, WriteBuffer, WriteGuard};
@@ -26,7 +26,7 @@ use sparrowdb_storage::wal::codec::WalPayload;
 use sparrowdb_storage::wal::writer::WalWriter;
 use sparrowdb_storage::wal::WalReplayer;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use tracing::{info_span, warn};
@@ -72,12 +72,17 @@ impl GraphDb {
     ///
     /// Besides the usual I/O and WAL-replay failures, this returns
     /// [`Error::Corruption`] when a persisted vector index file exists under
-    /// `<path>/vector_indexes/` but cannot be loaded.  Opening anyway would
-    /// silently drop every subsequent vector write for that `(label, prop)` and
-    /// return nothing for every search, so the database refuses to open instead.
-    /// Use [`GraphDb::vector_index_load_failures`] to find out which files are
-    /// at fault.  A database with *no* vector index files is unaffected —
-    /// absent is not the same as damaged.
+    /// `<path>/vector_indexes/` but cannot be loaded — or when that directory
+    /// exists and cannot be listed at all, which is the same condition seen
+    /// from further away.  Opening anyway would silently drop every subsequent
+    /// vector write for that `(label, prop)` and return nothing for every
+    /// search, so the database refuses to open instead.
+    ///
+    /// The error names **every** file at fault, not just the first: two damaged
+    /// indexes used to cost three restarts to get past, each naming only one of
+    /// them (#456).  [`GraphDb::vector_index_load_failures`] re-derives the same
+    /// report without opening.  A database with *no* vector index files is
+    /// unaffected — absent is not the same as damaged.
     pub fn open(path: &Path) -> Result<Self> {
         std::fs::create_dir_all(path)?;
         let wal_dir = path.join("wal");
@@ -2180,22 +2185,43 @@ impl GraphDb {
         Ok(())
     }
 
-    /// Report every persisted vector index under `path` whose bytes are
-    /// damaged.  Each entry is `(label, prop, path, reason)`, sorted for
-    /// determinism.
+    /// Cheap health report for the vector indexes under `path`: directory
+    /// metadata only, no index contents read, nothing mutated.
+    ///
+    /// This is the call for a poll loop.  Its cost is independent of index size,
+    /// so it is safe at any frequency.  [`GraphDb::vector_index_load_failures`]
+    /// is the deep counterpart: it additionally deserialises and validates every
+    /// live index, which for an 8 MB index polled hourly is 8 MB of I/O and a
+    /// full HNSW graph rebuild an hour spent confirming that nothing is wrong.
+    ///
+    /// Check [`VectorIndexHealth::unscannable`] before drawing any conclusion
+    /// from the result: a directory that could not be listed reports no damage
+    /// because nothing was observed, not because nothing is wrong.
+    /// [`VectorIndexHealth::is_healthy`] already accounts for that.
+    ///
+    /// What this tier sees: quarantine artifacts (split into `active` and
+    /// `historical` by whether something now serves the pair) and live entries
+    /// that do not resolve.  What it does not: whether a live index still
+    /// decodes.  That is sound for a *running* store, because [`GraphDb::open`]
+    /// loads and validates every live index and refuses to start when one fails
+    /// — a store that is up has had every live file verified already.
+    pub fn vector_index_health(path: &Path) -> VectorIndexHealth {
+        crate::helpers::vector_index_health(path)
+    }
+
+    /// Deep health report for the vector indexes under `path`: everything
+    /// [`GraphDb::vector_index_health`] reports, plus a real load and structural
+    /// validation of every live index file.
     ///
     /// This never returns `Err`, so it can be called on a database that refuses
     /// to open — it is the diagnostic side of the fail-closed policy in
-    /// [`GraphDb::open`]. An empty result means no damage is present, which
-    /// includes the ordinary case of a database with no vector indexes at all.
-    /// That is the distinction the loader used to collapse: an **absent** index
-    /// file means "no index configured" and is not an error, while a damaged
-    /// one is reported here.
+    /// [`GraphDb::open`], and answers "which file is the problem, and why?".
+    /// Use it from an operator's hands or a failed-start path, not a poll loop.
     ///
     /// Damage is reported in both the places it can live:
     ///
-    /// * a live `hnsw_<label>_<prop>.bin` that will not load — these also make
-    ///   `open` fail;
+    /// * a live `hnsw_<label>_<prop>.bin` that will not resolve or will not load
+    ///   — these also make `open` fail;
     /// * a `hnsw_<label>_<prop>.bin.corrupt.<millis>` artifact that a previous
     ///   load attempt rejected and moved aside (#442) — `open` succeeds once a
     ///   file has been quarantined, so this is the *only* remaining signal that
@@ -2206,16 +2232,16 @@ impl GraphDb {
     /// and whose vector writes are therefore being dropped — the same silent
     /// failure this API exists to eliminate.
     ///
-    /// The `path` is exact. The `reason` for a quarantine artifact is
-    /// reconstructed rather than recovered: the original decode failure is
-    /// reported only in the error returned at quarantine time and is not
-    /// persisted to disk.
+    /// The `path` of every entry is exact and resolves.  The `reason` for a
+    /// quarantine artifact is reconstructed rather than recovered: the original
+    /// decode failure is reported only in the error returned at quarantine time
+    /// and is not persisted to disk.
     ///
-    /// Note that this is not a read-only call when composed with #442: probing
-    /// a live entry may quarantine it. See the crate-internal
-    /// `helpers::vector_index_load_failures` for why that does not change the
-    /// result you observe.
-    pub fn vector_index_load_failures(path: &Path) -> Vec<(String, String, PathBuf, String)> {
+    /// This call is **read-only** (#456). It probes live entries without
+    /// quarantining them, so running it twice gives the same answer as running
+    /// it once, and the `path` it reports still resolves when you receive it
+    /// (#455).
+    pub fn vector_index_load_failures(path: &Path) -> VectorIndexHealth {
         crate::helpers::vector_index_load_failures(path)
     }
 

--- a/crates/sparrowdb/src/helpers.rs
+++ b/crates/sparrowdb/src/helpers.rs
@@ -364,23 +364,69 @@ enum IndexFile {
 
 /// Take one snapshot of `<dir>` and classify every recognised entry.
 ///
-/// A single `read_dir` pass matters. `VectorIndex::load` quarantines the file
-/// it rejects, so probing a live entry can *create* a quarantine artifact while
-/// we are working; snapshotting first means such an artifact cannot also be
-/// picked up in the same call and reported twice.
+/// A single `read_dir` pass matters on the open path: `load_and_quarantine`
+/// renames the file it rejects, so probing a live entry can *create* a
+/// quarantine artifact while we are working; snapshotting first means such an
+/// artifact cannot also be picked up in the same call and reported twice.
+/// (Since #456 the diagnostic uses the non-destructive `load` and cannot create
+/// artifacts at all, but the open path still can.)
 ///
 /// Results are sorted so callers get a deterministic order regardless of
 /// directory iteration order.
 ///
-/// Returns an empty vector when the directory does not exist (a database that
-/// has never had a vector index created).
-fn scan_vector_index_dir(dir: &Path) -> Vec<IndexFile> {
-    let mut found = Vec::new();
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return found;
+/// # "Nothing here" and "cannot tell" are different answers (#456)
+///
+/// `Ok(vec![])` means the directory was read and holds no recognised entry —
+/// including the ordinary case of a database that never created a vector index,
+/// where the directory does not exist at all.
+///
+/// `Err(reason)` means the directory could **not** be listed: a permission
+/// block, a plain file or dangling symlink sitting where the directory belongs,
+/// an I/O error.  This used to collapse into the same empty vector, so a
+/// `chmod 000` on `vector_indexes/` produced a result byte-identical to a
+/// genuinely healthy store.  A monitor could not distinguish green from blind,
+/// and a misconfigured service account or a transient mount failure during a
+/// poll reported "healthy".
+fn scan_vector_index_dir(dir: &Path) -> std::result::Result<Vec<IndexFile>, String> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        // An absent directory is the ordinary "no vector index was ever
+        // created" state.  `symlink_metadata` does not follow links, so a
+        // dangling symlink in the directory's place is *not* absent — it lands
+        // in the arm below, where it belongs.
+        Err(e)
+            if e.kind() == std::io::ErrorKind::NotFound
+                && std::fs::symlink_metadata(dir).is_err() =>
+        {
+            return Ok(Vec::new())
+        }
+        Err(e) => {
+            return Err(format!(
+                "{} could not be listed ({e}); the contents of this database's vector \
+                 index directory are unknown, so the absence of reported damage means \
+                 nothing was observed, not that nothing is wrong",
+                dir.display()
+            ))
+        }
     };
-    for entry in entries.flatten() {
+    let mut found = Vec::new();
+    for entry in entries {
+        // A per-entry error is the same blindness at a finer grain: we know
+        // something is there and cannot say what.
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                return Err(format!(
+                    "an entry in {} could not be read ({e}); the listing is incomplete, \
+                     so no conclusion about damage can be drawn from it",
+                    dir.display()
+                ))
+            }
+        };
         let name = entry.file_name();
+        // Our own names are ASCII by construction (`index_path` sanitises), so a
+        // non-UTF-8 name cannot be an index of ours and is genuinely not ours to
+        // report on.
         let Some(name) = name.to_str() else { continue };
         if let Some(stem) = name.strip_suffix(".bin") {
             if let Some((label, prop)) = parse_index_stem(stem) {
@@ -397,7 +443,7 @@ fn scan_vector_index_dir(dir: &Path) -> Vec<IndexFile> {
         }
     }
     found.sort_by(|a, b| sort_key(a).cmp(&sort_key(b)));
-    found
+    Ok(found)
 }
 
 fn sort_key(f: &IndexFile) -> (&str, &str, &Path) {
@@ -440,17 +486,33 @@ fn sort_key(f: &IndexFile) -> (&str, &str, &Path) {
 /// taken out of service, so they must not hold the database hostage on every
 /// subsequent start.  They stay visible through
 /// [`vector_index_load_failures`] instead.
+///
+/// # Every damaged file is probed, not just the first (#456)
+///
+/// This used to `return` on the first `Err`, so exactly one bad file was probed
+/// — and therefore quarantined — per `open()`.  With two damaged indexes that
+/// cost three restarts to reach a database that opens, and the operator saw one
+/// index named per attempt while the other stayed invisible.  The loop now runs
+/// to completion and reports every failure in one error, so a single failed
+/// `open` tells the operator the full extent of the damage.
 pub(crate) fn load_vector_indexes(db_root: &Path) -> crate::Result<crate::types::VectorIndexMap> {
     let dir = db_root.join("vector_indexes");
     let mut map: crate::types::VectorIndexMap = HashMap::new();
-    for (label, prop) in scan_vector_index_dir(&dir)
-        .into_iter()
-        .filter_map(|f| match f {
-            IndexFile::Live { label, prop } => Some((label, prop)),
-            IndexFile::Quarantined { .. } => None,
-        })
-    {
-        match sparrowdb_storage::VectorIndex::load(&dir, &label, &prop) {
+    let mut failures: Vec<String> = Vec::new();
+    // A directory we cannot list is not a directory we can declare empty.
+    // Opening anyway would mean "no index configured" for every pair that might
+    // be in there, and every vector write for them dropped on the floor — the
+    // silent outage this whole path is fail-closed to prevent (#456).
+    let entries = scan_vector_index_dir(&dir).map_err(Error::Corruption)?;
+    for (label, prop) in entries.into_iter().filter_map(|f| match f {
+        IndexFile::Live { label, prop } => Some((label, prop)),
+        IndexFile::Quarantined { .. } => None,
+    }) {
+        // The open path is the one caller entitled to quarantine: it is about to
+        // take ownership of this `(label, prop)` slot, so a later `save()` here
+        // is what would overwrite the damaged bytes.  Readers use the
+        // non-destructive `load` (#456).
+        match sparrowdb_storage::VectorIndex::load_and_quarantine(&dir, &label, &prop) {
             Ok(Some(idx)) => {
                 map.insert((label, prop), Arc::new(RwLock::new(idx)));
             }
@@ -458,83 +520,323 @@ pub(crate) fn load_vector_indexes(db_root: &Path) -> crate::Result<crate::types:
             // gone — it was removed between the scan and the read.  Nothing was
             // lost that we can observe, so treat it as absent.
             Ok(None) => continue,
-            Err(e) => {
-                return Err(Error::Corruption(format!(
-                    "vector index for ({label}, {prop}) exists at {} but could not be loaded: {e}. \
-                     Refusing to open: continuing would silently drop every vector write for this \
-                     index and return no results for every search. Move the file aside and re-open \
-                     to run without it, then rebuild the index.",
-                    dir.join(format!("hnsw_{label}_{prop}.bin")).display(),
-                )));
-            }
+            Err(e) => failures.push(format!(
+                "({label}, {prop}) at {}: {e}",
+                dir.join(format!("hnsw_{label}_{prop}.bin")).display(),
+            )),
         }
+    }
+    if !failures.is_empty() {
+        return Err(Error::Corruption(format!(
+            "{} vector index file(s) exist but could not be loaded: {}. \
+             Refusing to open: continuing would silently drop every vector write for these \
+             indexes and return no results for every search. Move the files aside and re-open \
+             to run without them, then rebuild the indexes.",
+            failures.len(),
+            failures.join("; "),
+        )));
     }
     Ok(map)
 }
 
-/// Report every vector index whose bytes are damaged, whether they are still
-/// in place or have already been moved aside.  Each entry is
-/// `(label, prop, path, reason)`, sorted for determinism.
+/// One vector index that is not in service, and why.
 ///
-/// Diagnostic counterpart to [`load_vector_indexes`]: it never returns `Err`,
-/// so it can be called on a database that refuses to open in order to find out
-/// *which* files are the problem.  An empty result means no damage is present —
-/// including the ordinary case of a database with no vector indexes at all.
+/// `path` names bytes that are actually on disk when the report is handed to
+/// you — the machine-readable field, and the one a caller can act on.  `reason`
+/// is prose: for a live file it is the loader's own error, for a quarantine
+/// artifact it is reconstructed, because #442 records the decode failure only in
+/// the `io::Error` it returns at quarantine time and writes no sidecar.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VectorIndexFailure {
+    /// Node label the index belongs to.
+    pub label: String,
+    /// Property the index is built on.
+    pub prop: String,
+    /// The file these findings are about.  Exact, and it resolves.
+    pub path: PathBuf,
+    /// Human-readable explanation.  Not machine-parseable; not stable.
+    pub reason: String,
+}
+
+/// What an inspection of `<db_root>/vector_indexes/` observed.
 ///
-/// Two kinds of damage are reported, because #442 leaves damage in two
-/// different places and reporting only one of them recreates the very defect
-/// this function exists to prevent:
+/// The three fields exist because a health report has three distinct things to
+/// say and collapsing any two of them has already cost this project an incident:
 ///
-/// * **Live but unloadable** — `hnsw_<label>_<prop>.bin` is present and
-///   `VectorIndex::load` rejects it.  `open` fails on these.  #442 quarantines
-///   *some* of them (bad magic/length/CRC) but deliberately not all: a file
-///   that decodes cleanly and then fails `validate_invariants` is left in place
-///   for inspection, so it stays visible here as a live entry.
-/// * **Already quarantined** — `hnsw_<label>_<prop>.bin.corrupt.<millis>`, the
-///   bytes a previous load attempt rejected and renamed aside (#442).  `open`
-///   succeeds once a file has been quarantined, because the damaged bytes are
-///   out of service; without this arm the *only* remaining evidence of the
-///   damage would be invisible, and a health check built on this call would
-///   report a clean bill on exactly the database whose vectors are gone.
+/// * `unscannable` — "I could not look."  Distinct from "I looked and found
+///   nothing," which is what the old `Vec` return said in both cases.
+/// * `active` — unrecovered damage.  This is what a monitor should alert on.
+/// * `historical` — damage that has since been recovered from.  Forensics, not
+///   an alarm.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct VectorIndexHealth {
+    /// `Some(reason)` when `vector_indexes/` could not be listed at all, in
+    /// which case `active` and `historical` are empty **for lack of
+    /// observation, not lack of damage**.
+    ///
+    /// A `chmod 000` on the directory, a plain file where the directory belongs,
+    /// a dangling symlink, a transient mount failure during a poll: each used to
+    /// return an empty vector byte-identical to a genuinely healthy store, so a
+    /// monitor could not tell green from blind.  Check this field before
+    /// concluding anything from the other two.
+    pub unscannable: Option<String>,
+    /// Damage that is still unrecovered: the vectors for these pairs are not in
+    /// service, and writes to them are being dropped.  Alert on this.
+    pub active: Vec<VectorIndexFailure>,
+    /// Quarantine artifacts whose `(label, prop)` has since been rebuilt — a
+    /// working index now serves the pair, so the artifact is debris.
+    ///
+    /// Reported separately rather than suppressed because #442 records no reason
+    /// at quarantine time, which makes the artifact the only surviving evidence
+    /// that the incident happened at all.  A monitor ignores this field; an
+    /// operator investigating "when did we lose vectors for this pair?" needs it.
+    ///
+    /// This is the field that decides whether the report is usable as an alarm.
+    /// Artifacts are never cleaned up automatically, so a report that keeps
+    /// naming a repaired pair can only ever go from green to red with no path
+    /// back — and an alert that never clears after the problem is fixed trains
+    /// people to ignore it, which is worse than no alert, because the attention
+    /// has been spent and nothing was bought with it.
+    pub historical: Vec<VectorIndexFailure>,
+}
+
+impl VectorIndexHealth {
+    /// True only when the directory was successfully scanned **and** no
+    /// unrecovered damage was found.
+    ///
+    /// An `unscannable` report is never healthy: not knowing is not the same as
+    /// being fine.
+    pub fn is_healthy(&self) -> bool {
+        self.unscannable.is_none() && self.active.is_empty()
+    }
+}
+
+/// How hard to look.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Depth {
+    /// Directory metadata only: names, plus one `stat` per live entry to
+    /// confirm it resolves.  No file *contents* are ever read, so the cost is
+    /// independent of index size.
+    Names,
+    /// Additionally deserialise and structurally validate every live index.
+    Contents,
+}
+
+/// Cheap health report: directory metadata only, no index contents read.
 ///
-/// The `reason` for a quarantined artifact is reconstructed, not recovered:
-/// #442 records the decode failure only in the `io::Error` it returns at
-/// quarantine time and writes no sidecar, so the original message is not
-/// recoverable from disk afterwards.  The path is exact.
+/// # Why the cheap tier exists (#456)
+///
+/// The deep tier fully deserialises every **healthy** index on every call.  For
+/// KMSmcp's 8 MB `Knowledge.embedding` index, polled hourly, that is 8 MB of
+/// I/O and a complete HNSW graph rebuild an hour spent to confirm that nothing
+/// is wrong.  The mutation this issue is named for was a correctness problem in
+/// an edge case; this is a permanent cost in the common case, and it is the
+/// reason the split holds even for someone who thinks the mutation was
+/// acceptable.
+///
+/// This tier is safe at any poll frequency: zero mutation, zero content I/O.
+///
+/// # What it can and cannot see
+///
+/// It reports quarantine artifacts (reconciled against live files, see
+/// [`VectorIndexHealth::historical`]) and live entries that do not resolve.  It
+/// does **not** verify that a live index still decodes.
+///
+/// That is the right trade for monitoring a *running* store, and the reason is
+/// structural rather than convenient: `open` loads and validates every live
+/// index, and refuses to start when one fails.  A store that is up has already
+/// had every live file verified, and the residual question a monitor is asking
+/// is "did we quarantine something and lose vectors?" — which is exactly what
+/// this answers, without reading a byte of payload.
+///
+/// It cannot tell you why a database refuses to *open*.  `open`'s own error
+/// names every damaged file and its reason; [`vector_index_load_failures`]
+/// re-derives the same thing without opening.
+pub(crate) fn vector_index_health(db_root: &Path) -> VectorIndexHealth {
+    health(db_root, Depth::Names)
+}
+
+/// Deep health report: everything [`vector_index_health`] reports, plus a real
+/// load and structural validation of every live index file.
+///
+/// This is the "why will this database not open, and which file is it?" call.
+/// Use it from an operator's hands, from a failed-start path, or from a
+/// deliberate integrity check — not from a poll loop, because it deserialises
+/// every healthy index it finds.
+///
+/// It never returns `Err`, so it can be called on a database that refuses to
+/// open.
 ///
 /// # Side effects
 ///
-/// Not read-only when composed with #442: probing a live entry calls
-/// `VectorIndex::load`, which quarantines the file it rejects.  That is the
-/// intended behaviour of quarantine — it protects the only surviving copy of
-/// the vectors from the next `save()` — and the observable result of this
-/// function is unchanged by it, since a file that is quarantined during one
-/// call is reported as a quarantine artifact by the next.
-pub(crate) fn vector_index_load_failures(db_root: &Path) -> Vec<(String, String, PathBuf, String)> {
+/// None.  Read-only since #456: live entries are probed with the
+/// non-destructive [`sparrowdb_storage::VectorIndex::load`], and the
+/// quarantining variant is reserved for the open path.  Two consequences:
+///
+/// * A health check that runs twice gets the same answer as one that runs once,
+///   and neither run changes the store.  It used to quarantine on the first
+///   call, so the second call answered differently — and the first call was the
+///   one that caused the change.
+/// * The `path` of a live-arm entry still resolves when the caller receives it
+///   (#455).  It used to name the `.bin` that the same probe had already
+///   renamed away, so `exists(path)` — the obvious sanity check, and the one a
+///   health check would use to confirm damage is real — was `false` on the very
+///   first, most-acted-on report.
+///
+/// For the record, the pre-#456 mutation was idempotent: a given damaged file
+/// was quarantined once and repeat polls did no further I/O.  It destroyed
+/// exactly once per incident — silently, from something shaped like a getter.
+pub(crate) fn vector_index_load_failures(db_root: &Path) -> VectorIndexHealth {
+    health(db_root, Depth::Contents)
+}
+
+/// Shared implementation of both tiers.
+///
+/// Damage is reported in two places because #442 leaves it in two places, and
+/// reporting only one of them recreates the very defect this exists to prevent:
+///
+/// * **Live but not serving** — `hnsw_<label>_<prop>.bin` is present and either
+///   does not resolve (a dangling symlink) or, at `Depth::Contents`, does not
+///   load.  `open` fails on these.  #442 quarantines *some* of them (bad
+///   magic/length/CRC) but deliberately not all: a file that decodes cleanly and
+///   then fails `validate_invariants` is left in place for inspection, so it
+///   stays visible here as a live entry.
+/// * **Quarantined** — `hnsw_<label>_<prop>.bin.corrupt.<millis>`, the bytes a
+///   previous load attempt rejected and renamed aside (#442).  `open` succeeds
+///   once a file has been quarantined, because the damaged bytes are out of
+///   service; without this arm the *only* remaining evidence of the damage would
+///   be invisible, and a health check built on this call would report a clean
+///   bill on exactly the database whose vectors are gone (#450).
+///
+/// An artifact is `active` while its pair has nothing serving it and
+/// `historical` once something does.  #450 is the case where the artifact is
+/// the *only* file for the pair — still `active`, still alarming.  What changed
+/// is only the case where a working index sits beside it.
+///
+/// The limit, stated plainly: neither tier can tell whether a rebuilt index
+/// contains everything the artifact held.  Nothing can — the artifact does not
+/// decode, which is why it is an artifact.  Completeness after a deliberate
+/// rebuild is not a property this call is able to assert, and staying red
+/// forever would not have asserted it either.
+fn health(db_root: &Path, depth: Depth) -> VectorIndexHealth {
     let dir = db_root.join("vector_indexes");
-    let mut failures = Vec::new();
-    for entry in scan_vector_index_dir(&dir) {
-        match entry {
-            IndexFile::Live { label, prop } => {
-                if let Err(e) = sparrowdb_storage::VectorIndex::load(&dir, &label, &prop) {
-                    let path = dir.join(format!("hnsw_{label}_{prop}.bin"));
-                    failures.push((label, prop, path, e.to_string()));
-                }
-            }
-            IndexFile::Quarantined { label, prop, path } => {
-                let reason = format!(
-                    "index file was rejected by a previous load attempt and preserved as {} \
-                     (#442 quarantine). The vectors it held are not in service and cannot be \
-                     rebuilt from column data; the original decode failure is not recorded on \
-                     disk. Recover from these bytes or rebuild the index deliberately, then \
-                     remove the artifact to clear this report.",
-                    path.display(),
-                );
-                failures.push((label, prop, path, reason));
+    let entries = match scan_vector_index_dir(&dir) {
+        Ok(entries) => entries,
+        Err(reason) => {
+            return VectorIndexHealth {
+                unscannable: Some(reason),
+                ..Default::default()
             }
         }
+    };
+
+    // Pass 1 — live entries.  Nothing here renames anything, at either depth.
+    let mut serving: HashSet<(String, String)> = HashSet::new();
+    let mut active: Vec<VectorIndexFailure> = Vec::new();
+    for entry in &entries {
+        let IndexFile::Live { label, prop } = entry else {
+            continue;
+        };
+        let path = dir.join(format!("hnsw_{label}_{prop}.bin"));
+
+        // One `stat`, no contents.  `read_dir` listed this name, so the entry is
+        // there; `exists` follows symlinks, so a `false` here means the entry
+        // resolves to nothing.  Classifying that as "absent" — which is what the
+        // loader's old `if !path.exists()` did — is the present-but-treated-as-
+        // absent failure #445 exists to kill: the pair silently becomes "no
+        // index configured" and every write for it is dropped.
+        if !path.exists() {
+            active.push(VectorIndexFailure {
+                label: label.clone(),
+                prop: prop.clone(),
+                path,
+                reason: "a directory entry with this name exists but does not resolve to a \
+                         readable file — most likely a symbolic link whose target has been \
+                         removed. It is not an absent index: the pair is configured, and \
+                         treating it as unconfigured would silently drop every vector write \
+                         for it."
+                    .to_owned(),
+            });
+            continue;
+        }
+
+        match depth {
+            // Present and resolving is as much as this tier claims.  Enough to
+            // reconcile artifacts against, and honest about being no more.
+            Depth::Names => {
+                serving.insert((label.clone(), prop.clone()));
+            }
+            Depth::Contents => match sparrowdb_storage::VectorIndex::load(&dir, label, prop) {
+                Ok(Some(_)) => {
+                    serving.insert((label.clone(), prop.clone()));
+                }
+                // Listed by the scan but gone by the time we read it — removed
+                // underneath us.  Neither serving nor damaged; deliberately not
+                // counted as serving, so an artifact for the same pair is still
+                // reported as active below.
+                Ok(None) => {}
+                Err(e) => active.push(VectorIndexFailure {
+                    label: label.clone(),
+                    prop: prop.clone(),
+                    path,
+                    reason: e.to_string(),
+                }),
+            },
+        }
     }
-    failures
+
+    // Pass 2 — artifacts, split on whether the pair has since been rebuilt.
+    let mut historical: Vec<VectorIndexFailure> = Vec::new();
+    for entry in entries {
+        let IndexFile::Quarantined { label, prop, path } = entry else {
+            continue;
+        };
+        let superseded = serving.contains(&(label.clone(), prop.clone()));
+        let reason = if superseded {
+            format!(
+                "index file was rejected by a previous load attempt and preserved as {} \
+                 (#442 quarantine). A working index now serves this (label, prop), so the \
+                 pair is back in service and these bytes are debris — kept because they are \
+                 the only surviving evidence that the incident happened. Whether the \
+                 rebuilt index holds everything these bytes held cannot be determined: they \
+                 do not decode. Remove the artifact when you are done with it.",
+                path.display(),
+            )
+        } else {
+            format!(
+                "index file was rejected by a previous load attempt and preserved as {} \
+                 (#442 quarantine). The vectors it held are not in service and cannot be \
+                 rebuilt from column data; the original decode failure is not recorded on \
+                 disk. Recover from these bytes or rebuild the index deliberately, then \
+                 remove the artifact to clear this report.",
+                path.display(),
+            )
+        };
+        let failure = VectorIndexFailure {
+            label,
+            prop,
+            path,
+            reason,
+        };
+        if superseded {
+            historical.push(failure);
+        } else {
+            active.push(failure);
+        }
+    }
+
+    // Sorted for determinism: the two passes above would otherwise group all
+    // live failures ahead of all artifacts regardless of name.
+    let by_name = |a: &VectorIndexFailure, b: &VectorIndexFailure| {
+        (&a.label, &a.prop, &a.path).cmp(&(&b.label, &b.prop, &b.path))
+    };
+    active.sort_by(by_name);
+    historical.sort_by(by_name);
+    VectorIndexHealth {
+        unscannable: None,
+        active,
+        historical,
+    }
 }
 
 // ── Storage-size helpers (SPA-171) ────────────────────────────────────────────

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -97,6 +97,10 @@ pub use helpers::fnv1a_col_id;
 /// Escape a Rust `&str` for safe interpolation inside a Cypher single-quoted string.
 pub use helpers::cypher_escape_string;
 
+/// Vector index health reporting — see [`GraphDb::vector_index_health`] and
+/// [`GraphDb::vector_index_load_failures`].
+pub use helpers::{VectorIndexFailure, VectorIndexHealth};
+
 // ── Legacy alias ──────────────────────────────────────────────────────────────
 
 /// Legacy alias kept for backward compatibility with Phase 0 tests.

--- a/crates/sparrowdb/tests/regression_456_load_is_not_destructive.rs
+++ b/crates/sparrowdb/tests/regression_456_load_is_not_destructive.rs
@@ -838,3 +838,101 @@ fn the_cheap_tier_reads_no_index_contents() {
     std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644))
         .expect("restore permissions");
 }
+
+// ── 9. Composition with #453's save() sidecars ───────────────────────────────
+
+/// #453 put two new files next to every index: `<index>.bin.lock`, which it
+/// deliberately never unlinks, and `<index>.bin.tmp.<pid>.<nonce>` staging
+/// files, which a crashed writer leaves behind for good.
+///
+/// Neither is an index. Both live in the directory this PR's scanner classifies
+/// **by file name**, and a scanner that guessed wrong would either refuse to
+/// open a healthy store or report a healthy store as damaged — on every store
+/// that has ever saved a vector, which is all of them.
+///
+/// #442 and #446 each behaved correctly alone and composed into #450, so this
+/// is asserted by execution rather than by reading the two patches side by side.
+#[test]
+fn save_sidecars_from_issue_453_are_not_mistaken_for_indexes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let vdir = root.join("vector_indexes");
+    {
+        let db = GraphDb::open(root).expect("open fresh db");
+        db.create_vector_index("Memory", "embedding", 3, "cosine")
+            .expect("create vector index");
+        let arc = db.get_vector_index("Memory", "embedding").expect("handle");
+        arc.write()
+            .expect("write lock")
+            .insert(7, &[1.0_f32, 0.0, 0.0]);
+        // A real save, so the lock file is created by #453's own code path
+        // rather than by this test guessing at its name.
+        arc.read()
+            .expect("read lock")
+            .save(&vdir, "Memory", "embedding")
+            .expect("persist index");
+    }
+
+    // Hand-derived from #453: `lock_path` appends `.lock` to the index path, so
+    // a store that has saved once holds `hnsw_Memory_embedding.bin.lock`. Assert
+    // it is really there — if #453 ever stops creating it, this test must fail
+    // loudly rather than quietly stop testing anything.
+    let lock = vdir.join("hnsw_Memory_embedding.bin.lock");
+    assert!(
+        lock.is_file(),
+        "fixture precondition: #453's save() must leave {} behind",
+        lock.display()
+    );
+
+    // And a staging file from a writer that died mid-save. `temp_path` appends
+    // `.tmp.<pid>.<nonce>`; the exact pid and nonce do not matter, only the
+    // shape, so plant one directly.
+    let staging = vdir.join("hnsw_Memory_embedding.bin.tmp.99999.0");
+    std::fs::write(&staging, [0xFF_u8; 64]).expect("plant stale staging file");
+    // Plus the pre-#452 fixed name, which #453's sweep still recognises.
+    let legacy_staging = vdir.join("hnsw_Memory_embedding.bin.tmp");
+    std::fs::write(&legacy_staging, [0xFF_u8; 64]).expect("plant legacy staging file");
+
+    // Hand-derived expectation. The scanner recognises exactly two shapes:
+    // a name ending `.bin`, and a name containing `.bin.corrupt.`.
+    //   hnsw_Memory_embedding.bin.lock      -> ends `.lock`, not `.bin`; no `.corrupt.`
+    //   hnsw_Memory_embedding.bin.tmp.99999.0 -> ends `.0`;    no `.corrupt.`
+    //   hnsw_Memory_embedding.bin.tmp       -> ends `.tmp`;    no `.corrupt.`
+    // So all three are ignored, and the only recognised entry is the healthy
+    // live index. Expected at BOTH tiers: 0 active, 0 historical, healthy.
+    for (tier, health) in [
+        ("deep", GraphDb::vector_index_load_failures(root)),
+        ("cheap", GraphDb::vector_index_health(root)),
+    ] {
+        assert_eq!(
+            health.unscannable, None,
+            "{tier}: the directory is perfectly readable"
+        );
+        assert!(
+            health.active.is_empty(),
+            "{tier}: #453's sidecars must not be reported as damage, got {:?}",
+            health.active
+        );
+        assert!(
+            health.historical.is_empty(),
+            "{tier}: and they are not quarantine artifacts either, got {:?}",
+            health.historical
+        );
+        assert!(
+            health.is_healthy(),
+            "{tier}: a store that merely saved a vector must read healthy"
+        );
+    }
+
+    // The other direction: open() must not refuse because of them, and the real
+    // index must still load with its one vector.
+    let db = GraphDb::open(root).expect("sidecars must not make open() fail");
+    let arc = db
+        .get_vector_index("Memory", "embedding")
+        .expect("the healthy index must still load");
+    assert_eq!(
+        arc.read().expect("read lock").len(),
+        1,
+        "one vector was saved, so one must come back"
+    );
+}

--- a/crates/sparrowdb/tests/regression_456_load_is_not_destructive.rs
+++ b/crates/sparrowdb/tests/regression_456_load_is_not_destructive.rs
@@ -1,0 +1,840 @@
+//! Regression guards for #456: `VectorIndex::load` must not modify the store.
+//!
+//! #442 moved the quarantine rename *inside* `VectorIndex::load`, so every
+//! caller inherited a destructive read.  Three non-test callers existed on
+//! `main`; only one of them — the open path — was entitled to mutate:
+//!
+//! | caller | may mutate? |
+//! |---|---|
+//! | `helpers::load_vector_indexes` (open) | yes, intended |
+//! | `helpers::vector_index_load_failures` (diagnostic) | **no** |
+//! | `engine/expr.rs` `hybrid_search` cached loader (query) | **no** |
+//!
+//! The observable defect: a `hybrid_search` **read** against an index damaged
+//! after `open` returned `Ok` with zero hits — no error, no log line — *and*
+//! renamed the last live copy of the index aside as a side effect.  A read
+//! query returned success, returned nothing, and destroyed data.
+//!
+//! The fix splits `load` (non-destructive, returns the error) from
+//! `load_and_quarantine` (renames on failure, open path only), which repairs
+//! the query path and the diagnostic in one change.
+//!
+//! Also guarded here, from the same review:
+//!
+//! * N damaged indexes must not require N failed restarts — one `open` reports
+//!   all of them.
+//! * A stale quarantine artifact must not keep a rebuilt `(label, prop)` red
+//!   forever; it moves to `historical`, where an operator can still see it and
+//!   a monitor can ignore it.
+//! * A dangling symlink must not classify as "no index configured" — the
+//!   present-but-treated-as-absent case #445 exists to kill.
+//! * A `vector_indexes/` directory that cannot be listed must not report the
+//!   same thing a healthy store reports.  A monitor must be able to tell green
+//!   from blind.
+//! * The poll-frequency tier must not read index contents: the deep tier fully
+//!   deserialises every healthy index on every call, which is a permanent cost
+//!   in the common case, not an edge case.
+//!
+//! Every expected value below is derived by hand from the fixture the test
+//! itself builds.  Nothing here is a recording of what the code returns.
+
+use sparrowdb::GraphDb;
+use sparrowdb_execution::Value;
+use sparrowdb_storage::vector_index::VectorIndex;
+use std::path::{Path, PathBuf};
+
+// ── Fixture helpers ───────────────────────────────────────────────────────────
+
+/// Path of the on-disk index file for `(label, prop)` inside a db root.
+///
+/// Hand-derived: `VectorIndex::index_path` (private) formats
+/// `hnsw_{label}_{prop}.bin` under `<db_root>/vector_indexes/`.
+fn index_file(db_root: &Path, label: &str, prop: &str) -> PathBuf {
+    db_root
+        .join("vector_indexes")
+        .join(format!("hnsw_{label}_{prop}.bin"))
+}
+
+/// Every file in `<db_root>/vector_indexes/` whose name contains `.corrupt.`,
+/// i.e. every #442 quarantine artifact.  Empty when the directory is absent.
+fn quarantine_artifacts(db_root: &Path) -> Vec<PathBuf> {
+    let dir = db_root.join("vector_indexes");
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let mut found: Vec<PathBuf> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.contains(".corrupt."))
+        })
+        .collect();
+    found.sort();
+    found
+}
+
+/// Truncate `file` to its first 4 bytes.
+///
+/// Hand-derivation of why this is guaranteed undecodable, independent of which
+/// 4 bytes survive:
+///
+/// * The v2 path requires `len >= 36` (8-byte magic, `version:u32`,
+///   `reserved:u32`, `payload_len:u64`, `generation:u64`, `crc32c:u32`).  4 < 36,
+///   so the v2 decoder is never even reached.
+/// * The legacy path hands the bytes to `bincode`, whose first act is to read
+///   the 8-byte little-endian length prefix of `nodes: Vec<HnswNode>`.  Only 4
+///   bytes exist, so it hits end-of-input immediately.
+///
+/// There is therefore no 4-byte string that decodes into a `VectorIndex`.
+fn truncate_to_4_bytes(file: &Path) {
+    let original = std::fs::metadata(file).expect("stat index file").len();
+    assert!(
+        original > 4,
+        "fixture precondition: a serialised VectorIndex must exceed the 4-byte \
+         truncation point, got {original} bytes"
+    );
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(file)
+        .expect("open index file for truncation")
+        .set_len(4)
+        .expect("truncate index file to 4 bytes");
+}
+
+// ── 1. HEADLINE: a read query neither destroys nor lies ───────────────────────
+
+/// `hybrid_search` against an index damaged *after* `open` must not rename the
+/// file, and must not answer "Ok, zero hits".
+///
+/// The damage is applied without closing the database, exactly as reported, so
+/// open-time validation never sees it and the only code that touches the file
+/// is the query path's own disk read.
+#[test]
+fn hybrid_search_on_an_index_damaged_after_open_neither_renames_nor_reports_zero_hits() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let db = GraphDb::open(root).expect("open fresh db");
+
+    // Fixture: one Doc node, one 3-dimensional cosine vector, no FTS index.
+    db.create_vector_index("Doc", "embedding", 3, "cosine")
+        .expect("create vector index");
+    db.execute("CREATE (d:Doc {dockey: 'only', content: 'alpha'})")
+        .expect("create node");
+    let node_id = match &db
+        .execute("MATCH (n:Doc) WHERE n.dockey = 'only' RETURN id(n) AS nid")
+        .expect("id query")
+        .rows[0][0]
+    {
+        Value::Int64(n) => *n as u64,
+        other => panic!("expected Int64 node id, got {other:?}"),
+    };
+
+    let arc = db.get_vector_index("Doc", "embedding").expect("handle");
+    arc.write()
+        .expect("write lock")
+        .insert(node_id, &[1.0_f32, 0.0, 0.0]);
+    arc.read()
+        .expect("read lock")
+        .save(&root.join("vector_indexes"), "Doc", "embedding")
+        .expect("persist index");
+
+    const QUERY: &str = "RETURN hybrid_search('Doc', 'embedding', 'content', \
+                         [1.0, 0.0, 0.0], 'alpha', 1) AS hits";
+
+    // ── Baseline, hand-derived ──
+    // Vector side: the index holds exactly one vector, so a k*2 = 2 search over
+    // a 1-element index returns exactly that one node id.
+    // Text side: no FTS index was ever created, so `FtsIndex::open` fails and
+    // the text list is empty.
+    // RRF over (one 1-element list, one empty list) yields one fused entry;
+    // `truncate(k = 1)` leaves it at one.  So: exactly one hit, and it is
+    // `node_id`.
+    let baseline = db.execute(QUERY).expect("baseline hybrid_search executes");
+    let baseline_ids = hit_ids(&baseline.rows[0][0]);
+    assert_eq!(
+        baseline_ids,
+        vec![node_id],
+        "fixture precondition: the healthy index must return exactly the one \
+         node that is in it"
+    );
+
+    // ── Damage the file underneath the open database ──
+    let file = index_file(root, "Doc", "embedding");
+    let healthy_len = std::fs::metadata(&file).expect("stat").len();
+    truncate_to_4_bytes(&file);
+    let damaged_bytes = std::fs::read(&file).expect("read damaged file");
+    assert_eq!(
+        damaged_bytes.len(),
+        4,
+        "fixture precondition: the file must now be exactly 4 bytes (was {healthy_len})"
+    );
+
+    // ── The query under test ──
+    //
+    // Hand-derived expectation: the cached copy from the baseline query cannot
+    // be reused, and this is exact rather than probabilistic.  The cache is
+    // validated against `VectorIndex::fingerprint`.  For the healthy v2 file
+    // that is `(generation, crc32c as u64)`, whose second element is at most
+    // `u32::MAX` = 4_294_967_295.  For the 4-byte file the header no longer
+    // fits, so `fingerprint` falls back to `(file_len, mtime_nanos)` =
+    // `(4, nanoseconds since 1970)`, whose second element is on the order of
+    // 1.7e18 — greater than `u32::MAX` for every instant after 1970-01-01
+    // 00:00:04.295.  The two tuples can never compare equal, so the loader is
+    // forced back to disk.
+    let result = db.execute(QUERY).expect("the query itself still executes");
+
+    // (a) The file must still be there, byte-for-byte as we left it.
+    assert!(
+        file.is_file(),
+        "a READ QUERY renamed {} away — this is the data destruction in #456",
+        file.display()
+    );
+    assert_eq!(
+        std::fs::read(&file).expect("re-read the damaged file"),
+        damaged_bytes,
+        "the damaged bytes are the only surviving copy of the vectors; a read \
+         query must leave them exactly as it found them"
+    );
+    assert!(
+        quarantine_artifacts(root).is_empty(),
+        "a read query must not create a quarantine artifact, found {:?}",
+        quarantine_artifacts(root)
+    );
+
+    // (b) The caller must not be told "Ok, zero hits".
+    let value = &result.rows[0][0];
+    assert!(
+        !matches!(value, Value::List(_)),
+        "hybrid_search returned a result list ({value:?}) for an index it could \
+         not read; a caller cannot distinguish that from 'nothing matched'"
+    );
+    assert!(
+        matches!(value, Value::Null),
+        "expected Value::Null — this function's existing failure signal — got {value:?}"
+    );
+}
+
+/// Extract the `node_id` of every hit in a `hybrid_search` return value.
+fn hit_ids(value: &Value) -> Vec<u64> {
+    match value {
+        Value::List(items) => items
+            .iter()
+            .filter_map(|item| match item {
+                Value::Map(kvs) => {
+                    kvs.iter()
+                        .find(|(k, _)| k == "node_id")
+                        .and_then(|(_, v)| match v {
+                            Value::Int64(n) => Some(*n as u64),
+                            _ => None,
+                        })
+                }
+                _ => None,
+            })
+            .collect(),
+        other => panic!("expected a hit list, got {other:?}"),
+    }
+}
+
+// ── 2. One open reports every damaged index, not just the first ───────────────
+
+/// Two damaged indexes must be named by a single failed `open`.
+///
+/// `load_vector_indexes` used to `return` on the first `Err`, so exactly one bad
+/// file was probed — and quarantined — per `open()`.  With two planted that cost
+/// three restarts (Err, Err, then Ok with *both* pairs silently reported as "no
+/// index configured"), and each failed start named only one of them.
+#[test]
+fn one_open_reports_every_damaged_index() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    {
+        let db = GraphDb::open(root).expect("open fresh db");
+        db.create_vector_index("Doc", "embedding", 3, "cosine")
+            .expect("create Doc index");
+        db.create_vector_index("Note", "vec", 3, "cosine")
+            .expect("create Note index");
+    }
+
+    // Both files are persisted by `create_vector_index`; damage both.
+    let doc = index_file(root, "Doc", "embedding");
+    let note = index_file(root, "Note", "vec");
+    truncate_to_4_bytes(&doc);
+    truncate_to_4_bytes(&note);
+
+    let err = match GraphDb::open(root) {
+        Ok(_) => panic!("open must fail while any damaged index file is live"),
+        Err(e) => e.to_string(),
+    };
+
+    // Hand-derived: two files were planted, for two distinct (label, prop)
+    // pairs, and both are undecodable, so one open must account for both.
+    // Pre-fix this message names only `Doc`/`embedding` — the scan is sorted by
+    // (label, prop) and "Doc" < "Note", so the early return fires on Doc and
+    // Note is never probed.
+    for token in ["Doc", "embedding", "Note", "vec"] {
+        assert!(
+            err.contains(token),
+            "the failure must name every damaged index; `{token}` missing from: {err}"
+        );
+    }
+
+    // Hand-derived: the open path quarantines what it rejects, and it rejected
+    // both, so both `.bin` files are gone and exactly two artifacts exist.
+    let artifacts = quarantine_artifacts(root);
+    assert_eq!(
+        artifacts.len(),
+        2,
+        "each damaged file must be quarantined by the same open that reported \
+         it, got {artifacts:?}"
+    );
+    assert!(
+        !doc.exists() && !note.exists(),
+        "both live files moved aside"
+    );
+
+    // Hand-derived: with both sets of bytes out of service, the next open
+    // succeeds — two restarts total, not three.
+    let db = GraphDb::open(root).expect("the next open must succeed");
+    assert!(db.get_vector_index("Doc", "embedding").is_none());
+    assert!(db.get_vector_index("Note", "vec").is_none());
+    drop(db);
+
+    // And the damage stays visible: two artifacts, neither superseded by a live
+    // index, so two failures.
+    let health = GraphDb::vector_index_load_failures(root);
+    assert_eq!(health.unscannable, None, "the directory is readable");
+    assert!(
+        health.historical.is_empty(),
+        "neither pair has been rebuilt, so nothing is merely historical: {:?}",
+        health.historical
+    );
+    assert_eq!(
+        health.active.len(),
+        2,
+        "both quarantined pairs must remain visible, got {:?}",
+        health.active
+    );
+    assert_eq!(
+        health
+            .active
+            .iter()
+            .map(|f| (f.label.as_str(), f.prop.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("Doc", "embedding"), ("Note", "vec")],
+        "results are sorted by (label, prop)"
+    );
+    assert!(!health.is_healthy(), "unrecovered damage is not healthy");
+}
+
+// ── 3. A rebuilt pair is not false-flagged by its own wreckage ────────────────
+
+/// A leftover artifact must not keep a repaired store red forever, **and** must
+/// still alarm on a pair that has no working index, **and** must remain visible
+/// to an operator either way.
+///
+/// Quarantine artifacts are never removed automatically, so a report that keeps
+/// naming a repaired pair can only ever go green -> red with no path back.  An
+/// alert that never clears after the problem is fixed trains people to ignore
+/// it, which is worse than no alert: the attention has been spent and nothing
+/// was bought with it.
+///
+/// The artifact is moved to `historical` rather than suppressed, because #442
+/// records no reason at quarantine time — these bytes are the only surviving
+/// evidence that the incident happened at all.
+#[test]
+fn a_rebuilt_pair_moves_from_active_to_historical() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    {
+        let db = GraphDb::open(root).expect("open fresh db");
+        db.create_vector_index("Memory", "embedding", 3, "cosine")
+            .expect("create vector index");
+        let arc = db.get_vector_index("Memory", "embedding").expect("handle");
+        arc.write()
+            .expect("write lock")
+            .insert(7, &[1.0_f32, 0.0, 0.0]);
+        arc.read()
+            .expect("read lock")
+            .save(&root.join("vector_indexes"), "Memory", "embedding")
+            .expect("persist index");
+    }
+
+    // Wreckage from an earlier incident on the SAME pair, which the operator
+    // has since rebuilt (the live file above).
+    let superseded = root
+        .join("vector_indexes")
+        .join("hnsw_Memory_embedding.bin.corrupt.1712345678901");
+    std::fs::write(&superseded, [0xFF_u8; 32]).expect("plant superseded artifact");
+
+    // Wreckage on a pair with NO live index — real, unrecovered damage.
+    let orphan = root
+        .join("vector_indexes")
+        .join("hnsw_Ghost_vec.bin.corrupt.1712345678902");
+    std::fs::write(&orphan, [0xFF_u8; 32]).expect("plant orphan artifact");
+
+    GraphDb::open(root)
+        .expect("artifacts must never block open")
+        .get_vector_index("Memory", "embedding")
+        .expect("the rebuilt index must load");
+
+    // Hand-derived: two artifacts on disk, one per pair.
+    //   (Memory, embedding) — a live file exists and loads, so the pair is back
+    //     in service and its artifact is debris -> exactly 1 `historical` entry,
+    //     naming `superseded`.
+    //   (Ghost, vec) — no live file at all, so its artifact is the only
+    //     remaining evidence those vectors are gone -> exactly 1 `active` entry,
+    //     naming `orphan`.
+    // Both tiers must agree here: neither conclusion needs a file's contents.
+    for (tier, health) in [
+        ("deep", GraphDb::vector_index_load_failures(root)),
+        ("cheap", GraphDb::vector_index_health(root)),
+    ] {
+        assert_eq!(
+            health.unscannable, None,
+            "{tier}: the directory is readable"
+        );
+        assert_eq!(
+            health.active.len(),
+            1,
+            "{tier}: a rebuilt pair must not stay in `active`, and an \
+             unrecovered one must be there; got {:?}",
+            health.active
+        );
+        assert_eq!(
+            (
+                health.active[0].label.as_str(),
+                health.active[0].prop.as_str()
+            ),
+            ("Ghost", "vec"),
+            "{tier}: the wrong pair was reported active: {:?}",
+            health.active
+        );
+        assert_eq!(
+            health.active[0].path, orphan,
+            "{tier}: the report must name the surviving bytes"
+        );
+        assert_eq!(
+            health.historical.len(),
+            1,
+            "{tier}: the repaired pair's wreckage must stay visible as history, \
+             got {:?}",
+            health.historical
+        );
+        assert_eq!(
+            (
+                health.historical[0].label.as_str(),
+                health.historical[0].prop.as_str()
+            ),
+            ("Memory", "embedding"),
+            "{tier}: wrong pair in history"
+        );
+        assert_eq!(
+            health.historical[0].path, superseded,
+            "{tier}: history must name the artifact an operator would inspect"
+        );
+        assert!(
+            !health.is_healthy(),
+            "{tier}: (Ghost, vec) is still unrecovered, so the store is not healthy"
+        );
+    }
+
+    // And once the orphan is dealt with, the store goes green again with the
+    // history intact — the property an alarm needs and did not have.
+    std::fs::remove_file(&orphan).expect("operator removes the orphan artifact");
+    let after = GraphDb::vector_index_load_failures(root);
+    assert!(
+        after.is_healthy(),
+        "with nothing unrecovered the store must read healthy, got {after:?}"
+    );
+    assert_eq!(
+        after.historical.len(),
+        1,
+        "going green must not erase the forensic trail"
+    );
+
+    assert!(
+        superseded.is_file(),
+        "the diagnostic must not delete anything — the superseded bytes are \
+         still the operator's to inspect"
+    );
+}
+
+// ── 4. The diagnostic is read-only, and its path field is honest (#455) ───────
+
+/// Running the diagnostic twice must give the same answer as running it once,
+/// and the path it reports must resolve when the caller receives it.
+///
+/// Pre-fix the live arm reported the `.bin` path while `load` renamed that very
+/// file during the same probe, so `exists(path)` was false on the first — and
+/// most-acted-on — report, and the second call answered differently.
+#[test]
+fn the_diagnostic_is_read_only_and_reports_a_path_that_resolves() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    {
+        let db = GraphDb::open(root).expect("open fresh db");
+        db.create_vector_index("Memory", "embedding", 3, "cosine")
+            .expect("create vector index");
+    }
+    let file = index_file(root, "Memory", "embedding");
+    truncate_to_4_bytes(&file);
+    let damaged_bytes = std::fs::read(&file).expect("read damaged");
+
+    // Hand-derived, first call: `vector_indexes/` holds exactly one recognised
+    // entry, a live `.bin` for (Memory, embedding) that cannot decode.  So one
+    // failure, from the live arm, whose path is that `.bin`.
+    let first = GraphDb::vector_index_load_failures(root);
+    assert_eq!(first.unscannable, None, "the directory is readable");
+    assert_eq!(
+        first.active.len(),
+        1,
+        "exactly one damaged file, got {:?}",
+        first.active
+    );
+    assert_eq!(
+        (
+            first.active[0].label.as_str(),
+            first.active[0].prop.as_str()
+        ),
+        ("Memory", "embedding")
+    );
+    assert_eq!(
+        first.active[0].path, file,
+        "the live arm must name the live file"
+    );
+    assert!(
+        first.active[0].path.is_file(),
+        "the reported path {} does not resolve — the only machine-readable \
+         field in the report is a lie (#455)",
+        first.active[0].path.display()
+    );
+
+    // Hand-derived: nothing above mutates, so the directory is byte-identical
+    // and the second call must produce an identical report.
+    assert!(
+        quarantine_artifacts(root).is_empty(),
+        "the diagnostic created a quarantine artifact: {:?}",
+        quarantine_artifacts(root)
+    );
+    assert_eq!(
+        std::fs::read(&file).expect("re-read"),
+        damaged_bytes,
+        "the diagnostic must not touch the bytes it is diagnosing"
+    );
+
+    let second = GraphDb::vector_index_load_failures(root);
+    assert_eq!(
+        second, first,
+        "a health check that runs twice must not get a different answer than one \
+         that runs once"
+    );
+}
+
+// ── 5. `load` vs `load_and_quarantine`, at the storage boundary ───────────────
+
+/// The split itself: same verdict, different side effect.
+#[test]
+fn load_leaves_the_file_alone_and_load_and_quarantine_moves_it() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let vdir = dir.path();
+    let mut idx = VectorIndex::new(3, sparrowdb_storage::vector_index::Metric::Cosine);
+    idx.insert(1, &[1.0_f32, 0.0, 0.0]);
+    idx.save(vdir, "L", "p").expect("save");
+
+    let path = vdir.join("hnsw_L_p.bin");
+    truncate_to_4_bytes(&path);
+    let damaged = std::fs::read(&path).expect("read damaged");
+
+    // Hand-derived: 4 bytes cannot decode (see `truncate_to_4_bytes`), so both
+    // entry points must return Err.  `load` leaves the file; only
+    // `load_and_quarantine` renames it.
+    let err = VectorIndex::load(vdir, "L", "p").expect_err("4 bytes cannot decode");
+    assert!(
+        err.to_string().contains("corrupt"),
+        "the error must name the problem, got: {err}"
+    );
+    assert!(path.is_file(), "load() must not move the file");
+    assert_eq!(
+        std::fs::read(&path).expect("re-read"),
+        damaged,
+        "load() must not alter the bytes"
+    );
+
+    // Repeatable, because it is non-destructive.
+    VectorIndex::load(vdir, "L", "p").expect_err("second load must fail the same way");
+    assert!(path.is_file(), "load() is still non-destructive on repeat");
+
+    VectorIndex::load_and_quarantine(vdir, "L", "p").expect_err("still undecodable");
+    assert!(
+        !path.exists(),
+        "load_and_quarantine() must move the damaged file aside"
+    );
+    let artifacts: Vec<PathBuf> = std::fs::read_dir(vdir)
+        .expect("read_dir")
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.contains(".corrupt."))
+        })
+        .collect();
+    assert_eq!(
+        artifacts.len(),
+        1,
+        "exactly one artifact, got {artifacts:?}"
+    );
+    assert_eq!(
+        std::fs::read(&artifacts[0]).expect("read artifact"),
+        damaged,
+        "the quarantined copy must be the damaged bytes, unmodified"
+    );
+}
+
+// ── 6. A dangling symlink is present, not absent ──────────────────────────────
+
+/// `scan_vector_index_dir` classifies by file name, so a symlink named
+/// `hnsw_<label>_<prop>.bin` reads as a live index.  `load` used to begin with
+/// `path.exists()`, which *follows* symlinks and is false for a broken one, so
+/// the loader answered `Ok(None)` — "no index configured".  That is exactly the
+/// present-but-treated-as-absent failure #445 exists to kill: every vector write
+/// for the pair is dropped and every search returns nothing, with no error.
+#[cfg(unix)]
+#[test]
+fn a_dangling_symlink_is_not_mistaken_for_an_absent_index() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let vdir = root.join("vector_indexes");
+    std::fs::create_dir_all(&vdir).expect("create vector_indexes");
+
+    let target = vdir.join("gone.bin");
+    let link = vdir.join("hnsw_Memory_embedding.bin");
+    std::os::unix::fs::symlink(&target, &link).expect("plant dangling symlink");
+
+    // Hand-derived fixture check: the entry is there (lstat succeeds) but does
+    // not resolve (stat fails).  This is the whole premise of the test.
+    assert!(
+        std::fs::symlink_metadata(&link).is_ok(),
+        "fixture precondition: the directory entry must exist"
+    );
+    assert!(
+        !link.exists(),
+        "fixture precondition: the link must not resolve"
+    );
+
+    // Hand-derived: one recognised live entry that cannot be read, therefore
+    // one active failure — never silence.  Both tiers must see it: detecting a
+    // non-resolving entry costs one `stat`, not a payload read.
+    for (tier, health) in [
+        ("deep", GraphDb::vector_index_load_failures(root)),
+        ("cheap", GraphDb::vector_index_health(root)),
+    ] {
+        assert_eq!(
+            health.unscannable, None,
+            "{tier}: the directory is readable"
+        );
+        assert_eq!(
+            health.active.len(),
+            1,
+            "{tier}: a present-but-unreadable entry must be reported, got {:?}",
+            health.active
+        );
+        assert_eq!(
+            (
+                health.active[0].label.as_str(),
+                health.active[0].prop.as_str()
+            ),
+            ("Memory", "embedding"),
+            "{tier}: the report must name the pair whose writes would otherwise vanish"
+        );
+        assert!(
+            !health.is_healthy(),
+            "{tier}: a configured pair that resolves to nothing is not healthy"
+        );
+    }
+
+    // And `open` must refuse rather than start up silently missing the index.
+    match GraphDb::open(root) {
+        Ok(_) => panic!(
+            "open() succeeded with a present-but-unreadable index at {}; the pair \
+             is now silently 'no index configured' and every vector write for it \
+             is dropped",
+            link.display()
+        ),
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                msg.contains("Memory") && msg.contains("embedding"),
+                "the failure must name the pair, got: {msg}"
+            );
+        }
+    }
+
+    // Nothing was renamed: there are no bytes to preserve, so quarantining a
+    // dangling link would only destroy the evidence.
+    assert!(
+        quarantine_artifacts(root).is_empty(),
+        "a dangling symlink must not be quarantined, found {:?}",
+        quarantine_artifacts(root)
+    );
+    assert!(
+        std::fs::symlink_metadata(&link).is_ok(),
+        "the link itself must be left in place for the operator"
+    );
+}
+
+// ── 7. "I could not look" must not read as "nothing is wrong" ────────────────
+
+/// A `vector_indexes/` directory that cannot be listed must not produce a report
+/// byte-identical to a healthy store's.
+///
+/// `read_dir` errors were swallowed into an empty vector, so a permission block
+/// — a misconfigured service account, a transient mount failure during a poll —
+/// answered exactly what a genuinely healthy store answers.  A monitor could not
+/// distinguish green from blind.
+#[cfg(unix)]
+#[test]
+fn an_unlistable_directory_is_not_reported_as_healthy() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    {
+        let db = GraphDb::open(root).expect("open fresh db");
+        db.create_vector_index("Memory", "embedding", 3, "cosine")
+            .expect("create vector index");
+    }
+    let vdir = root.join("vector_indexes");
+
+    // Control: hand-derived, this store is healthy — one live index that loads,
+    // no artifacts, directory readable.
+    let control = GraphDb::vector_index_load_failures(root);
+    assert!(
+        control.is_healthy() && control.unscannable.is_none(),
+        "fixture precondition: the control must be healthy, got {control:?}"
+    );
+
+    std::fs::set_permissions(&vdir, std::fs::Permissions::from_mode(0o000))
+        .expect("chmod 000 the vector index directory");
+
+    // Root ignores the permission bits, so the block would not be real there and
+    // the test would assert something that is not true of the run.  Skip rather
+    // than fail: the property under test cannot be exercised.
+    if std::fs::read_dir(&vdir).is_ok() {
+        std::fs::set_permissions(&vdir, std::fs::Permissions::from_mode(0o755)).ok();
+        eprintln!("skipping: chmod 000 did not block this uid (running as root?)");
+        return;
+    }
+
+    // Hand-derived: the directory exists and cannot be listed, so nothing about
+    // its contents was observed.  `unscannable` must say so, both lists must be
+    // empty (nothing was seen — not nothing is wrong), and the report must not
+    // read as healthy.
+    for (tier, health) in [
+        ("deep", GraphDb::vector_index_load_failures(root)),
+        ("cheap", GraphDb::vector_index_health(root)),
+    ] {
+        assert!(
+            health.unscannable.is_some(),
+            "{tier}: an unlistable directory must say so, got {health:?}"
+        );
+        assert!(
+            health.active.is_empty() && health.historical.is_empty(),
+            "{tier}: nothing was observed, so nothing may be claimed: {health:?}"
+        );
+        assert!(
+            !health.is_healthy(),
+            "{tier}: not knowing is not the same as being fine"
+        );
+        assert_ne!(
+            health, control,
+            "{tier}: blind must not be observationally identical to green"
+        );
+    }
+
+    // And `open` must refuse: a directory we cannot list may hold indexes, and
+    // starting anyway means "no index configured" for every one of them, with
+    // every vector write for them dropped.
+    let opened = GraphDb::open(root);
+    let refused = opened.is_err();
+    // Restore permissions before the assert so the tempdir can always be
+    // cleaned up, whichever way the assert goes.
+    std::fs::set_permissions(&vdir, std::fs::Permissions::from_mode(0o755))
+        .expect("restore permissions");
+    assert!(
+        refused,
+        "open() must not treat an unlistable vector_indexes/ as empty"
+    );
+}
+
+// ── 8. The cheap tier reads no index contents ────────────────────────────────
+
+/// `vector_index_health` must not open index files.
+///
+/// The deep tier fully deserialises every healthy index on every call — for an
+/// 8 MB index polled hourly, 8 MB of I/O and a complete HNSW graph rebuild an
+/// hour spent confirming that nothing is wrong.  That is a permanent cost in the
+/// common case, as opposed to the mutation, which is a correctness problem in an
+/// edge case.  Both argue for the same split; only this one applies when nothing
+/// is damaged at all.
+///
+/// Proving "it did not read the file" directly is not possible from a test, so
+/// this makes the file *unreadable* while leaving it present: `chmod 000` still
+/// permits `stat` (which the cheap tier does) and denies `open` (which only the
+/// deep tier does).  The two tiers must therefore disagree, and that disagreement
+/// is only possible if the cheap tier never opened it.
+#[cfg(unix)]
+#[test]
+fn the_cheap_tier_reads_no_index_contents() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    {
+        let db = GraphDb::open(root).expect("open fresh db");
+        db.create_vector_index("Memory", "embedding", 3, "cosine")
+            .expect("create vector index");
+    }
+    let file = index_file(root, "Memory", "embedding");
+    std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o000))
+        .expect("chmod 000 the index file");
+
+    if std::fs::read(&file).is_ok() {
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).ok();
+        eprintln!("skipping: chmod 000 did not block this uid (running as root?)");
+        return;
+    }
+
+    // Hand-derived, cheap tier: the directory lists one live entry, `stat`
+    // resolves it (permission bits do not affect `stat`), and no contents are
+    // read.  Nothing else is on disk.  So: no active failures, no history,
+    // healthy.
+    let cheap = GraphDb::vector_index_health(root);
+    assert_eq!(cheap.unscannable, None, "the directory itself is readable");
+    assert!(
+        cheap.is_healthy(),
+        "the cheap tier opened the index file — it must not; got {cheap:?}"
+    );
+
+    // Hand-derived, deep tier: it opens the file, `open` fails with EACCES, and
+    // an unreadable live index is a failure, not an absence.  So: exactly one
+    // active entry, naming this pair and this path.
+    let deep = GraphDb::vector_index_load_failures(root);
+    assert_eq!(deep.unscannable, None, "the directory itself is readable");
+    assert_eq!(
+        deep.active.len(),
+        1,
+        "the deep tier must report the file it cannot read, got {:?}",
+        deep.active
+    );
+    assert_eq!(
+        (deep.active[0].label.as_str(), deep.active[0].prop.as_str()),
+        ("Memory", "embedding")
+    );
+    assert_eq!(deep.active[0].path, file);
+
+    std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644))
+        .expect("restore permissions");
+}

--- a/crates/sparrowdb/tests/regression_456_load_is_not_destructive.rs
+++ b/crates/sparrowdb/tests/regression_456_load_is_not_destructive.rs
@@ -936,3 +936,216 @@ fn save_sidecars_from_issue_453_are_not_mistaken_for_indexes() {
         "one vector was saved, so one must come back"
     );
 }
+
+// ── 10. A damaged index is read once per incident, not once per row ──────────
+
+/// `hybrid_search` is a scalar function: it is evaluated once per candidate row.
+/// The success path has been cached against the on-disk fingerprint since #442,
+/// but the *failure* path was not, so a damaged index was re-read and re-decoded
+/// on every row and emitted an identical warning on every row.
+///
+/// For KMSmcp's 8 MB `Knowledge.embedding` index an N-row scan is N x 8 MB of
+/// I/O plus N identical log lines — an I/O storm and a log flood arriving
+/// exactly when the store is already degraded and someone is reading the logs to
+/// find out why. A file that decodes cleanly and then fails
+/// `validate_invariants` paid a full `bincode` decode every row.
+///
+/// The warning count is the observable: row 2 can only skip its warning by
+/// taking the cached path, so `warns == 1` over a 5-row scan is direct evidence
+/// that four rows never touched the file.
+///
+/// The second half is the dangerous half. A cached negative that outlived its
+/// repair would recreate, one layer down, the "fixed but still reports broken"
+/// failure this PR removes from the diagnostic — so the repair must become
+/// visible mid-session, and it is asserted here rather than assumed.
+mod warn_counter {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    pub static HYBRID_WARNS: AtomicUsize = AtomicUsize::new(0);
+    static INIT: std::sync::Once = std::sync::Once::new();
+
+    /// Collects an event's formatted fields so we can tell *our* warning apart
+    /// from any other warning the engine might emit.
+    struct Collect(String);
+
+    impl tracing::field::Visit for Collect {
+        fn record_debug(&mut self, _f: &tracing::field::Field, v: &dyn std::fmt::Debug) {
+            use std::fmt::Write;
+            let _ = write!(self.0, "{v:?} ");
+        }
+    }
+
+    struct Counter;
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for Counter {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            if *event.metadata().level() != tracing::Level::WARN {
+                return;
+            }
+            let mut fields = Collect(String::new());
+            event.record(&mut fields);
+            if fields.0.contains("hybrid_search") {
+                HYBRID_WARNS.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+    }
+
+    /// Install the counting subscriber once for this test binary.
+    ///
+    /// A global subscriber rather than a thread-local one: the query engine is
+    /// free to evaluate rows on a worker thread, and a thread-local default
+    /// would silently count zero there — a test that cannot observe the thing it
+    /// asserts is worse than no test. No other test in this binary produces a
+    /// warning mentioning `hybrid_search`, so the shared counter is unambiguous.
+    pub fn install() {
+        INIT.call_once(|| {
+            use tracing_subscriber::layer::SubscriberExt;
+            let subscriber = tracing_subscriber::registry().with(Counter);
+            let _ = tracing::subscriber::set_global_default(subscriber);
+        });
+    }
+
+    pub fn reset() {
+        HYBRID_WARNS.store(0, Ordering::SeqCst);
+    }
+
+    pub fn count() -> usize {
+        HYBRID_WARNS.load(Ordering::SeqCst)
+    }
+}
+
+#[test]
+fn a_damaged_index_is_read_and_warned_about_once_per_incident_not_once_per_row() {
+    warn_counter::install();
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let db = GraphDb::open(root).expect("open fresh db");
+
+    // Fixture: 5 Doc nodes, each with a vector, one saved index, no FTS index.
+    const ROWS: usize = 5;
+    db.create_vector_index("Doc", "embedding", 3, "cosine")
+        .expect("create vector index");
+    let arc = db.get_vector_index("Doc", "embedding").expect("handle");
+    for i in 0..ROWS {
+        db.execute(&format!(
+            "CREATE (d:Doc {{dockey: 'n{i}', content: 'alpha'}})"
+        ))
+        .expect("create node");
+        let node_id = match &db
+            .execute(&format!(
+                "MATCH (n:Doc) WHERE n.dockey = 'n{i}' RETURN id(n) AS nid"
+            ))
+            .expect("id query")
+            .rows[0][0]
+        {
+            Value::Int64(n) => *n as u64,
+            other => panic!("expected Int64 node id, got {other:?}"),
+        };
+        arc.write()
+            .expect("write lock")
+            .insert(node_id, &[1.0_f32, 0.0, 0.0]);
+    }
+    arc.read()
+        .expect("read lock")
+        .save(&root.join("vector_indexes"), "Doc", "embedding")
+        .expect("persist index");
+
+    // One row per Doc node, and `hybrid_search` is evaluated once per row.
+    //
+    // The `WITH d` is load-bearing, not decoration. Without it the chunked
+    // pipeline serves the scan and never dispatches `hybrid_search` at all —
+    // it returns Null for a perfectly healthy index, which would make this test
+    // pass for entirely the wrong reason. The baseline assertion below is what
+    // catches that: a shape that cannot produce a list when the index is intact
+    // cannot prove anything about what happens when it is damaged.
+    const QUERY: &str = "MATCH (d:Doc) WITH d RETURN hybrid_search('Doc', 'embedding', 'content', \
+                         [1.0, 0.0, 0.0], 'alpha', 3) AS hits";
+
+    // ── Baseline: healthy. Hand-derived: ROWS rows, every value a list. ──
+    let baseline = db.execute(QUERY).expect("baseline executes");
+    assert_eq!(
+        baseline.rows.len(),
+        ROWS,
+        "fixture precondition: one row per Doc node, so the scalar is evaluated \
+         {ROWS} times"
+    );
+    for (i, row) in baseline.rows.iter().enumerate() {
+        assert!(
+            matches!(row[0], Value::List(_)),
+            "fixture precondition: row {i} of a healthy index must be a list, got {:?}",
+            row[0]
+        );
+    }
+
+    let file = index_file(root, "Doc", "embedding");
+    let healthy_bytes = std::fs::read(&file).expect("read healthy index");
+
+    // ── Damage it under the open database. ──
+    truncate_to_4_bytes(&file);
+    warn_counter::reset();
+    let damaged = db.execute(QUERY).expect("the query still executes");
+
+    // Hand-derived. The scalar is evaluated once per row, so {ROWS} times.
+    // Row 1 finds no cache entry matching the new fingerprint, reads the file,
+    // fails, caches the verdict and warns. Rows 2..{ROWS} find that verdict
+    // under an unchanged fingerprint and reuse it without touching the file and
+    // without warning. Expected: {ROWS} Null values, and exactly ONE warning.
+    assert_eq!(
+        damaged.rows.len(),
+        ROWS,
+        "the scan still produces every row"
+    );
+    for (i, row) in damaged.rows.iter().enumerate() {
+        assert!(
+            matches!(row[0], Value::Null),
+            "row {i}: a damaged index must yield Null, not {:?}",
+            row[0]
+        );
+    }
+    assert_eq!(
+        warn_counter::count(),
+        1,
+        "a {ROWS}-row scan against one damaged index must warn once, not once \
+         per row; N identical lines bury the signal at the moment someone is \
+         reading the logs to find out what broke"
+    );
+    // Still non-destructive, and still exactly the bytes we wrote.
+    assert!(file.is_file(), "the read must not have moved the file");
+    assert!(
+        quarantine_artifacts(root).is_empty(),
+        "a read must not quarantine, found {:?}",
+        quarantine_artifacts(root)
+    );
+
+    // ── Repair it mid-session, the way an operator restoring a backup would. ──
+    //
+    // Hand-derived: writing the original image back restores the original
+    // fingerprint, `(generation, crc32c)`, which cannot equal the damaged file's
+    // `(4, mtime_nanos)` fallback — mtime_nanos is ~1.7e18 and crc32c is at most
+    // u32::MAX = 4_294_967_295, so the second elements can never match. The
+    // cached negative therefore cannot be reused, every row must see the
+    // repaired index, and no row may warn.
+    std::fs::write(&file, &healthy_bytes).expect("restore the index");
+    warn_counter::reset();
+    let repaired = db.execute(QUERY).expect("post-repair query executes");
+    assert_eq!(repaired.rows.len(), ROWS);
+    for (i, row) in repaired.rows.iter().enumerate() {
+        assert!(
+            matches!(row[0], Value::List(_)),
+            "row {i}: the repair must be visible immediately — a cached negative \
+             that outlives its repair is the 'fixed but still reports broken' \
+             failure this PR exists to remove, one layer down. Got {:?}",
+            row[0]
+        );
+    }
+    assert_eq!(
+        warn_counter::count(),
+        0,
+        "a repaired index must not warn at all"
+    );
+}

--- a/crates/sparrowdb/tests/vector_index_durability.rs
+++ b/crates/sparrowdb/tests/vector_index_durability.rs
@@ -112,6 +112,11 @@ fn shorter_index_written_over_longer_file_is_rejected_not_silently_truncated() {
 ///
 /// Expected: exactly one `*.corrupt.*` sibling exists afterwards, and it is
 /// byte-identical to the damaged image we wrote.
+///
+/// Since #456 quarantine is opt-in: it belongs to `load_and_quarantine`, the
+/// open path's loader, because that is the caller whose later `save()` would
+/// overwrite the damaged bytes.  Plain `load` is non-destructive — see
+/// `regression_456_load_is_not_destructive.rs`.
 #[test]
 fn rejected_index_file_is_quarantined_rather_than_left_to_be_overwritten() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -129,7 +134,7 @@ fn rejected_index_file_is_quarantined_rather_than_left_to_be_overwritten() {
     damaged[victim] ^= 0xFF;
     std::fs::write(&path, &damaged).expect("write damaged");
 
-    let err = VectorIndex::load(dir.path(), "L", "p")
+    let err = VectorIndex::load_and_quarantine(dir.path(), "L", "p")
         .expect_err("a single flipped payload byte must be detected");
     assert!(
         err.to_string().contains("corrupt"),

--- a/crates/sparrowdb/tests/vector_index_load_errors.rs
+++ b/crates/sparrowdb/tests/vector_index_load_errors.rs
@@ -125,7 +125,7 @@ fn absent_index_and_unloadable_index_are_distinguishable() {
         "absent case: no index was ever created, so there must be no handle"
     );
     assert!(
-        GraphDb::vector_index_load_failures(absent_dir.path()).is_empty(),
+        GraphDb::vector_index_load_failures(absent_dir.path()).is_healthy(),
         "absent case: nothing on disk can have failed to load"
     );
     drop(absent_db);
@@ -143,7 +143,9 @@ fn absent_index_and_unloadable_index_are_distinguishable() {
 
     // The bug being guarded is precisely that these two produced the *same*
     // observable: open() -> Ok, get_vector_index() -> None.
-    let failures = GraphDb::vector_index_load_failures(damaged_dir.path());
+    let health = GraphDb::vector_index_load_failures(damaged_dir.path());
+    assert_eq!(health.unscannable, None, "the directory is readable");
+    let failures = &health.active;
     // Hand-derived: exactly one file was planted, for exactly one (label, prop),
     // so exactly one entry must be reported.
     //
@@ -161,7 +163,7 @@ fn absent_index_and_unloadable_index_are_distinguishable() {
         "expected exactly 1 damaged index, got {failures:?}"
     );
     assert_eq!(
-        (failures[0].0.as_str(), failures[0].1.as_str()),
+        (failures[0].label.as_str(), failures[0].prop.as_str()),
         ("Memory", "embedding"),
         "the reported failure must identify the (label, prop) pair"
     );
@@ -170,9 +172,9 @@ fn absent_index_and_unloadable_index_are_distinguishable() {
     // assertion that would have caught the reported path going stale when the
     // file is renamed out from under it.
     assert!(
-        failures[0].2.is_file(),
+        failures[0].path.is_file(),
         "reported path {} must exist on disk",
-        failures[0].2.display()
+        failures[0].path.display()
     );
 }
 
@@ -229,7 +231,7 @@ fn absent_index_is_not_an_error() {
     let db = GraphDb::open(dir.path()).expect("a db with no vector index must open");
     assert!(db.get_vector_index("Memory", "embedding").is_none());
     assert!(
-        GraphDb::vector_index_load_failures(dir.path()).is_empty(),
+        GraphDb::vector_index_load_failures(dir.path()).is_healthy(),
         "no files at all means no damage to report"
     );
 }
@@ -272,19 +274,19 @@ fn quarantined_corrupt_file_is_not_loaded_but_is_reported() {
     // `hnsw_Memory_embedding.bin.corrupt.1712345678901` to get the stem
     // `hnsw_Memory_embedding`, then split at the last underscore, giving
     // label `Memory` and prop `embedding`.  So exactly one entry.
-    let failures = GraphDb::vector_index_load_failures(dir.path());
+    let failures = GraphDb::vector_index_load_failures(dir.path()).active;
     assert_eq!(
         failures.len(),
         1,
         "the quarantine artifact must be reported, got {failures:?}"
     );
     assert_eq!(
-        (failures[0].0.as_str(), failures[0].1.as_str()),
+        (failures[0].label.as_str(), failures[0].prop.as_str()),
         ("Memory", "embedding"),
         "the report must identify the (label, prop) whose vectors are gone"
     );
     assert_eq!(
-        failures[0].2, artifact,
+        failures[0].path, artifact,
         "the report must name the quarantine path, so the bytes can be recovered"
     );
 }
@@ -327,14 +329,14 @@ fn healthy_and_quarantined_indexes_are_reported_separately() {
         "the quarantined index must not produce a handle"
     );
 
-    let failures = GraphDb::vector_index_load_failures(path);
+    let failures = GraphDb::vector_index_load_failures(path).active;
     assert_eq!(
         failures.len(),
         1,
         "exactly the damaged pair must be reported, got {failures:?}"
     );
     assert_eq!(
-        (failures[0].0.as_str(), failures[0].1.as_str()),
+        (failures[0].label.as_str(), failures[0].prop.as_str()),
         ("Doc", "vec"),
         "the healthy pair must not be reported as damaged"
     );

--- a/npm/sparrowdb/index.d.ts
+++ b/npm/sparrowdb/index.d.ts
@@ -104,6 +104,67 @@ export interface VectorIndexLoadFailure {
   reason: string
 }
 /**
+ * What an inspection of a database's `vector_indexes/` observed — see
+ * `SparrowDB.vectorIndexLoadFailures` and `SparrowDB.vectorIndexDamageScan`.
+ *
+ * ```typescript
+ * interface VectorIndexDamageReport {
+ *   unscannable?: string;                  // present when the directory could not be listed
+ *   active: VectorIndexLoadFailure[];      // unrecovered damage — alert on this
+ *   historical: VectorIndexLoadFailure[];  // recovered-from damage — forensics only
+ *   healthy: boolean;                      // !unscannable && active.length === 0
+ * }
+ * ```
+ *
+ * Not to be confused with the instance method `db.vectorIndexHealth(label,
+ * prop)`, which returns per-index vector reachability counts. This type is
+ * about which index FILES are in service; that one is about how many vectors
+ * inside one healthy file a search can reach.
+ *
+ * Three fields, because a report has three things to say (#456). Before #456
+ * this was a bare `VectorIndexLoadFailure[]`, and `[]` meant all three at once:
+ *
+ * - `unscannable` — `[]` also meant "I could not read the directory". A
+ *   `chmod 000` on `vector_indexes/`, a bad mount during a poll, or a
+ *   misconfigured service account produced output byte-identical to a healthy
+ *   store, so a monitor could not tell green from blind. When this is non-null,
+ *   `active` and `historical` are empty FOR LACK OF OBSERVATION, not lack of
+ *   damage. Check it before concluding anything.
+ * - `historical` — a quarantine artifact whose `(label, prop)` is served again
+ *   by a working index. It used to stay in the one array forever, because #442
+ *   never cleans artifacts up, so a repaired store could go green to red and
+ *   never back. An alert that will not clear after the problem is fixed gets
+ *   muted, and a muted alert is worse than none. Reported rather than
+ *   suppressed because #442 records no reason at quarantine time and writes no
+ *   sidecar: the artifact file is the only surviving evidence of the incident.
+ * - `healthy` — computed natively as `!unscannable && active.length === 0`, so
+ *   a caller cannot get the composition wrong. An unscannable report is NOT
+ *   healthy: not knowing is not the same as being fine.
+ */
+export interface VectorIndexDamageReport {
+  /**
+   * Present when `vector_indexes/` could not be listed; the string says why.
+   * ABSENT (not null) when the scan succeeded — the native layer omits the
+   * property rather than setting it, so test it for truthiness.
+   *
+   * While set, `active` and `historical` are empty because nothing was
+   * observed — not because nothing is wrong.
+   */
+  unscannable?: string
+  /**
+   * Damage that is still unrecovered. The vectors for these pairs are not in
+   * service and writes to them are being dropped. This is the alert.
+   */
+  active: Array<VectorIndexLoadFailure>
+  /**
+   * Quarantine artifacts whose `(label, prop)` a working index now serves.
+   * Forensics for an operator; a monitor ignores this.
+   */
+  historical: Array<VectorIndexLoadFailure>
+  /** `!unscannable && active.length === 0`. Computed natively. */
+  healthy: boolean
+}
+/**
  * Top-level database handle.
  *
  * ```typescript
@@ -125,7 +186,8 @@ export declare class SparrowDB {
    */
   static open(path: string): SparrowDB
   /**
-   * Report every vector index at `path` whose bytes are damaged.
+   * Deep damage report for the vector indexes at `path`: reads and validates
+   * every live index file.
    *
    * **Static**, and deliberately so: the database this diagnoses is usually
    * one that will not open. `open` fails with a `Corruption` error when a
@@ -133,16 +195,20 @@ export declare class SparrowDB {
    * *which* files caused it — so requiring an instance would make it
    * unreachable in the exact situation it exists for.
    *
-   * **Never throws.** An unreadable or absent directory yields `[]`; there
-   * is no configuration of the filesystem that turns the diagnostic itself
-   * into a second failure to diagnose. An empty array therefore means "no
-   * damage found", which includes the ordinary case of a database with no
-   * vector indexes at all.
+   * **Never throws.** There is no configuration of the filesystem that turns
+   * the diagnostic itself into a second failure to diagnose. A directory it
+   * cannot list is reported in `unscannable` rather than raised.
    *
-   * Two kinds of damage are reported:
+   * **Not for a poll loop.** This deserialises every HEALTHY index it finds —
+   * for an 8 MB `Knowledge.embedding` index polled hourly, 8 MB of I/O and a
+   * complete HNSW graph rebuild an hour, spent confirming that nothing is
+   * wrong. Use `SparrowDB.vectorIndexDamageScan` for monitoring and this for
+   * "why will my database not open?".
    *
-   * - **live but unloadable** — `hnsw_<label>_<prop>.bin` is present and
-   *   rejected; `open` fails on these;
+   * Damage is reported in both places it can live:
+   *
+   * - **live but not serving** — `hnsw_<label>_<prop>.bin` is present and
+   *   either does not resolve or does not load; `open` fails on these;
    * - **already quarantined** — `hnsw_<label>_<prop>.bin.corrupt.<millis>`,
    *   bytes a previous load attempt moved aside (#442).
    *
@@ -152,19 +218,54 @@ export declare class SparrowDB {
    * so vector writes for that pair are dropped and searches return nothing.
    * Nothing else distinguishes that store from a healthy one.
    *
-   * Not read-only when composed with #442: probing a live entry may
-   * quarantine it. The observable result is unchanged — a file quarantined
-   * during one call is reported as a quarantine artifact by the next.
+   * **Read-only since #456.** It used to quarantine the live entries it
+   * probed, so a second call answered differently from the first and the
+   * `path` it reported had already been renamed away by the time you read it.
+   * Both are fixed: run it as often as you like, and `path` resolves.
    *
    * ```typescript
-   * const failures = SparrowDB.vectorIndexLoadFailures('/path/to/my.db')
-   * // [{ label: 'Memory', prop: 'embedding',
-   * //    path: '/path/to/my.db/vector_indexes/hnsw_Memory_embedding.bin',
-   * //    reason: 'HNSW index ... is corrupt ...' }]
-   * if (failures.length > 0) alert(failures.map(f => f.path))
+   * const report = SparrowDB.vectorIndexLoadFailures('/path/to/my.db')
+   * if (report.unscannable) throw new Error(`cannot inspect: ${report.unscannable}`)
+   * if (!report.healthy) alert(report.active.map(f => f.path))
+   * // report.historical — damage already recovered from; do not alert
    * ```
    */
-  static vectorIndexLoadFailures(path: string): Array<VectorIndexLoadFailure>
+  static vectorIndexLoadFailures(path: string): VectorIndexDamageReport
+  /**
+   * Cheap damage report for the vector indexes at `path`: directory metadata
+   * only, no index file contents read.
+   *
+   * **This is the call for a monitor.** Its cost is one directory listing plus
+   * one `stat` per live index, independent of index size, so it is safe at any
+   * poll frequency. `SparrowDB.vectorIndexLoadFailures` is the deep
+   * counterpart and deserialises every healthy index on every call.
+   *
+   * **Static** and **never throws**, for the same reasons.
+   *
+   * What it sees: quarantine artifacts, split into `active` and `historical`
+   * by whether a live index now serves the pair, and live entries that do not
+   * resolve. What it does not: whether a live index still DECODES.
+   *
+   * That is sound for a RUNNING store, and the reason is structural rather
+   * than convenient: `open` loads and validates every live index and refuses
+   * to start when one fails, so a store that is up has had every live file
+   * verified already. The question a monitor is left asking is "did we
+   * quarantine something and lose vectors?", which is exactly what this
+   * answers without reading a payload byte.
+   *
+   * It cannot tell you why a database refuses to OPEN. Use
+   * `SparrowDB.vectorIndexLoadFailures` for that.
+   *
+   * Not to be confused with the instance method `db.vectorIndexHealth(label,
+   * prop)`, which counts reachable vectors inside one healthy index.
+   *
+   * ```typescript
+   * const report = SparrowDB.vectorIndexDamageScan('/path/to/my.db')
+   * if (report.unscannable) page('cannot read the index directory')
+   * else if (!report.healthy) page(report.active.map(f => `${f.label}.${f.prop}`))
+   * ```
+   */
+  static vectorIndexDamageScan(path: string): VectorIndexDamageReport
   /**
    * Execute a Cypher query and return `{ columns, rows }`.
    *

--- a/npm/sparrowdb/test/integration.test.js
+++ b/npm/sparrowdb/test/integration.test.js
@@ -625,12 +625,11 @@ describe('anonymous relationship patterns — issue #406 regression', () => {
   })
 })
 
-describe('SparrowDB.vectorIndexLoadFailures — issues #446 / #451', () => {
+describe('SparrowDB vector index damage reporting — issues #446 / #451 / #455 / #456', () => {
   // #446 made a damaged HNSW index fail `open()` loudly instead of silently
   // degrading to "no index configured", and added
   // `GraphDb::vector_index_load_failures(path)` as the call an operator makes
-  // to find out WHICH files are the problem.  It had no napi binding, so the
-  // documented remediation was unreachable from JavaScript.
+  // to find out WHICH files are the problem.  #454 gave it a napi binding.
   //
   // #451 is why this is the only usable health signal: once a damaged file has
   // been quarantined to `<name>.bin.corrupt.<millis>`, the FIRST `open()` has
@@ -638,6 +637,15 @@ describe('SparrowDB.vectorIndexLoadFailures — issues #446 / #451', () => {
   // silently absent.  Vector writes for that (label, prop) are dropped and
   // every search returns nothing, and nothing else on the API surface
   // distinguishes that store from a healthy one.
+  //
+  // #456 changed the shape, because the bare array said three different things
+  // with the same value:
+  //   - `[]` for a healthy store AND for a directory that could not be read;
+  //   - a quarantine artifact stayed reported forever, even after the pair was
+  //     rebuilt, so the check could go green -> red and never back;
+  //   - probing a live entry QUARANTINED it, so the reported `path` had already
+  //     been renamed away by the time the caller saw it (#455).
+  // The report is now { unscannable?, active, historical, healthy }.
   //
   // ── Hand-derived fixture facts (from the on-disk format, not from output) ──
   //
@@ -699,6 +707,35 @@ describe('SparrowDB.vectorIndexLoadFailures — issues #446 / #451', () => {
     return { dir, dbPath, indexFile }
   }
 
+  function artifactsFor(dbPath, label = LABEL, prop = PROP) {
+    const vecDir = path.join(dbPath, 'vector_indexes')
+    if (!fs.existsSync(vecDir)) return []
+    return fs.readdirSync(vecDir)
+      .filter(n => n.startsWith(`hnsw_${label}_${prop}.bin.corrupt.`))
+  }
+
+  // Every report, from either tier, must carry the same three signals.  A
+  // consumer that cannot see all three is back to the defect: it cannot tell
+  // green from blind, and it cannot tell current damage from an old scar.
+  function assertReportShape(report) {
+    assert.equal(typeof report, 'object', 'report must be an object')
+    assert.ok(!Array.isArray(report), 'report must not be a bare array (#456)')
+    assert.ok(Array.isArray(report.active), 'active must be an array')
+    assert.ok(Array.isArray(report.historical), 'historical must be an array')
+    assert.equal(typeof report.healthy, 'boolean', 'healthy must be a boolean')
+    assert.ok(
+      report.unscannable === undefined || typeof report.unscannable === 'string',
+      `unscannable must be absent or a string, got ${typeof report.unscannable}`
+    )
+    // `healthy` is computed natively; assert the composition it claims so a JS
+    // caller can rely on the single field instead of re-deriving it.
+    assert.equal(
+      report.healthy,
+      !report.unscannable && report.active.length === 0,
+      'healthy must equal (!unscannable && active.length === 0)'
+    )
+  }
+
   function assertFailureShape(entry, indexFile) {
     // Named fields, not tuple positions — a consumer building an alert needs
     // to read `entry.path`, not `entry[2]`.
@@ -725,41 +762,80 @@ describe('SparrowDB.vectorIndexLoadFailures — issues #446 / #451', () => {
     )
   }
 
-  it('is a static method on the class, not an instance method', () => {
-    // Non-negotiable: the database this diagnoses is the one that will not
-    // open, so an instance method would be unreachable exactly when it is
-    // needed.  `SparrowDB.prototype` must NOT carry it.
+  it('both tiers are static methods on the class, not instance methods', () => {
+    // Non-negotiable: the database the deep tier diagnoses is the one that will
+    // not open, so an instance method would be unreachable exactly when it is
+    // needed.  `SparrowDB.prototype` must NOT carry either.
+    for (const name of ['vectorIndexLoadFailures', 'vectorIndexDamageScan']) {
+      assert.equal(
+        typeof SparrowDB[name], 'function',
+        `${name} must exist as a static on SparrowDB`
+      )
+      assert.equal(
+        typeof SparrowDB.prototype[name], 'undefined',
+        `${name} must NOT be an instance method`
+      )
+    }
+    // And the static damage scan must not be confused with the INSTANCE
+    // `vectorIndexHealth(label, prop)`, which counts reachable vectors inside
+    // one healthy index.  Different question, different receiver.
     assert.equal(
-      typeof SparrowDB.vectorIndexLoadFailures, 'function',
-      'vectorIndexLoadFailures must exist as a static on SparrowDB'
-    )
-    assert.equal(
-      typeof SparrowDB.prototype.vectorIndexLoadFailures, 'undefined',
-      'vectorIndexLoadFailures must NOT be an instance method'
+      typeof SparrowDB.prototype.vectorIndexHealth, 'function',
+      'the per-index reachability method stays an instance method'
     )
   })
 
-  it('never throws: unreadable / absent / invalid paths return []', () => {
-    // The diagnostic must not itself become a failure path.  Each of these is
-    // hand-derived as "no vector_indexes/ directory can be listed", therefore
-    // "no damage found", therefore an empty array — never an exception.
+  it('never throws, and distinguishes "nothing wrong" from "could not look" (#456)', () => {
+    // The diagnostic must not itself become a failure path — but it must also
+    // stop answering the same thing for two different situations.
+    //
+    // Hand-derived, from `scan_vector_index_dir`:
+    //   - a path whose `vector_indexes/` simply is not there gives read_dir
+    //     ENOENT and symlink_metadata ENOENT, which is the ordinary "no vector
+    //     index was ever created" case -> scanned successfully, nothing found.
+    //   - a path containing a NUL byte cannot be handed to the OS at all;
+    //     read_dir fails with InvalidInput, which is NOT NotFound -> we did not
+    //     observe the directory, so the report must say so.
     const dir = makeTempDir()
     try {
-      for (const p of [
-        path.join(dir, 'does-not-exist'),   // absent directory
-        dir,                                // a directory that is not a db
-        '/tmp/sparrowdb-\0-bad-path',       // invalid at the OS path layer
-        '',                                 // empty string
-      ]) {
-        let out
+      for (const tier of ['vectorIndexLoadFailures', 'vectorIndexDamageScan']) {
+        for (const p of [
+          path.join(dir, 'does-not-exist'),   // absent directory
+          dir,                                // a directory that is not a db
+          '',                                 // empty string
+        ]) {
+          let out
+          assert.doesNotThrow(
+            () => { out = SparrowDB[tier](p) },
+            `${tier}(${JSON.stringify(p)}) must not throw`
+          )
+          assertReportShape(out)
+          assert.equal(
+            out.unscannable, undefined,
+            `${tier}(${JSON.stringify(p)}): an absent directory is scanned ` +
+            `successfully, not unscannable`
+          )
+          assert.equal(out.active.length, 0, 'nothing on disk can be damaged')
+          assert.equal(out.historical.length, 0, 'and nothing is historical')
+          assert.equal(out.healthy, true, 'so the report is healthy')
+        }
+
+        // The blind case.  Same call, same absence of findings — and it must
+        // NOT read as healthy.
+        const bad = '/tmp/sparrowdb-\0-bad-path'
+        let blind
         assert.doesNotThrow(
-          () => { out = SparrowDB.vectorIndexLoadFailures(p) },
-          `vectorIndexLoadFailures(${JSON.stringify(p)}) must not throw`
+          () => { blind = SparrowDB[tier](bad) },
+          `${tier} must not throw on an unusable path`
         )
-        assert.ok(Array.isArray(out), 'must return an array')
+        assertReportShape(blind)
         assert.equal(
-          out.length, 0,
-          `expected 0 failures for ${JSON.stringify(p)}, got ${JSON.stringify(out)}`
+          typeof blind.unscannable, 'string',
+          `${tier}: a path the OS cannot accept must report unscannable`
+        )
+        assert.equal(
+          blind.healthy, false,
+          'not knowing is not the same as being fine'
         )
       }
     } finally {
@@ -767,10 +843,63 @@ describe('SparrowDB.vectorIndexLoadFailures — issues #446 / #451', () => {
     }
   })
 
-  it('returns [] for a healthy database with a healthy vector index', () => {
+  it('a chmod-000 index directory is not reported as healthy (#456)', () => {
+    // The demonstrated case: a misconfigured service account or a bad mount
+    // during a poll used to produce output byte-identical to a healthy store.
+    const dir = makeTempDir()
+    const dbPath = path.join(dir, 'graph.db')
+    const vecDir = path.join(dbPath, 'vector_indexes')
+    try {
+      const db = SparrowDB.open(dbPath)
+      db.createVectorIndex(LABEL, PROP, DIMENSIONS, 'cosine')
+
+      // Control: hand-derived — one live index, intact, no artifacts, so a
+      // healthy report with both lists empty.
+      const control = SparrowDB.vectorIndexLoadFailures(dbPath)
+      assertReportShape(control)
+      assert.equal(control.healthy, true, 'fixture precondition: healthy control')
+
+      fs.chmodSync(vecDir, 0o000)
+      // Running as root defeats the permission bits, so the property under test
+      // cannot be exercised; skip rather than assert something untrue.
+      let blocked = true
+      try { fs.readdirSync(vecDir); blocked = false } catch { /* expected */ }
+      if (!blocked) return
+
+      for (const tier of ['vectorIndexLoadFailures', 'vectorIndexDamageScan']) {
+        const blind = SparrowDB[tier](dbPath)
+        assertReportShape(blind)
+        assert.equal(
+          typeof blind.unscannable, 'string',
+          `${tier}: an unlistable directory must say so`
+        )
+        assert.equal(
+          blind.active.length, 0,
+          'nothing was observed, so nothing may be claimed'
+        )
+        assert.equal(blind.healthy, false, 'blind must not read as healthy')
+        assert.notDeepEqual(
+          blind, control,
+          'blind must not be observationally identical to green'
+        )
+      }
+
+      // And `open()` must refuse: a directory we cannot list may hold indexes,
+      // and starting anyway means "no index configured" for every one of them.
+      assert.throws(
+        () => SparrowDB.open(dbPath),
+        'open() must not treat an unlistable vector_indexes/ as empty'
+      )
+    } finally {
+      try { fs.chmodSync(vecDir, 0o755) } catch { /* best effort */ }
+      removeDir(dir)
+    }
+  })
+
+  it('a healthy database reports healthy, with both lists empty', () => {
     // Control.  One index is created and left intact, so the hand-derived
-    // expectation is 0 failures — an always-non-empty report would be useless
-    // as a health check.
+    // expectation is 0 active and 0 historical — an always-non-empty report
+    // would be useless as a health check.
     const dir = makeTempDir()
     try {
       const dbPath = path.join(dir, 'graph.db')
@@ -781,53 +910,157 @@ describe('SparrowDB.vectorIndexLoadFailures — issues #446 / #451', () => {
         LABEL, PROP, 'ok-1', new Float32Array([0.1, 0.2, 0.3])
       )
 
-      const failures = SparrowDB.vectorIndexLoadFailures(dbPath)
-      assert.ok(Array.isArray(failures))
+      for (const tier of ['vectorIndexLoadFailures', 'vectorIndexDamageScan']) {
+        const report = SparrowDB[tier](dbPath)
+        assertReportShape(report)
+        assert.equal(
+          report.active.length, 0,
+          `${tier}: a healthy index must report no active damage, got ` +
+          JSON.stringify(report.active)
+        )
+        assert.equal(report.historical.length, 0, `${tier}: nothing historical`)
+        assert.equal(report.healthy, true, `${tier}: must read healthy`)
+      }
+    } finally {
+      removeDir(dir)
+    }
+  })
+
+  it('reports live damage WITHOUT quarantining it — the report is read-only (#455 / #456)', () => {
+    // First observer of the damage.  The deep tier reads the file, rejects it,
+    // and MUST leave it exactly where it found it.
+    //
+    // Before #456 this same call renamed the .bin to `.bin.corrupt.<millis>`
+    // as a side effect of reporting on it, so `fs.existsSync(entry.path)` —
+    // the obvious sanity check, and the one a health check would use to
+    // confirm the damage is real — was false on the very first report, and a
+    // second call answered differently from the first.
+    const { dir, indexFile, dbPath } = makeDamagedDb()
+    try {
+      const before = fs.readFileSync(indexFile)
       assert.equal(
-        failures.length, 0,
-        `a healthy index must report no failures, got ${JSON.stringify(failures)}`
+        before.length, TRUNCATE_TO_BYTES,
+        'fixture precondition: the damaged file is 4 bytes'
+      )
+
+      const report = SparrowDB.vectorIndexLoadFailures(dbPath)
+      assertReportShape(report)
+      assert.equal(
+        report.active.length, EXPECTED_FAILURES,
+        `expected exactly ${EXPECTED_FAILURES} damaged index, got ` +
+        JSON.stringify(report.active)
+      )
+      assert.equal(report.historical.length, 0, 'nothing has been rebuilt')
+      assert.equal(report.healthy, false, 'a damaged live index is not healthy')
+
+      assertFailureShape(report.active[0], indexFile)
+      assert.equal(
+        report.active[0].path, indexFile,
+        'the live arm reports the .bin path it scanned'
+      )
+      assert.ok(
+        /corrupt/i.test(report.active[0].reason),
+        `reason must describe the damage, got: ${report.active[0].reason}`
+      )
+
+      // The three properties #455 and #456 are about.
+      assert.ok(
+        fs.existsSync(report.active[0].path),
+        `reported path ${report.active[0].path} must still resolve — a report ` +
+        `naming a file that is not there is not actionable (#455)`
+      )
+      assert.deepEqual(
+        fs.readFileSync(indexFile), before,
+        'the diagnostic must not alter the bytes it is diagnosing'
+      )
+      assert.deepEqual(
+        artifactsFor(dbPath), [],
+        'reading a report must not quarantine anything (#456)'
+      )
+
+      // Idempotent by construction, now that it does not mutate.
+      const second = SparrowDB.vectorIndexLoadFailures(dbPath)
+      assert.deepEqual(
+        second, report,
+        'a health check that runs twice must not get a different answer than ' +
+        'one that runs once'
       )
     } finally {
       removeDir(dir)
     }
   })
 
-  it('reports live damage on an index nothing has probed yet', () => {
-    // First observer of the damage.  The file is still in place, so the
-    // reported (label, prop) is the live entry.
-    const { dir, indexFile, dbPath } = makeDamagedDb()
+  it('a rebuilt pair moves from active to historical, so the check can go green again (#456)', () => {
+    // Quarantine artifacts are never cleaned up automatically.  Reporting one
+    // forever means a store that has been REPAIRED can never go back to green,
+    // and an alert that will not clear after the problem is fixed gets muted —
+    // worse than no alert, because the attention has been spent for nothing.
+    //
+    // The artifact is not suppressed either: #442 records no reason at
+    // quarantine time, so the file is the only surviving evidence of the
+    // incident.  It moves to `historical`, which a monitor ignores and an
+    // operator can still read.
+    const { dir, dbPath, indexFile } = makeDamagedDb()
     try {
-      const failures = SparrowDB.vectorIndexLoadFailures(dbPath)
+      // Phase 1 — the damaged index makes open() fail, and the failed open
+      // quarantines it.  Hand-derived: 1 artifact, 0 live .bin.
+      assert.throws(() => SparrowDB.open(dbPath), 'a live damaged index must fail open()')
       assert.equal(
-        failures.length, EXPECTED_FAILURES,
-        `expected exactly ${EXPECTED_FAILURES} damaged index, got ` +
-        JSON.stringify(failures)
+        artifactsFor(dbPath).length, 1,
+        'the open path quarantines what it rejects'
       )
-      assertFailureShape(failures[0], indexFile)
+      assert.equal(fs.existsSync(indexFile), false, 'the live .bin was moved aside')
+
+      const damaged = SparrowDB.vectorIndexLoadFailures(dbPath)
+      assertReportShape(damaged)
       assert.equal(
-        failures[0].path, indexFile,
-        'the live arm reports the .bin path it scanned'
+        damaged.active.length, EXPECTED_FAILURES,
+        'nothing serves the pair, so the artifact is ACTIVE damage'
       )
-      // Caveat worth encoding: probing a live entry is not read-only when
-      // composed with #442 — `VectorIndex::load` quarantines the bytes it
-      // rejects, so by the time this call returns the .bin has been renamed
-      // aside and the reported .bin path no longer resolves.  The surviving
-      // bytes are named in `reason`, and the NEXT call reports the artifact
-      // path (see the following test).  Asserting this rather than glossing
-      // it is the point: a consumer must not assume `path` is still there
-      // after a live-arm report.
-      assert.ok(
-        /corrupt/i.test(failures[0].reason),
-        `reason must describe the damage, got: ${failures[0].reason}`
-      )
-      const artifacts = fs
-        .readdirSync(path.join(dbPath, 'vector_indexes'))
-        .filter(n => n.startsWith(`hnsw_${LABEL}_${PROP}.bin.corrupt.`))
+      assert.equal(damaged.historical.length, 0, 'and nothing is historical yet')
+      assert.equal(damaged.healthy, false)
+
+      // Phase 2 — the operator rebuilds the index for the same (label, prop).
+      // Hand-derived: the artifact is untouched (still exactly 1), a fresh live
+      // .bin now exists, and the pair is served again.  So the SAME artifact
+      // must move to `historical` and the store must read healthy.
+      const db = SparrowDB.open(dbPath)
+      db.createVectorIndex(LABEL, PROP, DIMENSIONS, 'cosine')
+      assert.ok(fs.existsSync(indexFile), 'the rebuilt index is persisted')
       assert.equal(
-        artifacts.length, 1,
-        `#442 must have quarantined the probed file exactly once, got ` +
-        JSON.stringify(artifacts)
+        artifactsFor(dbPath).length, 1,
+        'rebuilding must not touch the artifact — it is the only evidence left'
       )
+
+      for (const tier of ['vectorIndexLoadFailures', 'vectorIndexDamageScan']) {
+        const after = SparrowDB[tier](dbPath)
+        assertReportShape(after)
+        assert.equal(
+          after.active.length, 0,
+          `${tier}: a repaired pair must not stay in active, got ` +
+          JSON.stringify(after.active)
+        )
+        assert.equal(
+          after.historical.length, 1,
+          `${tier}: the wreckage must remain visible as history, got ` +
+          JSON.stringify(after.historical)
+        )
+        assert.equal(after.historical[0].label, LABEL)
+        assert.equal(after.historical[0].prop, PROP)
+        assert.ok(
+          after.historical[0].path.startsWith(`${indexFile}.corrupt.`),
+          `history must name the artifact, got ${after.historical[0].path}`
+        )
+        assert.ok(
+          fs.existsSync(after.historical[0].path),
+          'and that path must resolve, so an operator can recover from it'
+        )
+        assert.equal(
+          after.healthy, true,
+          `${tier}: with the pair served again the store must read healthy — ` +
+          `this is the green-again property the check needs to be usable`
+        )
+      }
     } finally {
       removeDir(dir)
     }
@@ -852,12 +1085,13 @@ describe('SparrowDB.vectorIndexLoadFailures — issues #446 / #451', () => {
 
       // The whole reason this is static: there is no instance to hang it off.
       const duringOutage = SparrowDB.vectorIndexLoadFailures(dbPath)
+      assertReportShape(duringOutage)
       assert.equal(
-        duringOutage.length, EXPECTED_FAILURES,
+        duringOutage.active.length, EXPECTED_FAILURES,
         `expected exactly ${EXPECTED_FAILURES} damaged index while open() is ` +
-        `failing, got ${JSON.stringify(duringOutage)}`
+        `failing, got ${JSON.stringify(duringOutage.active)}`
       )
-      assertFailureShape(duringOutage[0], indexFile)
+      assertFailureShape(duringOutage.active[0], indexFile)
 
       // The failed open() quarantined the bytes, so the reported path is now
       // the artifact: `<indexFile>.corrupt.<unix_millis>`.  The stem is
@@ -867,22 +1101,22 @@ describe('SparrowDB.vectorIndexLoadFailures — issues #446 / #451', () => {
         `^${escapeRegExp(indexFile)}\\.corrupt\\.\\d+$`
       )
       assert.match(
-        duringOutage[0].path, artifactPattern,
+        duringOutage.active[0].path, artifactPattern,
         'the reported path must be the quarantine artifact'
       )
       // A report naming a file that is not on disk is not actionable.
       assert.ok(
-        fs.existsSync(duringOutage[0].path),
-        `reported path ${duringOutage[0].path} must exist on disk`
+        fs.existsSync(duringOutage.active[0].path),
+        `reported path ${duringOutage.active[0].path} must exist on disk`
       )
       assert.ok(
-        fs.statSync(duringOutage[0].path).isFile(),
+        fs.statSync(duringOutage.active[0].path).isFile(),
         'the reported path must be a regular file'
       )
       assert.ok(
-        /quarantine/i.test(duringOutage[0].reason),
+        /quarantine/i.test(duringOutage.active[0].reason),
         `reason must identify this as a quarantine artifact, got: ` +
-        duringOutage[0].reason
+        duringOutage.active[0].reason
       )
 
       // ── Phase 2: #451. The .bin is gone, so this is now the "absent" case
@@ -902,19 +1136,24 @@ describe('SparrowDB.vectorIndexLoadFailures — issues #446 / #451', () => {
 
       // ── Phase 3: the diagnostic is the ONLY remaining signal. ────────────
       const afterReopen = SparrowDB.vectorIndexLoadFailures(dbPath)
+      assertReportShape(afterReopen)
       assert.equal(
-        afterReopen.length, EXPECTED_FAILURES,
+        afterReopen.active.length, EXPECTED_FAILURES,
         `the quarantine must remain visible after the database reopens ` +
-        `"clean"; got ${JSON.stringify(afterReopen)}`
+        `"clean"; got ${JSON.stringify(afterReopen.active)}`
       )
-      assertFailureShape(afterReopen[0], indexFile)
       assert.equal(
-        afterReopen[0].path, duringOutage[0].path,
+        afterReopen.healthy, false,
+        'a store silently dropping vector writes is not healthy'
+      )
+      assertFailureShape(afterReopen.active[0], indexFile)
+      assert.equal(
+        afterReopen.active[0].path, duringOutage.active[0].path,
         'the artifact path must be stable across calls'
       )
       assert.ok(
-        fs.existsSync(afterReopen[0].path),
-        `reported path ${afterReopen[0].path} must exist on disk`
+        fs.existsSync(afterReopen.active[0].path),
+        `reported path ${afterReopen.active[0].path} must exist on disk`
       )
     } finally {
       removeDir(dir)


### PR DESCRIPTION
Closes #456. Also closes #455 — reasoning below.

Rebased onto c9f7a0b, so this sits on top of both #453 (the `save()` race) and #454 (the napi binding). #454's binding is migrated here, and the composition with #453 is asserted by execution rather than by reading the two patches side by side — see test 9.

## The cost that applies even when nothing is broken

Every call to `GraphDb::vector_index_load_failures` fully deserialised every **healthy** index it found. For an 8 MB `Knowledge.embedding` index polled hourly, that is 8 MB of I/O and a complete HNSW graph rebuild an hour, spent confirming that nothing is wrong.

That is a permanent cost in the common case. The destructive read this issue is named for is a correctness bug in an edge case. Both argue for the same change — splitting judgement from side effect, and cheap from deep — but the cost argument stands even for a reader who thinks the mutation was tolerable.

## The correctness bug

#442 moved the quarantine rename **inside** `VectorIndex::load()`. `load()` became destructive and every caller inherited it. Three non-test callers; one was entitled to mutate.

| caller | may mutate? | what it got |
|---|---|---|
| `helpers.rs` `load_vector_indexes` — open | yes, intended | correct |
| `helpers.rs` `vector_index_load_failures` — diagnostic | **no** | mutated while diagnosing |
| `expr.rs:196` `hybrid_search` cached loader — query | **no** | `.ok().flatten()?` swallowed it |

Measured against the pre-fix tree (probe deleted before commit): open a db, create + populate + save an index, `hybrid_search` → `List([{node_id: 0, …}])`. Truncate the `.bin` to 4 bytes **without closing the db**. `hybrid_search` again:

```
AFTER: Ok, value = List([])          hit_count = 0
bin still present: false
artifacts: ["hnsw_Doc_embedding.bin.corrupt.1785700052598"]
```

A read returned success, returned nothing, and renamed the last live copy of the index aside. Same fixture on this branch:

```
AFTER: Ok, value = Null              (+ a tracing::warn naming file and reason)
bin still present: true
artifacts: []
```

Against over-claiming: the pre-fix mutation was **idempotent**. A given damaged file is quarantined once; repeat polls do no further I/O. It destroyed exactly once per incident — silently, from something shaped like a getter.

## split_design

**`sparrowdb-storage`** — judgement in one place, side effect opt-in:

```rust
fn read_index(path) -> io::Result<LoadOutcome>   // private; Absent | Loaded | Unreadable | Undecodable | Inconsistent
pub fn load(dir, label, prop)                -> io::Result<Option<Self>>   // never touches disk
pub fn load_and_quarantine(dir, label, prop) -> io::Result<Option<Self>>   // renames Undecodable bytes aside
```

Only `Undecodable` is quarantine-eligible — those bytes are the only surviving copy of the vectors. `Inconsistent` (decodes, fails `validate_invariants`) stays put, as before. `Unreadable` (dangling symlink) stays put too: there are no bytes to preserve, so renaming would destroy evidence and protect nothing.

| caller | uses |
|---|---|
| `helpers::load_vector_indexes` (open) | `load_and_quarantine` — it is about to take ownership of the slot, so its own later `save()` is what would overwrite the damaged bytes |
| `helpers::health` (both diagnostic tiers) | `load` |
| `expr.rs` `hybrid_vector_index` (query) | `load` |

**`sparrowdb`** — one report type, two tiers:

```rust
pub struct VectorIndexFailure { label, prop, path, reason }
pub struct VectorIndexHealth  { unscannable: Option<String>, active: Vec<_>, historical: Vec<_> }
impl VectorIndexHealth { pub fn is_healthy(&self) -> bool }   // unscannable.is_none() && active.is_empty()

GraphDb::vector_index_health(path)         // NEW. directory metadata only, no contents read
GraphDb::vector_index_load_failures(path)  // as before, plus a real load of every live file
```

**`sparrowdb-node` / npm** — the same three signals, unflattened:

```typescript
interface VectorIndexDamageReport {
  unscannable?: string                   // present when the directory could not be listed
  active: VectorIndexLoadFailure[]       // unrecovered damage — alert on this
  historical: VectorIndexLoadFailure[]   // recovered-from damage — forensics only
  healthy: boolean                       // !unscannable && active.length === 0, computed natively
}

SparrowDB.vectorIndexLoadFailures(path): VectorIndexDamageReport   // deep
SparrowDB.vectorIndexDamageScan(path):   VectorIndexDamageReport   // NEW, cheap — this is the monitor's call
```

`is_healthy()` is not a method across the napi boundary, so it is exposed as a precomputed `healthy` field, derived in Rust from `is_healthy()`. A JS caller cannot get the composition wrong, and the JS suite asserts `healthy === (!unscannable && active.length === 0)` on every report it receives.

The napi type is `VectorIndexDamageReport`, not `VectorIndexHealth`: that name is already taken by the **instance** method `db.vectorIndexHealth(label, prop)`, which counts reachable vectors *inside one healthy index*. Different question, different receiver; both doc comments now say so explicitly.

`unscannable` is `Option<String>`, which napi renders as an **absent** property rather than `null` — the `.d.ts` declares `unscannable?: string` and the docs say to test it for truthiness. This was verified by execution, not assumed.

### Why the cheap tier does not verify live files

`vector_index_health` / `vectorIndexDamageScan` cost one `read_dir` plus one `stat` per live entry — independent of index size. They report quarantine artifacts (split `active`/`historical`) and live entries that do not resolve, but do **not** check that a live index still decodes.

That is sound for a *running* store, and the reason is structural rather than convenient: `open` loads and validates every live index and refuses to start when one fails, so a store that is up has had every live file verified already. The residual question a monitor is asking is "did we quarantine something and lose vectors?", which is exactly what this answers.

I deliberately did **not** make the poll call a pure name scan. Dropping the deep live-arm would create a *new* instance of the blindness this PR is fixing: an index that decodes but fails `validate_invariants` is deliberately never quarantined, so a name-only diagnostic would report nothing for a store that refuses to open.

### Composition with #453

#453 landed first and adds two sidecars next to every index: `<index>.bin.lock`, never unlinked by design, and `<index>.bin.tmp.<pid>.<nonce>`, which a crashed writer leaves behind for good. Both sit in the directory this PR classifies by file name, so a wrong guess would break every store that has ever saved a vector.

The rebase was textually clean, including in `vector_index.rs`. Reading the two patches says they compose — but #442 and #446 also read as composing and produced #450, so it is asserted by execution in test 9 instead.

One direction worth recording: this change strictly **reduces** the number of racers against #453's new save lock. Before it, three code paths could rename an index file out from under a writer holding that lock — `open`, the diagnostic, and a `hybrid_search` read. Now only `open` can. `load_and_quarantine` still does not take the save lock, but that is unchanged from `main` and is neither introduced nor worsened here.

**Breaking changes:** `GraphDb::vector_index_load_failures` returned `Vec<(String, String, PathBuf, String)>`; `SparrowDB.vectorIndexLoadFailures` returned `VectorIndexLoadFailure[]`. Both now return the report object. Every in-tree consumer is migrated in this PR (`db.rs`, `crates/sparrowdb-node/src/lib.rs`, `npm/sparrowdb/index.d.ts`, `npm/sparrowdb/test/integration.test.js`, `crates/sparrowdb/tests/vector_index_load_errors.rs`).

## expr_decision — refuse, do not degrade

Three candidates. **Returning an error is not reachable**: `eval_expr_graph` and every scalar function it dispatches are infallible by signature (`-> Value`), and making them fallible is an engine-wide change through `engine/{mod,scan,path,hop}.rs` — far outside this fix. A separate issue should track it; the same swallow class is alive in FTS (`mutation.rs:944-948`, `db.rs:978-982`, `engine/mod.rs:274-282`, and `hybrid_search`'s own FTS branch) and would be fixed by the same plumbing.

That leaves degrade-to-FTS or refuse. **Refuse**, because degrading produces the *same observable* as a legitimately absent index — precisely the absent-vs-damaged confusion #445 exists to eliminate. A caller who asked for a fusion of vector and text, and silently got text only, has been told the store is healthy by a store that is not.

So the loader returns three states and the caller keeps them apart:

- **absent** (`Ok(None)`) → full-text-only, unchanged. A pair with no index is a legitimate configuration.
- **damaged** (`Err`) → `Value::Null` plus `tracing::warn!` naming label, property and decode reason.

`Value::Null` is already this function's failure signal (bad arity, bad argument types, fusion failure), so it introduces no new shape, and a caller cannot mistake it for an empty result list.

Two related fixes in the same loader: the fingerprint is now a cache-validity token rather than an existence test (it opens the path, so a dangling symlink reported `NotFound` and a damaged header reported an error — neither means "no index here"), and an index with no fingerprint is no longer cached, because there would be no token to invalidate it against.

### Both verdicts are cached, under the same token

`hybrid_search` is a scalar function: it is evaluated once per candidate row. The success path has been cached against the on-disk fingerprint since #442, but the failure path was not — so a damaged index was re-read and re-decoded on **every** row, and emitted an identical warning on every row.

For an 8 MB `Knowledge.embedding` index an N-row scan is N × 8 MB of I/O plus N identical log lines: an I/O storm and a log flood arriving exactly when the store is already degraded and someone is reading the logs to find out why. A file that decodes cleanly and then fails `validate_invariants` paid a full `bincode` decode every row. A change whose purpose is "behave well when the index is damaged" must not amplify the incident.

The damaged verdict is now cached as `CachedIndex::Damaged(reason)` under the same fingerprint token as the success, in the same bounded map, so invalidation is identical for both: rebuild the index, the fingerprint changes, the entry stops matching, the next row sees the repair. `Value::Null` is unchanged as the observable — the absent-vs-damaged distinction is the point.

**A verdict is cached only when a fingerprint exists**, because the fingerprint *is* the invalidation token. That costs nothing: `fingerprint` fails only when the file cannot be opened at all (a dangling symlink, a permission block), and those re-probe for one failed `open` plus one `lstat` with no payload read — never the full decode this cache exists to avoid. Every case that costs a decode has a fingerprint. Caching a negative without a token could let it outlive its repair, recreating the "fixed but still reports broken" failure this PR removes from the diagnostic, one layer down; a repeated log line is the better trade in the one case where the two conflict.

The bound is now stated rather than implicit: the cache is process-global and keyed by `(dir, label, prop)`, so a long-running process — an MCP server that opens many databases is the realistic case — would otherwise retain one entry per pair it had ever queried, each `Ready` entry pinning a fully deserialised multi-megabyte index. Capped at 8, cleared wholesale: there is no access-recency information worth tracking, and a cleared cache costs a reload, not a wrong answer.

## issues_closed

**#456 — yes.** The query path no longer mutates and no longer swallows; the diagnostic no longer mutates; all sub-findings addressed.

**#455 — yes.** #455 is that the live arm reports the `.bin` path while `load` renames that file during the same probe, so `fs.existsSync(entry.path)` is `false` on the first — and, given #451, most-acted-on — report. Measured at the JS boundary against the pre-fix tree: `fs.existsSync(entry.path)` → **false**, one artifact created by a *read*, and the second call returned something different from the first. Post-fix all three are fixed, and `npm/sparrowdb/test/integration.test.js` asserts each. #455 suggested reporting the quarantine destination instead; removing the rename achieves the stated goal and also fixes the second-call-differs half.

**#459 — filed, not fixed here, and confirmed PRE-EXISTING.** Found while building the negative-cache test: `MATCH (d:Doc) RETURN hybrid_search(...)` returns `Null` for a **healthy** index, because the chunked pipeline never routes `Expr::FnCall` through the graph-aware evaluator. Same class as #415/#416.

Verified by execution against unmodified c9f7a0b from an isolated target dir, not inferred from the diff: all six query shapes behave **identically** on main and on this branch, row for row. It is therefore pre-existing and ships in 0.1.22 — not introduced here. The full comparison table is on #459. The fix belongs in `engine/{scan,pipeline_exec}.rs`, which this PR does not touch.

**#451 — not closed.** Fail-closed `open()` is still one-shot: after quarantine the store reopens "healthy" with the pair silently unconfigured. This PR reduces the restart count from N+1 to 2 and keeps the artifacts visible in `active`, but that behaviour is unchanged and out of scope.

## sub_findings_fixed

**1. N damaged indexes required N failed restarts** — fixed. `load_vector_indexes` `return`ed on the first `Err`; it now runs to completion and reports every failure in one `Error::Corruption`. With two planted, **pre-fix the message named only `(Doc, embedding)`** — the scan is sorted by `(label, prop)` and `"Doc" < "Note"`, so `Note` was never probed — and one artifact was created. Post-fix the message names both, both are quarantined by the same open, and the second open succeeds: 2 restarts, not 3.

**2. Stale artifacts false-flagged a healthy store forever** — fixed with `historical`, not suppression. An artifact whose `(label, prop)` is served by a working index moves to `historical`; one with nothing serving its pair stays in `active`. This is the adoption-deciding property: artifacts are never cleaned up automatically, so a report that keeps naming a repaired pair can only ever go green → red with no path back, and an alert that never clears after the problem is fixed gets muted — worse than no alert, because the attention has been spent and nothing was bought with it.

Reported separately rather than suppressed because #442 records no reason at quarantine time and writes no sidecar: those bytes are the only surviving evidence that the incident happened.

This does not weaken #450 — the artifact-is-the-only-file case is still `active`. Only the case where a working index sits beside it changed.

Stated plainly: neither tier can tell whether a rebuilt index holds everything the artifact held. Nothing can — the artifact does not decode, which is why it is an artifact. Staying red forever would not have asserted that either.

**3. Dangling symlink classified as absent** — fixed. `load` began with `if !path.exists()`, which follows symlinks and is `false` for a broken one → `Ok(None)` → "no index configured". `read_index` now distinguishes with `symlink_metadata`; the diagnostic makes the same distinction with one `stat` at both tiers. **Pre-fix: 0 entries reported and `open()` → `Ok`** with the pair silently unconfigured. Post-fix: 1 active failure at both tiers, `open()` refuses.

**4. `[]` conflated "healthy" with "could not tell"** — fixed. `scan_vector_index_dir` now returns `Result<Vec<IndexFile>, String>`; an absent directory is still `Ok(vec![])` (distinguished with `symlink_metadata`, so a dangling symlink standing in for the directory is *not* absent), while a permission block, a plain file in the directory's place, an I/O error, or an unreadable entry becomes `unscannable`. `is_healthy()` is false for it: not knowing is not the same as being fine. Still no `Err` channel — a diagnostic must not become a failure path.

`open()` also now refuses on an unlistable `vector_indexes/`, for the same fail-closed reason it refuses on a damaged file: a directory we cannot list may hold indexes, and starting anyway means "no index configured" for every one of them.

**Deferred deliberately:** #451 (above); the FTS swallow class (needs the fallible-evaluator plumbing); automatic cleanup of `historical` artifacts (deleting the only evidence of an incident is the operator's call).

## tests_added

### Rust — `crates/sparrowdb/tests/regression_456_load_is_not_destructive.rs`, 10 tests

Every expected value hand-derived in a comment from the fixture the test builds; none captured from output.

1. **`hybrid_search_on_an_index_damaged_after_open_neither_renames_nor_reports_zero_hits`** (headline). One `Doc` node, one 3-d cosine vector, no FTS index. Baseline derivation: a 1-element index searched with `k*2 = 2` returns exactly that node id; `FtsIndex::open` fails with no FTS index so the text list is empty; RRF over (1-element, empty) yields one entry and `truncate(k=1)` leaves it — exactly `[node_id]`. Then truncate to 4 bytes with the db still open. The cache miss is derived *exactly*, not probabilistically: the healthy v2 fingerprint is `(generation, crc32c as u64)` whose second element is ≤ `u32::MAX` = 4_294_967_295, while the 4-byte file falls back to `(file_len, mtime_nanos)` ≈ `(4, 1.7e18)` — greater than `u32::MAX` for every instant after 1970-01-01 00:00:04.295, so the tuples can never compare equal. Asserts the file is present, byte-identical, no artifact created, and the value is `Null` and specifically not a `List`.
2. **`one_open_reports_every_damaged_index`**. Two indexes truncated to 4 bytes. Two files, two distinct pairs, both undecodable → one open names both, quarantines both, next open succeeds with neither pair configured; then 2 artifacts with nothing serving either pair → 2 `active`, 0 `historical`, sorted `[("Doc","embedding"), ("Note","vec")]`.
3. **`a_rebuilt_pair_moves_from_active_to_historical`**. Healthy `(Memory, embedding)` + an artifact for that same pair + an artifact for `(Ghost, vec)` with no live file. One pair is served → its artifact is debris → 1 `historical`; the other has nothing serving it → 1 `active`. Asserted at **both** tiers, since neither conclusion needs a file's contents. Removing the orphan then makes the store `is_healthy()` with `historical` still at 1.
4. **`the_diagnostic_is_read_only_and_reports_a_path_that_resolves`**. One truncated live file, never opened → 1 `active` from the live arm whose path is that `.bin`. Asserts `path.is_file()`, no artifact created, bytes unchanged, `second == first`.
5. **`load_leaves_the_file_alone_and_load_and_quarantine_moves_it`**. Both entry points return `Err` on 4 bytes; `load` leaves the file (twice, to show it is repeatable); `load_and_quarantine` moves it, and the artifact is byte-identical to the damaged bytes.
6. **`a_dangling_symlink_is_not_mistaken_for_an_absent_index`** (unix). `symlink_metadata` succeeds, `exists()` false → 1 `active` at both tiers, `open()` refuses, nothing quarantined.
7. **`an_unlistable_directory_is_not_reported_as_healthy`** (unix). Healthy control captured first, then `chmod 000` → `unscannable.is_some()`, both lists empty, `!is_healthy()`, `health != control`, and `open()` refuses. Skips with a printed note if `chmod 000` does not block the uid (root), so it never asserts something untrue of the run.
8. **`the_cheap_tier_reads_no_index_contents`** (unix). `chmod 000` on the index *file* — `stat` still succeeds, `open` does not. Cheap tier stats and stops → healthy; deep tier gets `EACCES` → exactly 1 `active` naming that pair and path. The two tiers can only disagree if the cheap one never opened the file.
9. **`save_sidecars_from_issue_453_are_not_mistaken_for_indexes`** (new, from the rebase). #453 puts `<index>.bin.lock` — which it deliberately never unlinks — and `<index>.bin.tmp.<pid>.<nonce>` staging files next to every index. Neither is an index, and both live in the directory this PR classifies **by file name**: a scanner that guessed wrong would either refuse to open a healthy store or report one as damaged, on every store that has ever saved a vector. Derivation: the scanner recognises exactly two shapes, a name ending `.bin` and a name containing `.bin.corrupt.`; `…​.bin.lock` ends `.lock`, `…​.bin.tmp.99999.0` ends `.0`, `…​.bin.tmp` ends `.tmp`, and none contains `.corrupt.` — so all three are ignored and the only recognised entry is the healthy live index. Expected at both tiers: 0 active, 0 historical, healthy; and `open()` still returns the index with its one vector. The lock file is produced by a **real** `save()` rather than written by the test, and the test asserts it exists, so it fails loudly if #453 ever stops creating it instead of quietly testing nothing.
10. **`a_damaged_index_is_read_and_warned_about_once_per_incident_not_once_per_row`** (new). Five `Doc` nodes, one saved index, then damaged under the open database. The **warning count is the observable**: row 2 can only skip its warning by taking the cached path, so `warns == 1` over a five-row scan is direct evidence that four rows never touched the file. A `tracing` layer counts `WARN` events mentioning `hybrid_search`; it is installed globally rather than thread-locally because the engine may evaluate rows on a worker thread and a thread-local default would silently count zero — a test that cannot observe what it asserts is worse than no test. Then the original image is written back mid-session and every row must see the repair with zero warnings. That the cached negative cannot survive the repair is hand-derived, not assumed: the restored fingerprint is `(generation, crc32c)` whose second element is at most `u32::MAX` = 4_294_967_295, while the damaged file's fallback is `(4, mtime_nanos)` at ~1.7e18, so the two can never compare equal.

    The `WITH d` in the test query is **load-bearing**. Without it the chunked pipeline serves the scan and never dispatches `hybrid_search` at all, returning `Null` for a perfectly healthy index — the test would have passed for entirely the wrong reason, never reaching the path it claims to exercise. The baseline assertion is what caught that, and it is filed separately as #459.

### JavaScript — `npm/sparrowdb/test/integration.test.js`, 7 tests (4 rewritten, 3 new)

Run by the existing CI Node.js job. Every report received is checked with `assertReportShape`, which re-derives `healthy` from `unscannable` and `active.length` and asserts the native field agrees.

- **`both tiers are static methods on the class, not instance methods`** — extends the #454 guard to the new static, and pins that the *instance* `vectorIndexHealth(label, prop)` stays an instance method, so the two "health" calls cannot be confused.
- **`never throws, and distinguishes "nothing wrong" from "could not look"`** (new). Derived from `scan_vector_index_dir`: an absent `vector_indexes/` gives `read_dir` ENOENT *and* `symlink_metadata` ENOENT → ordinary no-index case → scanned, healthy. A path containing a NUL byte cannot reach the OS at all; `read_dir` fails `InvalidInput`, which is not `NotFound` → `unscannable`, `healthy === false`. Both tiers.
- **`a chmod-000 index directory is not reported as healthy`** (new). Healthy control, then `chmod 000` on `vector_indexes/`: `unscannable` is a string, `active` empty, `healthy === false`, `notDeepEqual(blind, control)`, and `open()` throws. Skips under root.
- **`a healthy database reports healthy, with both lists empty`** — control, both tiers.
- **`reports live damage WITHOUT quarantining it — the report is read-only`** (rewritten; this is the #455 guard). Asserts `active.length === 1`, `path === indexFile`, `fs.existsSync(entry.path)`, bytes unchanged, **zero** artifacts created by the read, and `second` deep-equals the first.
- **`a rebuilt pair moves from active to historical`** (new). Damaged index → failed `open()` quarantines it → 1 `active`, 0 `historical`. Operator calls `createVectorIndex` for the same pair → the artifact count is still exactly 1 (rebuilding must not touch it) and the *same* artifact must now be 1 `historical`, 0 `active`, `healthy === true`, with `fs.existsSync(historical[0].path)` still true. Both tiers.
- **`is callable on a database that refuses to open, and keeps reporting after it starts opening "clean"`** — the #451 guard from #454, migrated to `report.active`, with `healthy === false` added.

**Existing tests updated, not weakened:** `vector_index_durability.rs::rejected_index_file_is_quarantined_rather_than_left_to_be_overwritten` now calls `load_and_quarantine` (assertions unchanged — that arm still quarantines). `vector_index_load_errors.rs` migrated from tuple indexing to named fields; all six assertions kept.

## prefix_failure_proof

Proved by reverting the source to the pre-fix tree (`git stash` / `git checkout c9524be -- <files>`), running, then restoring. The Rust test file was restored byte-exact and verified by sha256 (`88ddfaf0…` round 1, `60a50ed6…` round 2).

**Round 1 — the six original Rust tests: 6 failed, 0 passed**, each with the named symptom. The only adaptation was `load_and_quarantine(` → `load(`, since the function does not exist pre-fix; that substitution makes test 5 fail on the right assertion.

```
hybrid_search_..._neither_renames_nor_reports_zero_hits  a READ QUERY renamed .../hnsw_Doc_embedding.bin away
one_open_reports_every_damaged_index                     `Note` missing from: corruption: vector index for (Doc, embedding) …
the_diagnostic_is_read_only_and_reports_a_path...        the reported path .../hnsw_Memory_embedding.bin does not resolve
a_stale_artifact_beside_a_healthy_index_is_not_reported  left: 2  right: 1
a_dangling_symlink_is_not_mistaken_for_an_absent_index   left: 0  right: 1
load_leaves_the_file_alone_and_load_and_quarantine...    load() must not move the file
```

**Round 2 — MEASURED pre-fix values for the reshaped and newly added Rust claims:**

```
P7 control (healthy store)             : len=0
P7 chmod-000 dir really blocked        : true
P7 blind (chmod 000 vector_indexes/)   : len=0
P7 blind == control                    : true          <- green and blind are byte-identical
P7 open() on unlistable dir            : Ok
P7   get_vector_index(Memory,embedding): false         <- and the index silently vanished
P8 chmod-000 file really blocked       : true
P8 pre-fix deep report                 : len=1
P8 pre-fix cheap tier                  : does not exist (no vector_index_health)
P3 rebuilt pair + orphan artifact      : reported=2 (expected active=1, historical=1)
P3   reported: (Ghost, vec)
P3   reported: (Memory, embedding)                     <- repaired pair still red
P6 dangling symlink reported           : len=0
P6 open() with dangling symlink        : Ok            <- present, treated as absent
```

**Round 3 — MEASURED at the JS boundary**, against a `--release` `sparrowdb-node` built from the pre-fix source:

```
J5 return type              : Array
J5 reported len             : 1
J5 reported path            : .bin
J5 fs.existsSync(entry.path): false     <- #455, at the boundary the consumer actually calls
J5 artifacts created by READ: 1         <- a getter-shaped call renamed the file
J5 second call == first     : false     <- and the first call caused the difference
J6 after rebuild, reported  : 1 (expected active=0, historical=1)
J6 has `historical` field   : no — bare array
J6 has `healthy` field      : no — bare array
J3 chmod really blocked     : true
J3 control                  : []
J3 blind                    : []
J3 blind === control        : true      <- green and blind are byte-identical in JS too
J3 has `unscannable` field  : no — bare array
J3 open() on unlistable dir : Ok
```

**Round 4 — MEASURED for the negative cache**, with only the caching change reverted (the rest of the PR in place), five-row scan against one damaged index:

```
warnings emitted, before the caching commit : 5     <- one per row, one full re-read per row
warnings emitted, after                     : 1
after mid-session repair                    : 0, and every row returns a list
```

Test 8 (`the_cheap_tier_reads_no_index_contents`) and the `vectorIndexDamageScan` assertions cannot "fail pre-fix" in the regression sense: the cheap tier did not exist. P8 and the J-rows record what the only pre-fix behaviour was.

## verification_run

`CARGO_TARGET_DIR=/Volumes/Dev/target-456`, cargo `/Users/ryaker/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo`. All re-run on the tree rebased onto c9f7a0b.

| command | result |
|---|---|
| `cargo test -p sparrowdb -p sparrowdb-storage -p sparrowdb-execution --no-fail-fast` | exit 0 — see below |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --exclude sparrowdb-ruby --all-targets --keep-going -- -D warnings` | clean |
| `cargo build --release -p sparrowdb-node` (CI's Node.js job, reproduced locally) | builds |
| `node --test npm/sparrowdb/test/integration.test.js` | **47 pass, 0 fail** |
| fresh clone of the pushed branch, `cargo fmt --all -- --check` | clean |

`tracing-subscriber` is added as a **dev-dependency** of `sparrowdb` for the warning-count test. It was already a workspace dependency and already in `Cargo.lock`, so nothing new is vendored and no shipped artifact gains a dependency.

## could_not_verify

- **Anything requiring `cargo test --workspace`.** `sparrowdb-ruby` does not compile against the installed Ruby here (magnus/rb_sys, ~79 errors). It was not touched and has no reference to these APIs, but it was not compiled.
- **`index.d.ts` does not parse as TypeScript** — pre-existing, issue #449. I matched the surrounding style rather than fixing it, so my additions inherit the same problem. Not verified with `tsc`.
- **Non-unix behaviour.** Rust tests 6-8 and the JS `chmod` test are unix-gated or unix-dependent. Dangling-symlink and permission semantics on Windows are unverified; the underlying `symlink_metadata` / `read_dir` calls are portable but the fixtures are not. The CI Node.js job runs on Linux only, so the `chmod` test is not exercised on Windows.
- **Running as root.** The three permission tests skip themselves if `chmod 000` does not block the uid. On a root runner they pass without exercising anything.
- **The 8 MB scale claim.** Argued from the code path (`load` → `fs::read` + `bincode::deserialize` + `validate_invariants` over the whole graph, once per live index per call) and from the consumer's report. Not benchmarked on an 8 MB index.
- **Concurrency.** No test exercises a diagnostic running concurrently with a writer's `save()`, or two `open()`s racing to quarantine the same file. The scan-then-probe window is unchanged from `main`.
- **Concurrency against #453's save lock.** Test 9 covers the static composition — that the new `.lock` and `.tmp.<pid>.<nonce>` sidecars are not misread as indexes. It does **not** cover a diagnostic running while a writer holds the save lock, nor two `open()`s racing to quarantine the same file. `load_and_quarantine` does not take that lock; unchanged from `main`, but unverified under contention.
- **Which thread evaluates a row.** The warning counter uses a global `tracing` subscriber precisely so the count is correct either way, but I did not confirm whether rows are evaluated on the calling thread or a worker. The assertion holds regardless; the claim I am *not* making is that evaluation is single-threaded.
- **npm publish artifacts.** The `@sparrowdb/*` platform packages are not rebuilt here; only the locally built `.node` was exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE
