### PR TITLE
fix(storage): bound WAL props count before allocating (closes #461)

### DIFF
--- a/crates/sparrowdb-storage/src/wal/codec.rs
+++ b/crates/sparrowdb-storage/src/wal/codec.rs
@@ -185,6 +185,17 @@ fn decode_props(bytes: &[u8], offset: usize) -> Result<(Vec<WalProp>, usize)> {
     }
     let count = u32::from_le_bytes(bytes[pos..pos + 4].try_into().unwrap()) as usize;
     pos += 4;
+    // `count` is read straight from the (possibly corrupt/mis-decrypted) buffer
+    // and must be bounded before it drives an allocation. Every prop needs at
+    // least 8 bytes on the wire (key_len + val_len), so a count implying more
+    // props than could possibly fit in the remaining bytes is provably corrupt
+    // — reject it here rather than trusting it to size a `Vec`.
+    let remaining = bytes.len() - pos;
+    if count > remaining / 8 {
+        return Err(Error::Corruption(format!(
+            "props count {count} exceeds remaining bytes ({remaining})"
+        )));
+    }
     let mut props = Vec::with_capacity(count);
     for _ in 0..count {
         if bytes.len() < pos + 4 {
@@ -865,6 +876,79 @@ mod tests {
                 assert_eq!(image.len(), 4096);
             }
             _ => panic!("wrong payload"),
+        }
+    }
+
+    #[test]
+    fn test_decode_props_rejects_bogus_count_before_allocating() {
+        // count = u32::MAX, followed by only 4 trailing bytes.
+        //
+        // Hand-derived expected outcome (not captured from running the code):
+        // - offset = 0, so after reading the 4-byte count, pos = 4.
+        // - remaining = bytes.len() - pos = 8 - 4 = 4.
+        // - Each prop needs >= 8 bytes on the wire (key_len(4) + val_len(4)),
+        //   so the maximum count that could possibly fit is remaining / 8 = 0.
+        // - count (u32::MAX = 4294967295) > 0, so this must be rejected as
+        //   corrupt *before* `Vec::with_capacity(count)` ever runs — that
+        //   capacity would be ~4.29e9 * size_of::<WalProp>() bytes, the same
+        //   class of allocation that aborts the process on #461.
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&u32::MAX.to_le_bytes()); // count
+        bytes.extend_from_slice(&[0u8; 4]); // far too little data to follow
+
+        let result = decode_props(&bytes, 0);
+        match result {
+            Err(Error::Corruption(msg)) => {
+                assert!(
+                    msg.contains("props count") && msg.contains("4294967295"),
+                    "unexpected corruption message: {msg}"
+                );
+            }
+            other => panic!("expected Err(Error::Corruption(_)), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_node_create_round_trip_with_props() {
+        // Sanity check that the new bound in decode_props doesn't reject
+        // legitimate encodings: a real prop list is always >= 8 bytes/entry
+        // on the wire, so count <= remaining / 8 always holds for genuine data.
+        let payload = WalPayload::NodeCreate {
+            node_id: 7,
+            label_id: 3,
+            props: vec![
+                ("name".to_string(), vec![1, 2, 3]),
+                ("age".to_string(), vec![42]),
+            ],
+        };
+        let encoded = payload.encode();
+        let decoded = WalPayload::decode_plaintext(WalRecordKind::NodeCreate, &encoded).unwrap();
+        assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    fn test_node_create_rejects_bogus_props_count_via_public_entry_point() {
+        // Same corruption as test_decode_props_rejects_bogus_count_before_allocating,
+        // but exercised through the public WalPayload::decode_plaintext entry
+        // point (the one WAL replay actually calls) with a NodeCreate payload:
+        // node_id(8) + label_id(4) + count(4)=u32::MAX + 4 trailing bytes.
+        // remaining after count = 4, 4 / 8 = 0, so u32::MAX is rejected before
+        // any allocation is attempted.
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&7u64.to_le_bytes()); // node_id
+        bytes.extend_from_slice(&3u32.to_le_bytes()); // label_id
+        bytes.extend_from_slice(&u32::MAX.to_le_bytes()); // bogus props count
+        bytes.extend_from_slice(&[0u8; 4]); // far too little data to follow
+
+        let result = WalPayload::decode_plaintext(WalRecordKind::NodeCreate, &bytes);
+        match result {
+            Err(Error::Corruption(msg)) => {
+                assert!(
+                    msg.contains("props count") && msg.contains("4294967295"),
+                    "unexpected corruption message: {msg}"
+                );
+            }
+            other => panic!("expected Err(Error::Corruption(_)), got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary

`decode_props()` in `crates/sparrowdb-storage/src/wal/codec.rs:186` read an unvalidated `u32` count straight from the WAL buffer and passed it to `Vec::with_capacity(count)` **before** any of the loop's own bounds checks ran. Decrypting an encrypted WAL with the wrong key (or replaying any corrupt WAL — encryption isn't required to trigger this) turns `count` into garbage up to `u32::MAX`. With `WalProp = (String, Vec<u8>)` at 48 bytes, that's up to a ~192 GiB allocation attempt, which SIGABRTs the process instead of returning the `Error::Corruption` every other field read in this decoder already produces.

## Mechanism — measured, not inferred

The GH issue observed `memory allocation of 135243999024 bytes failed` and `180977756016 bytes failed` on Linux CI. Both divide evenly by `size_of::<WalProp>() = 48`, landing on plausible garbage `u32` values.

I reproduced the exact abort locally via a Linux container with strict overcommit accounting (`vm.overcommit_memory=2`, the setting that makes an oversized `mmap` fail immediately instead of being lazily reserved):

```
$ ./repro   # Vec::<WalProp>::with_capacity(u32::MAX) under vm.overcommit_memory=2
memory allocation of 206158430160 bytes failed
Aborted
$ echo $?
134   # SIGABRT
```

`206158430160 / 48 = 4294967295 = u32::MAX` exactly — confirms the arithmetic mechanism byte-for-byte, not just by analogy to the issue's numbers.

Running the **fixed** logic (bound check applied) under the identical strict-overcommit condition:

```
$ ./repro_fixed
REJECTED before allocating: count=4294967295 exceeds remaining/8=0
$ echo $?
0
```

**macOS caveat (this dev machine):** `Vec::with_capacity` for the same size does *not* abort on macOS — its VM overcommit lazily reserves address space without touching physical pages, so the reservation silently succeeds and the loop's own downstream bounds check then catches the corruption anyway (with a different `Error::Corruption` message). `spa_98_wal_encryption` passes 4/4 on this machine both **before and after** this fix, for the same reason — confirmed, not assumed. `ulimit -v` does not work on Darwin (`setrlimit failed: invalid argument`), so I used a Linux container with `vm.overcommit_memory=2` to get an apples-to-apples repro of the actual CI failure mode instead.

## Fix

```rust
let remaining = bytes.len() - pos;
if count > remaining / 8 {
    return Err(Error::Corruption(format!(
        "props count {count} exceeds remaining bytes ({remaining})"
    )));
}
let mut props = Vec::with_capacity(count);
```

Each prop needs >= 8 bytes on the wire (`key_len` + `val_len`), so `count > remaining / 8` is provably corrupt and rejected up front — same `Error::Corruption` type and style as the neighbouring checks in this file, no behavior change beyond turning an abort into the error it should already have been.

## Audit of every other length/count read in codec.rs

| Site | Reads | Disposition |
|---|---|---|
| `:186` (`decode_props`, props count) | **Fixed** — unbounded, drove the allocation directly |
| `:232` (`decode_str`, string length) | Validated against `bytes.len()` before the slice/`to_vec()`; safe |
| `:376` (`Write` payload, `image_len`) | Validated (`bytes.len() < 12 + image_len`) before slicing; safe |
| `:410` / `:421` (`NodeUpdate`, `before_len`/`after_len`) | Both validated against remaining bytes before slicing; safe |
| `:506` (`WalRecord::encode`, `Vec::with_capacity(total_len)`) | Write/encode path — `total_len` derives from an in-memory `Vec` the caller already owns, not an untrusted on-disk buffer. Not a corruption vector. |
| `:546` / `:622` (`WalRecord::decode`/`decode_with_version`, `length_val`) | Validated against `bytes.len()` before use; only slices (borrows), never allocates from the value. Safe |

`:186` was the only unguarded site in this file.

## Tests

Three new tests in `codec.rs`:
- `test_decode_props_rejects_bogus_count_before_allocating` — `decode_props` given an 8-byte buffer (`count=u32::MAX` + 4 trailing bytes). Expected outcome hand-derived: `remaining=4`, `4/8=0`, so `u32::MAX > 0` is rejected before any allocation.
- `test_node_create_rejects_bogus_props_count_via_public_entry_point` — same corruption exercised through the real `WalPayload::decode_plaintext` entry point WAL replay calls.
- `test_node_create_round_trip_with_props` — sanity check the new bound doesn't reject legitimate encodings (real prop lists are always >= 8 bytes/entry on the wire).

All three complete in <0.01s with no gigabyte-scale allocation (~245MB peak RSS measured).

## Test plan

- [x] `cargo test -p sparrowdb-storage --lib wal::codec` — 15 passed, 1 ignored (fixture generator), 0 failed
- [x] `cargo test -p sparrowdb --test spa_98_wal_encryption` — 4/4 passed (both before and after fix, on macOS — see caveat above)
- [x] `cargo test --workspace --exclude sparrowdb-ruby --no-fail-fast` — 216/216 test binaries `ok`, 1464 test cases, 0 failures
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --exclude sparrowdb-ruby --all-targets --keep-going -- -D warnings` — clean
- [x] Literal pre-fix repro on Linux with `vm.overcommit_memory=2`: SIGABRT, exit 134, "memory allocation of 206158430160 bytes failed"
- [x] Literal post-fix repro under identical conditions: clean rejection, exit 0

Closes #461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when decoding stored data to detect corrupt or implausibly large property counts.
  * Prevented invalid data from triggering excessive memory allocation.
  * Added coverage for valid records and corruption handling across decoding paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->