### PR TITLE
feat(cypher): UNWIND MATCH SET/DELETE + DELETE RETURN (SPA-415) — rebase of #411 with tests (closes #468)

### DIFF
--- a/crates/sparrowdb-cypher/src/ast.rs
+++ b/crates/sparrowdb-cypher/src/ast.rs
@@ -327,6 +327,34 @@ pub struct MatchMutateStatement {
     /// For SET, there may be multiple items (comma-separated).
     /// For DELETE, this always contains exactly one `Mutation::Delete`.
     pub mutations: Vec<Mutation>,
+    /// Optional RETURN clause after mutations (e.g. `DELETE n RETURN count(n)`).
+    pub return_clause: Option<ReturnClause>,
+}
+
+/// UNWIND … MATCH … SET/DELETE statement (SPA-415).
+///
+/// Iterates a list expression, binding each element to `alias`, then for
+/// each element executes a MATCH + mutation (SET or DELETE).
+///
+/// ```cypher
+/// UNWIND $updates AS row
+/// MATCH (n:Memory {id: row.id})
+/// SET n.score = row.score
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct UnwindMatchMutateStatement {
+    /// The list expression to unwind (e.g. `$updates`).
+    pub expr: Expr,
+    /// Variable bound to each list element (e.g. `row`).
+    pub alias: String,
+    /// The MATCH patterns whose nodes are mutated.
+    pub match_patterns: Vec<PathPattern>,
+    /// Optional WHERE predicate on the MATCH.
+    pub where_clause: Option<Expr>,
+    /// The mutations to apply (SET or DELETE).
+    pub mutations: Vec<Mutation>,
+    /// Optional RETURN clause after mutations.
+    pub return_clause: Option<ReturnClause>,
 }
 
 /// A single projection in a WITH clause: `expr AS alias`.
@@ -501,6 +529,8 @@ pub enum Statement {
     /// MATCH … MERGE (a)-[r:TYPE]->(b) — find-or-create a relationship (SPA-233).
     MatchMergeRel(MatchMergeRelStatement),
     MatchMutate(MatchMutateStatement),
+    /// UNWIND … MATCH … SET/DELETE — batched mutations via list parameter (SPA-415).
+    UnwindMatchMutate(UnwindMatchMutateStatement),
     OptionalMatch(OptionalMatchStatement),
     MatchOptionalMatch(MatchOptionalMatchStatement),
     Union(UnionStatement),

--- a/crates/sparrowdb-cypher/src/binder.rs
+++ b/crates/sparrowdb-cypher/src/binder.rs
@@ -14,8 +14,8 @@ use sparrowdb_catalog::catalog::Catalog;
 use sparrowdb_common::Result;
 
 use crate::ast::{
-    MatchMergeRelStatement, MatchOptionalMatchStatement, MatchStatement,
-    MatchWithStatement, PathPattern, Statement, UnwindMatchMutateStatement,
+    MatchMergeRelStatement, MatchOptionalMatchStatement, MatchStatement, MatchWithStatement,
+    PathPattern, Statement, UnwindMatchMutateStatement,
 };
 
 /// A bound statement — the AST annotated with resolved catalog IDs.

--- a/crates/sparrowdb-cypher/src/binder.rs
+++ b/crates/sparrowdb-cypher/src/binder.rs
@@ -14,8 +14,8 @@ use sparrowdb_catalog::catalog::Catalog;
 use sparrowdb_common::Result;
 
 use crate::ast::{
-    MatchMergeRelStatement, MatchMutateStatement, MatchOptionalMatchStatement, MatchStatement,
-    MatchWithStatement, PathPattern, Statement,
+    MatchMergeRelStatement, MatchOptionalMatchStatement, MatchStatement,
+    MatchWithStatement, PathPattern, Statement, UnwindMatchMutateStatement,
 };
 
 /// A bound statement — the AST annotated with resolved catalog IDs.
@@ -57,7 +57,8 @@ pub fn bind(stmt: Statement, catalog: &Catalog) -> Result<BoundStatement> {
         // MATCH…MERGE relationship: validate the MATCH patterns (labels must
         // exist); the rel type may not exist yet — merge_edge will create it.
         Statement::MatchMergeRel(mm) => bind_match_merge_rel(mm, catalog)?,
-        Statement::MatchMutate(mm) => bind_match_mutate(mm, catalog)?,
+        Statement::MatchMutate(mm) => bind_match_mutate_patterns(&mm.match_patterns, catalog)?,
+        Statement::UnwindMatchMutate(umm) => bind_unwind_match_mutate(umm, catalog)?,
         // OPTIONAL MATCH: label/rel-type may not exist yet — that is exactly
         // the case that produces NULL rows.  Skip existence checks.
         Statement::OptionalMatch(_) => {}
@@ -92,13 +93,19 @@ fn bind_match_with(mw: &MatchWithStatement, catalog: &Catalog) -> Result<()> {
     Ok(())
 }
 
-fn bind_match_mutate(mm: &MatchMutateStatement, catalog: &Catalog) -> Result<()> {
-    for pat in &mm.match_patterns {
+fn bind_match_mutate_patterns(patterns: &[PathPattern], catalog: &Catalog) -> Result<()> {
+    for pat in patterns {
         bind_path_pattern(pat, catalog)?;
     }
     // The mutation itself (SET/DELETE) targets variables already bound by
     // the MATCH patterns — no additional catalog lookups are needed here.
     Ok(())
+}
+
+fn bind_unwind_match_mutate(umm: &UnwindMatchMutateStatement, catalog: &Catalog) -> Result<()> {
+    // UNWIND expression uses parameters ($param) — no catalog binding needed.
+    // MATCH patterns must reference existing labels/rel-types.
+    bind_match_mutate_patterns(&umm.match_patterns, catalog)
 }
 
 fn bind_match_merge_rel(mm: &MatchMergeRelStatement, catalog: &Catalog) -> Result<()> {

--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -677,28 +677,37 @@ impl Parser {
     /// Called after the `SET` keyword has already been consumed.
     /// Returns a `Vec<Mutation::Set>` with at least one item.
     fn parse_set_items(&mut self) -> Result<Vec<Mutation>> {
+        self.parse_set_items_inner(false)
+    }
+
+    /// Variant that allows `PropAccess` values (e.g. `row.score`) in SET,
+    /// used inside `UNWIND … MATCH … SET` where the caller resolves row
+    /// references at execution time (SPA-415).
+    fn parse_set_items_allow_prop(&mut self) -> Result<Vec<Mutation>> {
+        self.parse_set_items_inner(true)
+    }
+
+    fn parse_set_items_inner(&mut self, allow_prop_access: bool) -> Result<Vec<Mutation>> {
         let mut items = Vec::new();
         loop {
             let var = self.expect_ident()?;
             self.expect_tok(&Token::Dot)?;
-            // Use advance_as_prop_name so keyword tokens (e.g. `match`, `count`)
-            // are accepted as property names, consistent with SPA-265 behavior.
             let prop = self.advance_as_prop_name()?;
             self.expect_tok(&Token::Eq)?;
             let value = self.parse_expr()?;
             // Guard: the write helpers (expr_to_value / expr_to_value_with_params)
-            // only materialise Expr::Literal values.  Any other expression (e.g.
-            // arithmetic, property access) would be silently coerced to
-            // Value::Int64(0) and corrupt data.  Reject them at parse time until
-            // a full expression evaluator is wired into the SET path.
-            if !matches!(value, Expr::Literal(_)) {
+            // only materialise Expr::Literal values.  PropAccess is allowed when
+            // the caller (UNWIND … MATCH … SET) resolves it at execution time.
+            let is_literal = matches!(value, Expr::Literal(_));
+            let is_prop = matches!(value, Expr::PropAccess { .. });
+            if !is_literal && !(allow_prop_access && is_prop) {
                 return Err(Error::InvalidArgument(
                     "SET property value must be a literal or $parameter".into(),
                 ));
             }
             items.push(Mutation::Set { var, prop, value });
             if matches!(self.peek(), Token::Comma) {
-                self.advance(); // consume the comma
+                self.advance();
             } else {
                 break;
             }
@@ -1735,7 +1744,7 @@ impl Parser {
         let (where_clause, mutations) = match self.peek().clone() {
             Token::Set => {
                 self.advance();
-                (None, self.parse_set_items()?)
+                (None, self.parse_set_items_allow_prop()?)
             }
             Token::Detach => {
                 self.advance();
@@ -1754,7 +1763,7 @@ impl Parser {
                 let mutations = match self.peek().clone() {
                     Token::Set => {
                         self.advance();
-                        self.parse_set_items()?
+                        self.parse_set_items_allow_prop()?
                     }
                     Token::Detach => {
                         self.advance();

--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -1658,18 +1658,50 @@ impl Parser {
             self.advance(); // consume MATCH
             let patterns = self.parse_pattern_list()?;
 
-            // Peek ahead to decide: mutation (SET/DELETE/WHERE) or read pipeline?
+            // A WHERE here belongs to the MATCH and is legal in *both* shapes:
+            //   UNWIND … MATCH … WHERE … SET/DELETE   (mutation)
+            //   UNWIND … MATCH … WHERE … RETURN       (read)
+            // Parse it once, up front, so the read/mutate decision is made on
+            // the token that actually distinguishes them. Dispatching on WHERE
+            // itself sent every read with a predicate into the mutation tail,
+            // which then rejected it (#468).
+            let where_clause = if matches!(self.peek(), Token::Where) {
+                self.advance();
+                Some(self.parse_expr()?)
+            } else {
+                None
+            };
+
             match self.peek().clone() {
-                Token::Set | Token::Delete | Token::Detach | Token::Where => {
-                    return self.parse_unwind_match_mutate_tail(expr, alias, patterns);
+                Token::Set | Token::Delete | Token::Detach => {
+                    return self.parse_unwind_match_mutate_tail(
+                        expr,
+                        alias,
+                        patterns,
+                        where_clause,
+                    );
                 }
                 _ => {
                     // Read pipeline: UNWIND ... MATCH ... RETURN/WITH/...
+                    //
+                    // The MATCH is handed over as a pipeline *stage*, not as
+                    // `leading_match`. `execute_pipeline_inner` picks the leading
+                    // clause with an `if / else if` chain that tests
+                    // `leading_unwind` before `leading_match`, so setting both
+                    // makes the MATCH arm unreachable and the pattern is dropped
+                    // silently — rows come back with no binding and project as
+                    // NULL (#468). Before SPA-415 this MATCH was consumed by
+                    // `parse_pipeline_continuation`'s own loop as a stage; we
+                    // only pre-consumed it here to look ahead for SET/DELETE, so
+                    // hand it back in the shape that loop would have produced.
                     return self.parse_pipeline_continuation(
-                        Some(patterns),
+                        None,
                         None,
                         Some((expr, alias)),
-                        vec![],
+                        vec![PipelineStage::Match {
+                            patterns,
+                            where_clause,
+                        }],
                     );
                 }
             }
@@ -1728,66 +1760,39 @@ impl Parser {
 
     // ── UNWIND … MATCH … SET/DELETE (SPA-415) ────────────────────────────────
 
-    /// Parse the mutation tail after `UNWIND … AS alias MATCH patterns`
-    /// have already been consumed by the caller.  The caller is responsible
-    /// for peeking at the token after `patterns` to decide whether this is
-    /// a mutation (SET/DELETE/DETACH/WHERE) or a read pipeline.
+    /// Parse the mutation tail after `UNWIND … AS alias MATCH patterns
+    /// [WHERE pred]` have already been consumed by the caller.  The caller
+    /// parses any WHERE and passes it in, then dispatches on SET / DELETE /
+    /// DETACH — the tokens that actually distinguish a mutation from a read
+    /// pipeline.
     fn parse_unwind_match_mutate_tail(
         &mut self,
         expr: Expr,
         alias: String,
         patterns: Vec<PathPattern>,
+        where_clause: Option<Expr>,
     ) -> Result<Statement> {
-
         // Dispatch on the next token to determine the mutation type, reusing
         // the same logic as parse_match_or_match_mutate.
-        let (where_clause, mutations) = match self.peek().clone() {
+        let mutations = match self.peek().clone() {
             Token::Set => {
                 self.advance();
-                (None, self.parse_set_items_allow_prop()?)
+                self.parse_set_items_allow_prop()?
             }
             Token::Detach => {
                 self.advance();
                 self.expect_tok(&Token::Delete)?;
                 let var = self.expect_ident()?;
-                (None, vec![Mutation::Delete { var, detach: true }])
+                vec![Mutation::Delete { var, detach: true }]
             }
             Token::Delete => {
                 self.advance();
                 let var = self.expect_ident()?;
-                (None, vec![Mutation::Delete { var, detach: false }])
-            }
-            Token::Where => {
-                self.advance();
-                let where_expr = self.parse_expr()?;
-                let mutations = match self.peek().clone() {
-                    Token::Set => {
-                        self.advance();
-                        self.parse_set_items_allow_prop()?
-                    }
-                    Token::Detach => {
-                        self.advance();
-                        self.expect_tok(&Token::Delete)?;
-                        let var = self.expect_ident()?;
-                        vec![Mutation::Delete { var, detach: true }]
-                    }
-                    Token::Delete => {
-                        self.advance();
-                        let var = self.expect_ident()?;
-                        vec![Mutation::Delete { var, detach: false }]
-                    }
-                    other => {
-                        return Err(Error::InvalidArgument(format!(
-                            "expected SET, DELETE, or DETACH DELETE after WHERE in UNWIND MATCH, got {:?}",
-                            other
-                        )));
-                    }
-                };
-                (Some(where_expr), mutations)
+                vec![Mutation::Delete { var, detach: false }]
             }
             other => {
                 return Err(Error::InvalidArgument(format!(
-                    "expected SET, DELETE, DETACH DELETE, or WHERE after UNWIND MATCH patterns, got {:?}",
+                    "expected SET, DELETE, or DETACH DELETE after UNWIND MATCH patterns, got {:?}",
                     other
                 )));
             }
@@ -1797,14 +1802,13 @@ impl Parser {
         let return_clause = self.parse_optional_return()?;
 
         Ok(Statement::UnwindMatchMutate(UnwindMatchMutateStatement {
-                expr,
-                alias,
-                match_patterns: patterns,
-                where_clause,
-                mutations,
-                return_clause,
-            },
-        ))
+            expr,
+            alias,
+            match_patterns: patterns,
+            where_clause,
+            mutations,
+            return_clause,
+        }))
     }
 
     fn parse_create_body(&mut self) -> Result<CreateStatement> {

--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -1765,13 +1765,7 @@ impl Parser {
         };
 
         // Optional RETURN clause after mutations.
-        let return_clause = if matches!(self.peek(), Token::Return) {
-            self.advance();
-            let items = self.parse_return_items()?;
-            Some(ReturnClause { items })
-        } else {
-            None
-        };
+        let return_clause = self.parse_optional_return()?;
 
         Ok(Statement::UnwindMatchMutate(UnwindMatchMutateStatement {
                 expr,

--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -1646,7 +1646,24 @@ impl Parser {
             return self.parse_pipeline_continuation(None, None, Some((expr, alias)), vec![]);
         }
         if matches!(self.peek(), Token::Match) {
-            return self.parse_unwind_match_mutate(expr, alias);
+            self.advance(); // consume MATCH
+            let patterns = self.parse_pattern_list()?;
+
+            // Peek ahead to decide: mutation (SET/DELETE/WHERE) or read pipeline?
+            match self.peek().clone() {
+                Token::Set | Token::Delete | Token::Detach | Token::Where => {
+                    return self.parse_unwind_match_mutate_tail(expr, alias, patterns);
+                }
+                _ => {
+                    // Read pipeline: UNWIND ... MATCH ... RETURN/WITH/...
+                    return self.parse_pipeline_continuation(
+                        Some(patterns),
+                        None,
+                        Some((expr, alias)),
+                        vec![],
+                    );
+                }
+            }
         }
 
         self.expect_tok(&Token::Return)?;
@@ -1702,13 +1719,16 @@ impl Parser {
 
     // ── UNWIND … MATCH … SET/DELETE (SPA-415) ────────────────────────────────
 
-    /// Parse `UNWIND <expr> AS <var> MATCH <patterns> SET/DELETE ... [RETURN ...]`.
-    ///
-    /// The UNWIND keyword and expression have already been consumed by
-    /// `parse_unwind`.  This function handles the MATCH + mutation tail.
-    fn parse_unwind_match_mutate(&mut self, expr: Expr, alias: String) -> Result<Statement> {
-        self.expect_tok(&Token::Match)?;
-        let patterns = self.parse_pattern_list()?;
+    /// Parse the mutation tail after `UNWIND … AS alias MATCH patterns`
+    /// have already been consumed by the caller.  The caller is responsible
+    /// for peeking at the token after `patterns` to decide whether this is
+    /// a mutation (SET/DELETE/DETACH/WHERE) or a read pipeline.
+    fn parse_unwind_match_mutate_tail(
+        &mut self,
+        expr: Expr,
+        alias: String,
+        patterns: Vec<PathPattern>,
+    ) -> Result<Statement> {
 
         // Dispatch on the next token to determine the mutation type, reusing
         // the same logic as parse_match_or_match_mutate.

--- a/crates/sparrowdb-cypher/src/parser.rs
+++ b/crates/sparrowdb-cypher/src/parser.rs
@@ -11,7 +11,7 @@ use crate::ast::{
     MatchOptionalMatchStatement, MatchStatement, MergeStatement, Mutation, NodePattern,
     OptionalMatchStatement, PathPattern, PipelineStage, PipelineStatement, PropEntry, RelPattern,
     ReturnClause, ReturnItem, ShortestPathExpr, SortDir, Statement, UnionStatement,
-    UnwindStatement, WithClause, WithItem,
+    UnwindMatchMutateStatement, UnwindStatement, WithClause, WithItem,
 };
 use crate::lexer::{tokenize, Token};
 
@@ -353,10 +353,12 @@ impl Parser {
                 // MATCH ... SET var.prop = expr [, var.prop = expr ...]
                 self.advance();
                 let mutations = self.parse_set_items()?;
+                let return_clause = self.parse_optional_return()?;
                 Ok(Statement::MatchMutate(MatchMutateStatement {
                     match_patterns: patterns,
                     where_clause: None,
                     mutations,
+                    return_clause,
                 }))
             }
             Token::Detach => {
@@ -364,20 +366,24 @@ impl Parser {
                 self.advance();
                 self.expect_tok(&Token::Delete)?;
                 let var = self.expect_ident()?;
+                let return_clause = self.parse_optional_return()?;
                 Ok(Statement::MatchMutate(MatchMutateStatement {
                     match_patterns: patterns,
                     where_clause: None,
                     mutations: vec![Mutation::Delete { var, detach: true }],
+                    return_clause,
                 }))
             }
             Token::Delete => {
                 // MATCH ... DELETE var
                 self.advance();
                 let var = self.expect_ident()?;
+                let return_clause = self.parse_optional_return()?;
                 Ok(Statement::MatchMutate(MatchMutateStatement {
                     match_patterns: patterns,
                     where_clause: None,
                     mutations: vec![Mutation::Delete { var, detach: false }],
+                    return_clause,
                 }))
             }
             Token::Where => {
@@ -388,10 +394,12 @@ impl Parser {
                     Token::Set => {
                         self.advance();
                         let mutations = self.parse_set_items()?;
+                        let return_clause = self.parse_optional_return()?;
                         Ok(Statement::MatchMutate(MatchMutateStatement {
                             match_patterns: patterns,
                             where_clause: Some(where_expr),
                             mutations,
+                            return_clause,
                         }))
                     }
                     Token::Detach => {
@@ -399,19 +407,23 @@ impl Parser {
                         self.advance();
                         self.expect_tok(&Token::Delete)?;
                         let var = self.expect_ident()?;
+                        let return_clause = self.parse_optional_return()?;
                         Ok(Statement::MatchMutate(MatchMutateStatement {
                             match_patterns: patterns,
                             where_clause: Some(where_expr),
                             mutations: vec![Mutation::Delete { var, detach: true }],
+                            return_clause,
                         }))
                     }
                     Token::Delete => {
                         self.advance();
                         let var = self.expect_ident()?;
+                        let return_clause = self.parse_optional_return()?;
                         Ok(Statement::MatchMutate(MatchMutateStatement {
                             match_patterns: patterns,
                             where_clause: Some(where_expr),
                             mutations: vec![Mutation::Delete { var, detach: false }],
+                            return_clause,
                         }))
                     }
                     Token::With => {
@@ -1629,8 +1641,12 @@ impl Parser {
         // If the next token is WITH or MATCH, this is a pipeline:
         //   UNWIND … WITH … RETURN  (SPA-134)
         //   UNWIND … MATCH … RETURN (SPA-237)
-        if matches!(self.peek(), Token::With | Token::Match) {
+        //   UNWIND … MATCH … SET/DELETE … [RETURN] (SPA-415)
+        if matches!(self.peek(), Token::With) {
             return self.parse_pipeline_continuation(None, None, Some((expr, alias)), vec![]);
+        }
+        if matches!(self.peek(), Token::Match) {
+            return self.parse_unwind_match_mutate(expr, alias);
         }
 
         self.expect_tok(&Token::Return)?;
@@ -1682,6 +1698,90 @@ impl Parser {
         }
         self.expect_tok(&Token::RBracket)?;
         Ok(Expr::List(elems))
+    }
+
+    // ── UNWIND … MATCH … SET/DELETE (SPA-415) ────────────────────────────────
+
+    /// Parse `UNWIND <expr> AS <var> MATCH <patterns> SET/DELETE ... [RETURN ...]`.
+    ///
+    /// The UNWIND keyword and expression have already been consumed by
+    /// `parse_unwind`.  This function handles the MATCH + mutation tail.
+    fn parse_unwind_match_mutate(&mut self, expr: Expr, alias: String) -> Result<Statement> {
+        self.expect_tok(&Token::Match)?;
+        let patterns = self.parse_pattern_list()?;
+
+        // Dispatch on the next token to determine the mutation type, reusing
+        // the same logic as parse_match_or_match_mutate.
+        let (where_clause, mutations) = match self.peek().clone() {
+            Token::Set => {
+                self.advance();
+                (None, self.parse_set_items()?)
+            }
+            Token::Detach => {
+                self.advance();
+                self.expect_tok(&Token::Delete)?;
+                let var = self.expect_ident()?;
+                (None, vec![Mutation::Delete { var, detach: true }])
+            }
+            Token::Delete => {
+                self.advance();
+                let var = self.expect_ident()?;
+                (None, vec![Mutation::Delete { var, detach: false }])
+            }
+            Token::Where => {
+                self.advance();
+                let where_expr = self.parse_expr()?;
+                let mutations = match self.peek().clone() {
+                    Token::Set => {
+                        self.advance();
+                        self.parse_set_items()?
+                    }
+                    Token::Detach => {
+                        self.advance();
+                        self.expect_tok(&Token::Delete)?;
+                        let var = self.expect_ident()?;
+                        vec![Mutation::Delete { var, detach: true }]
+                    }
+                    Token::Delete => {
+                        self.advance();
+                        let var = self.expect_ident()?;
+                        vec![Mutation::Delete { var, detach: false }]
+                    }
+                    other => {
+                        return Err(Error::InvalidArgument(format!(
+                            "expected SET, DELETE, or DETACH DELETE after WHERE in UNWIND MATCH, got {:?}",
+                            other
+                        )));
+                    }
+                };
+                (Some(where_expr), mutations)
+            }
+            other => {
+                return Err(Error::InvalidArgument(format!(
+                    "expected SET, DELETE, DETACH DELETE, or WHERE after UNWIND MATCH patterns, got {:?}",
+                    other
+                )));
+            }
+        };
+
+        // Optional RETURN clause after mutations.
+        let return_clause = if matches!(self.peek(), Token::Return) {
+            self.advance();
+            let items = self.parse_return_items()?;
+            Some(ReturnClause { items })
+        } else {
+            None
+        };
+
+        Ok(Statement::UnwindMatchMutate(UnwindMatchMutateStatement {
+                expr,
+                alias,
+                match_patterns: patterns,
+                where_clause,
+                mutations,
+                return_clause,
+            },
+        ))
     }
 
     fn parse_create_body(&mut self) -> Result<CreateStatement> {
@@ -2531,6 +2631,19 @@ impl Parser {
     }
 
     // ── RETURN items ──────────────────────────────────────────────────────────
+
+    /// Parse an optional RETURN clause that may follow a mutation (SET/DELETE).
+    ///
+    /// Returns `None` when the next token is not `RETURN`.
+    fn parse_optional_return(&mut self) -> Result<Option<ReturnClause>> {
+        if matches!(self.peek(), Token::Return) {
+            self.advance();
+            let items = self.parse_return_items()?;
+            Ok(Some(ReturnClause { items }))
+        } else {
+            Ok(None)
+        }
+    }
 
     fn parse_return_items(&mut self) -> Result<Vec<ReturnItem>> {
         if matches!(self.peek(), Token::Star) {

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -976,6 +976,7 @@ impl Engine {
             Statement::Merge(_)
             | Statement::MatchMergeRel(_)
             | Statement::MatchMutate(_)
+            | Statement::UnwindMatchMutate(_)
             | Statement::MatchCreate(_) => Err(sparrowdb_common::Error::InvalidArgument(
                 "mutation statements must be executed via execute_mutation".into(),
             )),
@@ -1031,6 +1032,7 @@ impl Engine {
             Statement::Merge(_)
             | Statement::MatchMergeRel(_)
             | Statement::MatchMutate(_)
+            | Statement::UnwindMatchMutate(_)
             | Statement::MatchCreate(_) => true,
             // All standalone CREATE statements must go through the
             // write-transaction path to ensure WAL durability and correct

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -1762,6 +1762,10 @@ impl GraphDb {
         }
         let mut total_mutated: u64 = 0;
         let mut has_detach_delete = false;
+        // prop -> (vector, raw node ids). Accumulated across all UNWIND rows so
+        // the HNSW index is serialised once per (label, prop), not once per row.
+        let mut pending_vectors: std::collections::HashMap<String, (Vec<f32>, Vec<u64>)> =
+            std::collections::HashMap::new();
 
         for element in list {
             // Honour caller's deadline between iterations (fixes #310).
@@ -1818,15 +1822,19 @@ impl GraphDb {
                         // #410 silent-data-loss shape (KMSmcp ch#202), reached
                         // through a second entry point.
                         //
+                        // Writes are ACCUMULATED here and applied once after the
+                        // row loop. Saving per row costs a full index
+                        // serialization + fsync each time — measured at ~10 ms
+                        // per row, so a 1000-row UNWIND would spend ~10 s
+                        // rewriting the same file 1000 times. The MATCH…SET path
+                        // saves once per (label, prop) per statement and this
+                        // must match it.
+                        //
                         // Only the `$param` form is handled, matching the
                         // MATCH…SET path: a vector cannot survive
                         // `resolve_set_value`'s storage-layer round trip, so
                         // `SET n.emb = row.emb` cannot carry one today (see #475,
                         // where that coercion silently yields Int64(0)).
-                        //
-                        // Label is derived per matched NodeId rather than from the
-                        // AST, so anonymous and multi-label UNWIND patterns resolve
-                        // correctly.
                         if let sparrowdb_cypher::ast::Expr::Literal(
                             sparrowdb_cypher::ast::Literal::Param(p),
                         ) = value
@@ -1835,37 +1843,11 @@ impl GraphDb {
                                 .and_then(|m| m.get(p.as_str()))
                                 .and_then(|v| v.as_vector())
                             {
-                                let vidx_dir = self.inner.path.join("vector_indexes");
-                                let cat = self.catalog_snapshot();
-                                let label_id_to_name: std::collections::HashMap<u16, String> =
-                                    cat.list_labels().unwrap_or_default().into_iter().collect();
-                                let vidx_guard =
-                                    self.inner.vector_indexes.read().expect("vector_indexes");
-
-                                let mut label_to_raw_ids: std::collections::HashMap<
-                                    &str,
-                                    Vec<u64>,
-                                > = std::collections::HashMap::new();
-                                for node_id in &matching_ids {
-                                    let lid = (node_id.0 >> 32) as u16;
-                                    if let Some(name) = label_id_to_name.get(&lid) {
-                                        label_to_raw_ids
-                                            .entry(name.as_str())
-                                            .or_default()
-                                            .push(node_id.0);
-                                    }
-                                }
-                                for (label, raw_ids) in &label_to_raw_ids {
-                                    let key = (label.to_string(), prop.clone());
-                                    if let Some(arc_idx) = vidx_guard.get(&key) {
-                                        let mut idx = arc_idx.write().expect("vector_index write");
-                                        for &raw_id in raw_ids {
-                                            idx.insert(raw_id, &vec);
-                                        }
-                                        // Persist once per (label, prop) pair.
-                                        idx.save(&vidx_dir, label, prop).map_err(Error::Io)?;
-                                    }
-                                }
+                                pending_vectors
+                                    .entry(prop.clone())
+                                    .or_insert_with(|| (vec.clone(), Vec::new()))
+                                    .1
+                                    .extend(matching_ids.iter().map(|n| n.0));
                             }
                         }
                     }
@@ -1883,6 +1865,39 @@ impl GraphDb {
                 }
             }
             total_mutated += matching_ids.len() as u64;
+        }
+
+        // Apply the accumulated vector writes once, grouping by the label each
+        // matched node actually carries (derived from the NodeId's upper 32
+        // bits) rather than from the AST, so anonymous and multi-label UNWIND
+        // patterns resolve correctly.
+        if !pending_vectors.is_empty() {
+            let vidx_dir = self.inner.path.join("vector_indexes");
+            let cat = self.catalog_snapshot();
+            let label_id_to_name: std::collections::HashMap<u16, String> =
+                cat.list_labels().unwrap_or_default().into_iter().collect();
+            let vidx_guard = self.inner.vector_indexes.read().expect("vector_indexes");
+            for (prop, (vec, raw_ids)) in &pending_vectors {
+                let mut label_to_raw: std::collections::HashMap<&str, Vec<u64>> =
+                    std::collections::HashMap::new();
+                for &raw in raw_ids {
+                    let lid = (raw >> 32) as u16;
+                    if let Some(name) = label_id_to_name.get(&lid) {
+                        label_to_raw.entry(name.as_str()).or_default().push(raw);
+                    }
+                }
+                for (label, ids) in &label_to_raw {
+                    let key = (label.to_string(), prop.clone());
+                    if let Some(arc_idx) = vidx_guard.get(&key) {
+                        let mut idx = arc_idx.write().expect("vector_index write");
+                        for &raw in ids {
+                            idx.insert(raw, vec);
+                        }
+                        // One save per (label, prop) for the whole statement.
+                        idx.save(&vidx_dir, label, prop).map_err(Error::Io)?;
+                    }
+                }
+            }
         }
 
         tx.commit()?;

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -1649,7 +1649,7 @@ impl GraphDb {
                     let col = rc.items[0]
                         .alias
                         .clone()
-                        .unwrap_or_else(|| format!("count({})", count));
+                        .unwrap_or_else(|| "count(n)".to_string());
                     Ok(QueryResult {
                         columns: vec![col],
                         rows: vec![vec![sparrowdb_execution::Value::Int64(count as i64)]],
@@ -1672,7 +1672,7 @@ impl GraphDb {
         params: &HashMap<String, sparrowdb_execution::Value>,
     ) -> Result<QueryResult> {
         let list = eval_unwind_list(&umm.expr, params)?;
-        self.execute_unwind_mutate_inner(umm, list.as_slice())
+        self.execute_unwind_mutate_inner(umm, list.as_slice(), Some(params))
     }
 
     /// Execute `UNWIND [literal] AS var MATCH ... SET/DELETE` without params.
@@ -1694,14 +1694,18 @@ impl GraphDb {
                 ));
             }
         };
-        self.execute_unwind_mutate_inner(umm, list.as_slice())
+        self.execute_unwind_mutate_inner(umm, list.as_slice(), None)
     }
 
     /// Shared inner: iterate UNWIND elements, apply mutations per row, single tx.
+    ///
+    /// When `params` is `Some`, the engine and `resolve_set_value` can resolve
+    /// `$param` references in `where_clause` and `SET` value expressions.
     fn execute_unwind_mutate_inner(
         &self,
         umm: &sparrowdb_cypher::ast::UnwindMatchMutateStatement,
         list: &[sparrowdb_execution::Value],
+        params: Option<&HashMap<String, sparrowdb_execution::Value>>,
     ) -> Result<QueryResult> {
         if list.is_empty() {
             return Ok(QueryResult::empty(vec![]));
@@ -1709,12 +1713,16 @@ impl GraphDb {
 
         let mut tx = self.begin_write()?;
         let csrs = self.cached_csr_map();
-        let engine = Engine::new(
+        let mut engine = Engine::new(
             NodeStore::open(&self.inner.path)?,
             self.catalog_snapshot(),
             csrs,
             &self.inner.path,
         );
+        // Configure engine with params so WHERE clause can resolve $param.
+        if let Some(p) = params {
+            engine = engine.with_params(p.clone());
+        }
         let mut total_mutated: u64 = 0;
         let mut has_detach_delete = false;
 
@@ -1724,8 +1732,8 @@ impl GraphDb {
                 sparrowdb_execution::Value::Map(entries) => entries,
                 _ => {
                     return Err(Error::InvalidArgument(format!(
-                        "UNWIND element must be a map (e.g. {{id: '...', score: 0.5}}), got {:?}",
-                        std::mem::discriminant(element)
+                        "UNWIND element must be a map (e.g. {{id: '...', score: 0.5}}), got {}",
+                        element
                     )));
                 }
             };
@@ -1753,7 +1761,7 @@ impl GraphDb {
             for mutation in &umm.mutations {
                 match mutation {
                     sparrowdb_cypher::ast::Mutation::Set { prop, value, .. } => {
-                        let sv = resolve_set_value(value, &umm.alias, row);
+                        let sv = resolve_set_value(value, &umm.alias, row, params)?;
                         for node_id in &matching_ids {
                             tx.set_property(*node_id, prop, sv.clone())?;
                         }
@@ -3174,9 +3182,8 @@ fn eval_unwind_list(
             match params.get(name.as_str()) {
                 Some(sparrowdb_execution::Value::List(items)) => Ok(items.clone()),
                 Some(other) => Err(Error::InvalidArgument(format!(
-                    "UNWIND parameter ${} must be a list, got {:?}",
-                    name,
-                    std::mem::discriminant(other)
+                    "UNWIND parameter ${} must be a list, got {}",
+                    name, other
                 ))),
                 None => Err(Error::InvalidArgument(format!(
                     "UNWIND parameter ${} not found in params",
@@ -3264,24 +3271,29 @@ fn exec_value_to_expr_literal(v: &sparrowdb_execution::Value) -> sparrowdb_cyphe
 
 /// Resolve a mutation SET value expression to a storage-layer Value.
 /// If the value is `alias.prop`, look it up from the row map; otherwise
-/// evaluate it directly via `expr_to_value`.
+/// evaluate it via `expr_to_value_with_params` when params are available,
+/// falling back to `expr_to_value` for literal-only expressions.
 fn resolve_set_value(
     value: &sparrowdb_cypher::ast::Expr,
     alias: &str,
     row: &[(String, sparrowdb_execution::Value)],
-) -> Value {
+    params: Option<&HashMap<String, sparrowdb_execution::Value>>,
+) -> crate::Result<Value> {
     use sparrowdb_cypher::ast::Expr;
     if let Expr::PropAccess { var, prop } = value {
         if var == alias {
             for (key, val) in row {
                 if key == prop {
-                    return exec_value_to_storage(val);
+                    return Ok(exec_value_to_storage(val));
                 }
             }
         }
     }
-    // Fall back to standard literal evaluation.
-    expr_to_value(value)
+    // Fall back: use params-aware evaluation when available, otherwise literal-only.
+    match params {
+        Some(p) => expr_to_value_with_params(value, p),
+        None => Ok(expr_to_value(value)),
+    }
 }
 
 /// Migrate WAL segments from legacy v21 (CRC32 IEEE) to v2 (CRC32C Castagnoli).

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -1843,11 +1843,21 @@ impl GraphDb {
                                 .and_then(|m| m.get(p.as_str()))
                                 .and_then(|v| v.as_vector())
                             {
-                                pending_vectors
+                                // LAST write wins, matching `tx.set_property`
+                                // and the MATCH…SET vector path (which calls
+                                // idx.insert per mutation, in order). A
+                                // first-write-wins accumulator would leave the
+                                // stored property as the last value while the
+                                // index held the first — property and index
+                                // silently disagreeing is the #410 class this
+                                // block exists to prevent. `SET n.e = $a, n.e = $b`
+                                // reaches this: parse_set_items_inner is a bare
+                                // comma loop with no duplicate-prop guard.
+                                let entry = pending_vectors
                                     .entry(prop.clone())
-                                    .or_insert_with(|| (vec.clone(), Vec::new()))
-                                    .1
-                                    .extend(matching_ids.iter().map(|n| n.0));
+                                    .or_insert_with(|| (vec.clone(), Vec::new()));
+                                entry.0 = vec.clone();
+                                entry.1.extend(matching_ids.iter().map(|n| n.0));
                             }
                         }
                     }
@@ -1878,9 +1888,15 @@ impl GraphDb {
                 cat.list_labels().unwrap_or_default().into_iter().collect();
             let vidx_guard = self.inner.vector_indexes.read().expect("vector_indexes");
             for (prop, (vec, raw_ids)) in &pending_vectors {
+                // A node accumulates once per matching row and again per
+                // duplicate SET on the same prop, so dedup before inserting.
+                let mut seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
                 let mut label_to_raw: std::collections::HashMap<&str, Vec<u64>> =
                     std::collections::HashMap::new();
                 for &raw in raw_ids {
+                    if !seen.insert(raw) {
+                        continue;
+                    }
                     let lid = (raw >> 32) as u16;
                     if let Some(name) = label_id_to_name.get(&lid) {
                         label_to_raw.entry(name.as_str()).or_default().push(raw);

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -1807,6 +1807,67 @@ impl GraphDb {
                         for node_id in &matching_ids {
                             tx.set_property(*node_id, prop, sv.clone())?;
                         }
+
+                        // Vector index write-path — the same maintenance
+                        // `execute_match_mutate_with_params` performs, which this
+                        // entry point must not skip. Without it,
+                        // `UNWIND $rows AS row MATCH (n:L {id: row.id}) SET n.emb = $vec`
+                        // would store the property and leave the HNSW file
+                        // untouched: the vector becomes invisible to search
+                        // forever, with the write reporting success. That is the
+                        // #410 silent-data-loss shape (KMSmcp ch#202), reached
+                        // through a second entry point.
+                        //
+                        // Only the `$param` form is handled, matching the
+                        // MATCH…SET path: a vector cannot survive
+                        // `resolve_set_value`'s storage-layer round trip, so
+                        // `SET n.emb = row.emb` cannot carry one today (see #475,
+                        // where that coercion silently yields Int64(0)).
+                        //
+                        // Label is derived per matched NodeId rather than from the
+                        // AST, so anonymous and multi-label UNWIND patterns resolve
+                        // correctly.
+                        if let sparrowdb_cypher::ast::Expr::Literal(
+                            sparrowdb_cypher::ast::Literal::Param(p),
+                        ) = value
+                        {
+                            if let Some(vec) = params
+                                .and_then(|m| m.get(p.as_str()))
+                                .and_then(|v| v.as_vector())
+                            {
+                                let vidx_dir = self.inner.path.join("vector_indexes");
+                                let cat = self.catalog_snapshot();
+                                let label_id_to_name: std::collections::HashMap<u16, String> =
+                                    cat.list_labels().unwrap_or_default().into_iter().collect();
+                                let vidx_guard =
+                                    self.inner.vector_indexes.read().expect("vector_indexes");
+
+                                let mut label_to_raw_ids: std::collections::HashMap<
+                                    &str,
+                                    Vec<u64>,
+                                > = std::collections::HashMap::new();
+                                for node_id in &matching_ids {
+                                    let lid = (node_id.0 >> 32) as u16;
+                                    if let Some(name) = label_id_to_name.get(&lid) {
+                                        label_to_raw_ids
+                                            .entry(name.as_str())
+                                            .or_default()
+                                            .push(node_id.0);
+                                    }
+                                }
+                                for (label, raw_ids) in &label_to_raw_ids {
+                                    let key = (label.to_string(), prop.clone());
+                                    if let Some(arc_idx) = vidx_guard.get(&key) {
+                                        let mut idx = arc_idx.write().expect("vector_index write");
+                                        for &raw_id in raw_ids {
+                                            idx.insert(raw_id, &vec);
+                                        }
+                                        // Persist once per (label, prop) pair.
+                                        idx.save(&vidx_dir, label, prop).map_err(Error::Io)?;
+                                    }
+                                }
+                            }
+                        }
                     }
                     sparrowdb_cypher::ast::Mutation::Delete { detach: true, .. } => {
                         has_detach_delete = true;

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -760,7 +760,7 @@ impl GraphDb {
                 Statement::Merge(ref m) => self.execute_merge(m),
                 Statement::MatchMutate(ref mm) => self.execute_match_mutate_deadline(mm, deadline),
                 Statement::UnwindMatchMutate(ref umm) => {
-                    self.execute_unwind_match_mutate(umm)
+                    self.execute_unwind_match_mutate_deadline(umm, deadline)
                 }
                 Statement::MatchCreate(ref mc) => self.execute_match_create_deadline(mc, deadline),
                 Statement::Create(ref c) => self.execute_create_standalone(c),
@@ -1642,10 +1642,10 @@ impl GraphDb {
         match return_clause {
             None => Ok(QueryResult::empty(vec![])),
             Some(rc) => {
-                // Simple heuristic: if RETURN has a single count-like item,
-                // return the count.  Full RETURN expression evaluation for
-                // mutations is deferred to a future engine extension.
-                if rc.items.len() == 1 {
+                // Only honour RETURN when the expression is count(n) / count(*).
+                // Full RETURN expression evaluation for mutations is deferred
+                // to a future engine extension.
+                if rc.items.len() == 1 && is_count_expr(&rc.items[0].expr) {
                     let col = rc.items[0]
                         .alias
                         .clone()
@@ -1672,7 +1672,7 @@ impl GraphDb {
         params: &HashMap<String, sparrowdb_execution::Value>,
     ) -> Result<QueryResult> {
         let list = eval_unwind_list(&umm.expr, params)?;
-        self.execute_unwind_mutate_inner(umm, list.as_slice(), Some(params))
+        self.execute_unwind_mutate_inner(umm, list.as_slice(), Some(params), None)
     }
 
     /// Execute `UNWIND [literal] AS var MATCH ... SET/DELETE` without params.
@@ -1694,18 +1694,55 @@ impl GraphDb {
                 ));
             }
         };
-        self.execute_unwind_mutate_inner(umm, list.as_slice(), None)
+        self.execute_unwind_mutate_inner(umm, list.as_slice(), None, None)
+    }
+
+    /// Deadline-aware variant (fixes #310).
+    fn execute_unwind_match_mutate_deadline(
+        &self,
+        umm: &sparrowdb_cypher::ast::UnwindMatchMutateStatement,
+        deadline: std::time::Instant,
+    ) -> Result<QueryResult> {
+        // Evaluate the UNWIND list from the expression (non-params path).
+        let list = match &umm.expr {
+            sparrowdb_cypher::ast::Expr::List(items) => items
+                .iter()
+                .map(|e| {
+                    let sv = expr_to_value(e);
+                    Ok(storage_value_to_exec(&sv))
+                })
+                .collect::<Result<Vec<_>>>()?,
+            _ => {
+                return Err(Error::InvalidArgument(
+                    "UNWIND MATCH SET/DELETE with timeout requires a list literal".into(),
+                ));
+            }
+        };
+        self.execute_unwind_mutate_inner(umm, list.as_slice(), None, Some(deadline))
     }
 
     /// Shared inner: iterate UNWIND elements, apply mutations per row, single tx.
     ///
     /// When `params` is `Some`, the engine and `resolve_set_value` can resolve
     /// `$param` references in `where_clause` and `SET` value expressions.
+    ///
+    /// When `deadline` is `Some`, each iteration checks elapsed time and returns
+    /// `Err(Timeout)` if the caller's deadline has passed (fixes #310).
+    ///
+    /// **Visibility limitation**: each UNWIND row is scanned against committed
+    /// storage — earlier rows' mutations within the same transaction are NOT
+    /// visible to later rows' MATCH scans.  This is by design: the single-pass
+    /// engine reuses the same read snapshot for all iterations, matching the
+    /// semantics of `UNWIND` in standard Cypher (all rows see the same pre-query
+    /// state).  Use cases that require row-to-row visibility (e.g. accumulating
+    /// mutations on the same node across iterations) must issue separate
+    /// statements.
     fn execute_unwind_mutate_inner(
         &self,
         umm: &sparrowdb_cypher::ast::UnwindMatchMutateStatement,
         list: &[sparrowdb_execution::Value],
         params: Option<&HashMap<String, sparrowdb_execution::Value>>,
+        deadline: Option<std::time::Instant>,
     ) -> Result<QueryResult> {
         if list.is_empty() {
             return Ok(QueryResult::empty(vec![]));
@@ -1727,6 +1764,11 @@ impl GraphDb {
         let mut has_detach_delete = false;
 
         for element in list {
+            // Honour caller's deadline between iterations (fixes #310).
+            if let Some(dl) = deadline {
+                Self::check_deadline(dl)?;
+            }
+
             // Each element must be a Map (e.g. {id: "m1", score: 0.5}).
             let row = match element {
                 sparrowdb_execution::Value::Map(entries) => entries,
@@ -3168,6 +3210,18 @@ impl GraphDb {
         self.invalidate_csr_map();
         Ok(())
     }
+}
+
+// ── RETURN helpers ──────────────────────────────────────────────────────────
+
+/// Check whether an expression is a `count(n)` or `count(*)` aggregate call.
+fn is_count_expr(expr: &sparrowdb_cypher::ast::Expr) -> bool {
+    use sparrowdb_cypher::ast::Expr;
+    matches!(
+        expr,
+        Expr::FnCall { name, .. } if name.eq_ignore_ascii_case("count")
+            || name == "COUNT"
+    ) || matches!(expr, Expr::CountStar)
 }
 
 // ── UNWIND helpers (SPA-415) ────────────────────────────────────────────────

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -642,16 +642,16 @@ impl GraphDb {
             // Mutations don't use the read pipeline — fall through to the
             // standard mutation paths (write transactions are unaffected).
             match bound.inner {
-            Statement::Merge(ref m) => self.execute_merge(m),
-            Statement::MatchMergeRel(ref mm) => self.execute_match_merge_rel(mm),
-            Statement::MatchMutate(ref mm) => self.execute_match_mutate(mm),
-            Statement::UnwindMatchMutate(ref umm) => self.execute_unwind_match_mutate(umm),
-            Statement::MatchCreate(ref mc) => self.execute_match_create(mc),
-            Statement::Create(ref c) => self.execute_create_standalone(c),
-            _ => unreachable!(),
-        }
-    } else {
-        let _span = info_span!("sparrowdb.query_chunked").entered();
+                Statement::Merge(ref m) => self.execute_merge(m),
+                Statement::MatchMergeRel(ref mm) => self.execute_match_merge_rel(mm),
+                Statement::MatchMutate(ref mm) => self.execute_match_mutate(mm),
+                Statement::UnwindMatchMutate(ref umm) => self.execute_unwind_match_mutate(umm),
+                Statement::MatchCreate(ref mc) => self.execute_match_create(mc),
+                Statement::Create(ref c) => self.execute_create_standalone(c),
+                _ => unreachable!(),
+            }
+        } else {
+            let _span = info_span!("sparrowdb.query_chunked").entered();
 
             let mut engine = {
                 let _open_span = info_span!("sparrowdb.open_engine").entered();
@@ -3258,7 +3258,7 @@ fn resolve_pattern_props(
     alias: &str,
     row: &[(String, sparrowdb_execution::Value)],
 ) -> sparrowdb_cypher::ast::PathPattern {
-    use sparrowdb_cypher::ast::{Expr, Literal, NodePattern, PropEntry};
+    use sparrowdb_cypher::ast::{NodePattern, PropEntry};
 
     let nodes: Vec<NodePattern> = pat
         .nodes
@@ -3298,7 +3298,7 @@ fn row_expr_to_literal(
     alias: &str,
     row: &[(String, sparrowdb_execution::Value)],
 ) -> sparrowdb_cypher::ast::Expr {
-    use sparrowdb_cypher::ast::{Expr, Literal};
+    use sparrowdb_cypher::ast::Expr;
     if let Expr::PropAccess { var, prop } = expr {
         if var == alias {
             for (key, val) in row {

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -7,9 +7,10 @@
 use crate::batch::augment_rows_with_pending;
 use crate::helpers::{
     build_label_row_counts_from_disk, collect_maintenance_params, dir_size_bytes, eval_expr_merge,
-    expr_to_value, expr_to_value_with_params, fnv1a_col_id, is_edge_delete_mutation,
-    is_reserved_label, literal_to_value, load_constraints, load_vector_indexes, open_csr_map,
-    save_constraints, storage_value_to_exec, try_open_csr_map, VectorIndexHealth,
+    exec_value_to_storage, expr_to_value, expr_to_value_with_params, fnv1a_col_id,
+    is_edge_delete_mutation, is_reserved_label, literal_to_value, load_constraints,
+    load_vector_indexes, open_csr_map, save_constraints, storage_value_to_exec, try_open_csr_map,
+    VectorIndexHealth,
 };
 use crate::read_tx::ReadTx;
 use crate::types::{DbInner, NodeVersions, PendingOp, VersionStore, WriteBuffer, WriteGuard};
@@ -557,6 +558,7 @@ impl GraphDb {
                 Statement::Merge(ref m) => self.execute_merge(m),
                 Statement::MatchMergeRel(ref mm) => self.execute_match_merge_rel(mm),
                 Statement::MatchMutate(ref mm) => self.execute_match_mutate(mm),
+                Statement::UnwindMatchMutate(ref umm) => self.execute_unwind_match_mutate(umm),
                 Statement::MatchCreate(ref mc) => self.execute_match_create(mc),
                 // Standalone CREATE with edges — must go through WriteTx so
                 // create_edge can register the rel type and write the WAL.
@@ -640,15 +642,16 @@ impl GraphDb {
             // Mutations don't use the read pipeline — fall through to the
             // standard mutation paths (write transactions are unaffected).
             match bound.inner {
-                Statement::Merge(ref m) => self.execute_merge(m),
-                Statement::MatchMergeRel(ref mm) => self.execute_match_merge_rel(mm),
-                Statement::MatchMutate(ref mm) => self.execute_match_mutate(mm),
-                Statement::MatchCreate(ref mc) => self.execute_match_create(mc),
-                Statement::Create(ref c) => self.execute_create_standalone(c),
-                _ => unreachable!(),
-            }
-        } else {
-            let _span = info_span!("sparrowdb.query_chunked").entered();
+            Statement::Merge(ref m) => self.execute_merge(m),
+            Statement::MatchMergeRel(ref mm) => self.execute_match_merge_rel(mm),
+            Statement::MatchMutate(ref mm) => self.execute_match_mutate(mm),
+            Statement::UnwindMatchMutate(ref umm) => self.execute_unwind_match_mutate(umm),
+            Statement::MatchCreate(ref mc) => self.execute_match_create(mc),
+            Statement::Create(ref c) => self.execute_create_standalone(c),
+            _ => unreachable!(),
+        }
+    } else {
+        let _span = info_span!("sparrowdb.query_chunked").entered();
 
             let mut engine = {
                 let _open_span = info_span!("sparrowdb.open_engine").entered();
@@ -756,6 +759,9 @@ impl GraphDb {
             return match bound.inner {
                 Statement::Merge(ref m) => self.execute_merge(m),
                 Statement::MatchMutate(ref mm) => self.execute_match_mutate_deadline(mm, deadline),
+                Statement::UnwindMatchMutate(ref umm) => {
+                    self.execute_unwind_match_mutate(umm)
+                }
                 Statement::MatchCreate(ref mc) => self.execute_match_create_deadline(mc, deadline),
                 Statement::Create(ref c) => self.execute_create_standalone(c),
                 _ => unreachable!(),
@@ -1243,6 +1249,9 @@ impl GraphDb {
             return match bound.inner {
                 Stmt::Merge(ref m) => self.execute_merge_with_params(m, &params),
                 Stmt::MatchMutate(ref mm) => self.execute_match_mutate_with_params(mm, &params),
+                Stmt::UnwindMatchMutate(ref umm) => {
+                    self.execute_unwind_match_mutate_with_params(umm, &params)
+                }
                 _ => Err(Error::InvalidArgument(
                     "execute_with_params: parameterized MATCH...CREATE and standalone CREATE \
                      are not yet supported; use MERGE or MATCH...SET with $params"
@@ -1618,7 +1627,160 @@ impl GraphDb {
             self.invalidate_csr_map();
         }
 
-        Ok(QueryResult::empty(vec![]))
+        Self::build_mutate_return(&mm.return_clause, matching_ids.len() as u64)
+    }
+
+    /// Build a QueryResult from an optional RETURN clause after a mutation.
+    ///
+    /// When `return_clause` is `None`, returns an empty result (backward compat).
+    /// When present and the RETURN expression is `count(n)`, returns one row
+    /// with the mutation count.
+    fn build_mutate_return(
+        return_clause: &Option<sparrowdb_cypher::ast::ReturnClause>,
+        count: u64,
+    ) -> Result<QueryResult> {
+        match return_clause {
+            None => Ok(QueryResult::empty(vec![])),
+            Some(rc) => {
+                // Simple heuristic: if RETURN has a single count-like item,
+                // return the count.  Full RETURN expression evaluation for
+                // mutations is deferred to a future engine extension.
+                if rc.items.len() == 1 {
+                    let col = rc.items[0]
+                        .alias
+                        .clone()
+                        .unwrap_or_else(|| format!("count({})", count));
+                    Ok(QueryResult {
+                        columns: vec![col],
+                        rows: vec![vec![sparrowdb_execution::Value::Int64(count as i64)]],
+                    })
+                } else {
+                    Ok(QueryResult::empty(vec![]))
+                }
+            }
+        }
+    }
+
+    // ── UNWIND … MATCH … SET/DELETE execution (SPA-415) ─────────────────────
+
+    /// Execute `UNWIND $param AS var MATCH ... SET/DELETE` with runtime
+    /// parameter bindings.  Evaluates the UNWIND list, then for each element
+    /// runs the MATCH + mutation inside a single write transaction.
+    fn execute_unwind_match_mutate_with_params(
+        &self,
+        umm: &sparrowdb_cypher::ast::UnwindMatchMutateStatement,
+        params: &HashMap<String, sparrowdb_execution::Value>,
+    ) -> Result<QueryResult> {
+        let list = eval_unwind_list(&umm.expr, params)?;
+        self.execute_unwind_mutate_inner(umm, list.as_slice())
+    }
+
+    /// Execute `UNWIND [literal] AS var MATCH ... SET/DELETE` without params.
+    fn execute_unwind_match_mutate(
+        &self,
+        umm: &sparrowdb_cypher::ast::UnwindMatchMutateStatement,
+    ) -> Result<QueryResult> {
+        let list = match &umm.expr {
+            sparrowdb_cypher::ast::Expr::List(items) => items
+                .iter()
+                .map(|e| {
+                    let sv = expr_to_value(e);
+                    Ok(storage_value_to_exec(&sv))
+                })
+                .collect::<Result<Vec<_>>>()?,
+            _ => {
+                return Err(Error::InvalidArgument(
+                    "UNWIND MATCH SET/DELETE without parameters requires a list literal".into(),
+                ));
+            }
+        };
+        self.execute_unwind_mutate_inner(umm, list.as_slice())
+    }
+
+    /// Shared inner: iterate UNWIND elements, apply mutations per row, single tx.
+    fn execute_unwind_mutate_inner(
+        &self,
+        umm: &sparrowdb_cypher::ast::UnwindMatchMutateStatement,
+        list: &[sparrowdb_execution::Value],
+    ) -> Result<QueryResult> {
+        if list.is_empty() {
+            return Ok(QueryResult::empty(vec![]));
+        }
+
+        let mut tx = self.begin_write()?;
+        let csrs = self.cached_csr_map();
+        let engine = Engine::new(
+            NodeStore::open(&self.inner.path)?,
+            self.catalog_snapshot(),
+            csrs,
+            &self.inner.path,
+        );
+        let mut total_mutated: u64 = 0;
+        let mut has_detach_delete = false;
+
+        for element in list {
+            // Each element must be a Map (e.g. {id: "m1", score: 0.5}).
+            let row = match element {
+                sparrowdb_execution::Value::Map(entries) => entries,
+                _ => {
+                    return Err(Error::InvalidArgument(format!(
+                        "UNWIND element must be a map (e.g. {{id: '...', score: 0.5}}), got {:?}",
+                        std::mem::discriminant(element)
+                    )));
+                }
+            };
+
+            // Build a temporary MatchMutateStatement with inline property
+            // filters resolved from the row values.
+            let resolved_patterns: Vec<sparrowdb_cypher::ast::PathPattern> = umm
+                .match_patterns
+                .iter()
+                .map(|pat| resolve_pattern_props(pat, &umm.alias, row))
+                .collect();
+
+            let resolved_mm = sparrowdb_cypher::ast::MatchMutateStatement {
+                match_patterns: resolved_patterns,
+                where_clause: umm.where_clause.clone(),
+                mutations: umm.mutations.clone(),
+                return_clause: None,
+            };
+
+            let matching_ids = engine.scan_match_mutate(&resolved_mm)?;
+            if matching_ids.is_empty() {
+                continue;
+            }
+
+            for mutation in &umm.mutations {
+                match mutation {
+                    sparrowdb_cypher::ast::Mutation::Set { prop, value, .. } => {
+                        let sv = resolve_set_value(value, &umm.alias, row);
+                        for node_id in &matching_ids {
+                            tx.set_property(*node_id, prop, sv.clone())?;
+                        }
+                    }
+                    sparrowdb_cypher::ast::Mutation::Delete { detach: true, .. } => {
+                        has_detach_delete = true;
+                        for node_id in &matching_ids {
+                            tx.detach_delete_node(*node_id)?;
+                        }
+                    }
+                    sparrowdb_cypher::ast::Mutation::Delete { detach: false, .. } => {
+                        for node_id in &matching_ids {
+                            tx.delete_node(*node_id)?;
+                        }
+                    }
+                }
+            }
+            total_mutated += matching_ids.len() as u64;
+        }
+
+        tx.commit()?;
+        self.invalidate_catalog();
+        if has_detach_delete {
+            self.invalidate_csr_map();
+        }
+
+        Self::build_mutate_return(&umm.return_clause, total_mutated)
     }
 
     /// Internal: execute a MATCH … SET / DELETE by scanning then writing.
@@ -1649,20 +1811,21 @@ impl GraphDb {
         // SPA-219: `MATCH (a)-[r:REL]->(b) DELETE r` — edge delete path.
         if is_edge_delete_mutation(mm) {
             let edges = engine.scan_match_mutate_edges(mm)?;
+            let edge_count = edges.len();
             for (src, dst, rel_type) in edges {
                 tx.delete_edge(src, dst, &rel_type)?;
             }
             tx.commit()?;
             self.invalidate_csr_map();
             self.invalidate_catalog();
-            return Ok(QueryResult::empty(vec![]));
+            return Self::build_mutate_return(&mm.return_clause, edge_count as u64);
         }
 
         // Collect matching node ids via the engine's scan (lock already held).
         let matching_ids = engine.scan_match_mutate(mm)?;
 
         if matching_ids.is_empty() {
-            return Ok(QueryResult::empty(vec![]));
+            return Self::build_mutate_return(&mm.return_clause, 0);
         }
 
         let mut has_detach_delete = false;
@@ -1693,7 +1856,7 @@ impl GraphDb {
         if has_detach_delete {
             self.invalidate_csr_map();
         }
-        Ok(QueryResult::empty(vec![]))
+        Self::build_mutate_return(&mm.return_clause, matching_ids.len() as u64)
     }
 
     /// Deadline-aware variant of [`execute_match_mutate`] (fixes #310).
@@ -1766,7 +1929,8 @@ impl GraphDb {
         if has_detach_delete {
             self.invalidate_csr_map();
         }
-        Ok(QueryResult::empty(vec![]))
+        // Honor optional RETURN clause.
+        Self::build_mutate_return(&mm.return_clause, matching_ids.len() as u64)
     }
 
     /// Internal: execute a `MATCH … CREATE (a)-[:R]->(b)` statement.
@@ -2365,6 +2529,16 @@ impl GraphDb {
                     has_detach_delete = true;
                 }
             }
+            if let sparrowdb_cypher::ast::Statement::UnwindMatchMutate(ref umm) = bound.inner {
+                if umm.mutations.iter().any(|m| {
+                    matches!(
+                        m,
+                        sparrowdb_cypher::ast::Mutation::Delete { detach: true, .. }
+                    )
+                }) {
+                    has_detach_delete = true;
+                }
+            }
 
             let result = if Engine::is_mutation(&bound.inner) {
                 self.execute_batch_mutation(bound.inner, &mut tx)?
@@ -2541,6 +2715,7 @@ impl GraphDb {
                     for (src, dst, rel_type) in edges {
                         tx.delete_edge(src, dst, &rel_type)?;
                     }
+                    Ok(QueryResult::empty(vec![]))
                 } else {
                     let matching_ids = engine.scan_match_mutate(mm)?;
                     for mutation in &mm.mutations {
@@ -2563,9 +2738,15 @@ impl GraphDb {
                             }
                         }
                     }
+                    Ok(QueryResult::empty(vec![]))
                 }
-                Ok(QueryResult::empty(vec![]))
             }
+
+            Statement::UnwindMatchMutate(_) => Err(Error::InvalidArgument(
+                "UNWIND...MATCH...SET/DELETE is not yet supported in batch execution; \
+                 use execute_with_params instead"
+                    .into(),
+            )),
 
             Statement::MatchCreate(ref mc) => {
                 for (_, rel_pat, _) in &mc.create.edges {
@@ -2979,6 +3160,128 @@ impl GraphDb {
         self.invalidate_csr_map();
         Ok(())
     }
+}
+
+// ── UNWIND helpers (SPA-415) ────────────────────────────────────────────────
+
+/// Evaluate a UNWIND expression to a list of `Value`s.
+fn eval_unwind_list(
+    expr: &sparrowdb_cypher::ast::Expr,
+    params: &HashMap<String, sparrowdb_execution::Value>,
+) -> Result<Vec<sparrowdb_execution::Value>> {
+    match expr {
+        sparrowdb_cypher::ast::Expr::Literal(sparrowdb_cypher::ast::Literal::Param(name)) => {
+            match params.get(name.as_str()) {
+                Some(sparrowdb_execution::Value::List(items)) => Ok(items.clone()),
+                Some(other) => Err(Error::InvalidArgument(format!(
+                    "UNWIND parameter ${} must be a list, got {:?}",
+                    name,
+                    std::mem::discriminant(other)
+                ))),
+                None => Err(Error::InvalidArgument(format!(
+                    "UNWIND parameter ${} not found in params",
+                    name
+                ))),
+            }
+        }
+        _ => Err(Error::InvalidArgument(
+            "UNWIND expression must be a $param bound to a list".into(),
+        )),
+    }
+}
+
+/// Resolve inline property filters in a PathPattern by replacing
+/// `alias.prop` references with literal values from the UNWIND row.
+fn resolve_pattern_props(
+    pat: &sparrowdb_cypher::ast::PathPattern,
+    alias: &str,
+    row: &[(String, sparrowdb_execution::Value)],
+) -> sparrowdb_cypher::ast::PathPattern {
+    use sparrowdb_cypher::ast::{Expr, Literal, NodePattern, PropEntry};
+
+    let nodes: Vec<NodePattern> = pat
+        .nodes
+        .iter()
+        .map(|np| {
+            let props: Vec<PropEntry> = np
+                .props
+                .iter()
+                .map(|pe| {
+                    let resolved_expr = row_expr_to_literal(&pe.value, alias, row);
+                    PropEntry {
+                        key: pe.key.clone(),
+                        value: resolved_expr,
+                    }
+                })
+                .collect();
+            NodePattern {
+                var: np.var.clone(),
+                labels: np.labels.clone(),
+                props,
+            }
+        })
+        .collect();
+
+    sparrowdb_cypher::ast::PathPattern {
+        path_var: pat.path_var.clone(),
+        nodes,
+        rels: pat.rels.clone(),
+    }
+}
+
+/// Resolve an expression that references `alias.prop` to a literal Expr.
+/// If the expression is `alias.prop`, look up `prop` in the row map and
+/// return the corresponding `Expr::Literal`. Otherwise return the expr as-is.
+fn row_expr_to_literal(
+    expr: &sparrowdb_cypher::ast::Expr,
+    alias: &str,
+    row: &[(String, sparrowdb_execution::Value)],
+) -> sparrowdb_cypher::ast::Expr {
+    use sparrowdb_cypher::ast::{Expr, Literal};
+    if let Expr::PropAccess { var, prop } = expr {
+        if var == alias {
+            for (key, val) in row {
+                if key == prop {
+                    return exec_value_to_expr_literal(val);
+                }
+            }
+        }
+    }
+    expr.clone()
+}
+
+/// Convert a sparrowdb_execution::Value to an Expr::Literal for inline props.
+fn exec_value_to_expr_literal(v: &sparrowdb_execution::Value) -> sparrowdb_cypher::ast::Expr {
+    use sparrowdb_cypher::ast::{Expr, Literal};
+    match v {
+        sparrowdb_execution::Value::String(s) => Expr::Literal(Literal::String(s.clone())),
+        sparrowdb_execution::Value::Int64(n) => Expr::Literal(Literal::Int(*n)),
+        sparrowdb_execution::Value::Float64(f) => Expr::Literal(Literal::Float(*f)),
+        sparrowdb_execution::Value::Bool(b) => Expr::Literal(Literal::Bool(*b)),
+        _ => Expr::Literal(Literal::Null),
+    }
+}
+
+/// Resolve a mutation SET value expression to a storage-layer Value.
+/// If the value is `alias.prop`, look it up from the row map; otherwise
+/// evaluate it directly via `expr_to_value`.
+fn resolve_set_value(
+    value: &sparrowdb_cypher::ast::Expr,
+    alias: &str,
+    row: &[(String, sparrowdb_execution::Value)],
+) -> Value {
+    use sparrowdb_cypher::ast::Expr;
+    if let Expr::PropAccess { var, prop } = value {
+        if var == alias {
+            for (key, val) in row {
+                if key == prop {
+                    return exec_value_to_storage(val);
+                }
+            }
+        }
+    }
+    // Fall back to standard literal evaluation.
+    expr_to_value(value)
 }
 
 /// Migrate WAL segments from legacy v21 (CRC32 IEEE) to v2 (CRC32C Castagnoli).

--- a/crates/sparrowdb/tests/spa_415_unwind_match_mutate.rs
+++ b/crates/sparrowdb/tests/spa_415_unwind_match_mutate.rs
@@ -1,0 +1,659 @@
+//! SPA-415: `UNWIND … MATCH … SET/DELETE` and `DELETE … RETURN` e2e coverage.
+//!
+//! PR #411 added 576 lines across ast.rs/binder.rs/parser.rs/engine/mod.rs/db.rs
+//! with zero tests. This file covers the two headline features end-to-end
+//! against a real `GraphDb` on real disk (tempdir, real WAL, real catalog):
+//!
+//!   1. `UNWIND $list AS row MATCH (n {prop: row.field}) SET/DELETE ...`
+//!   2. `MATCH (n) DELETE n RETURN count(n)` (and the UNWIND equivalent)
+//!
+//! Every UNWIND-mutate query in this file uses the `$param` + PropAccess
+//! (`row.field`) form, not the literal-list form. That is deliberate, not an
+//! oversight — see the "KNOWN BUG" test at the bottom and the PR report for
+//! why the literal-list path (`execute_unwind_match_mutate`, no `$param`) is
+//! currently unusable for any non-empty list.
+
+use sparrowdb::GraphDb;
+use sparrowdb_execution::Value;
+use std::collections::HashMap;
+use tempfile::tempdir;
+
+fn open_db() -> (GraphDb, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    (db, dir)
+}
+
+/// Build a `$param` map-list value: `[{k1: v1, ...}, ...]` from row tuples.
+fn map_list(rows: Vec<Vec<(&str, Value)>>) -> Value {
+    Value::List(
+        rows.into_iter()
+            .map(|entries| {
+                Value::Map(
+                    entries
+                        .into_iter()
+                        .map(|(k, v)| (k.to_string(), v))
+                        .collect(),
+                )
+            })
+            .collect(),
+    )
+}
+
+fn params(pairs: Vec<(&str, Value)>) -> HashMap<String, Value> {
+    pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
+}
+
+// ── 1. UNWIND MATCH SET via $param — only targeted nodes change ────────────
+
+/// Three nodes exist; the UNWIND list names two of them. Only those two may
+/// change — the third is the control that would catch an implementation that
+/// mutates every row of the label instead of filtering by the UNWIND value.
+#[test]
+fn unwind_param_set_updates_only_matched_nodes() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Memory {id: 'm1', score: 1})")
+        .unwrap();
+    db.execute("CREATE (n:Memory {id: 'm2', score: 1})")
+        .unwrap();
+    db.execute("CREATE (n:Memory {id: 'm3', score: 1})")
+        .unwrap();
+
+    let p = params(vec![(
+        "updates",
+        map_list(vec![
+            vec![
+                ("id", Value::String("m1".into())),
+                ("score", Value::Int64(50)),
+            ],
+            vec![
+                ("id", Value::String("m2".into())),
+                ("score", Value::Int64(90)),
+            ],
+        ]),
+    )]);
+
+    let r = db
+        .execute_with_params(
+            "UNWIND $updates AS row MATCH (n:Memory {id: row.id}) SET n.score = row.score",
+            p,
+        )
+        .unwrap();
+    assert!(r.rows.is_empty(), "no RETURN clause => empty result");
+
+    let check = db
+        .execute("MATCH (n:Memory) RETURN n.id, n.score ORDER BY n.id")
+        .unwrap();
+    let got: Vec<(String, i64)> = check
+        .rows
+        .iter()
+        .map(|row| {
+            let id = match &row[0] {
+                Value::String(s) => s.clone(),
+                other => panic!("expected string id, got {other:?}"),
+            };
+            let score = match &row[1] {
+                Value::Int64(n) => *n,
+                other => panic!("expected int score, got {other:?}"),
+            };
+            (id, score)
+        })
+        .collect();
+
+    // Hand-derived from the fixture: m1->50, m2->90, m3 untouched (still 1).
+    assert_eq!(
+        got,
+        vec![
+            ("m1".to_string(), 50),
+            ("m2".to_string(), 90),
+            ("m3".to_string(), 1),
+        ],
+        "m3 was never named in the UNWIND list and must be untouched"
+    );
+}
+
+// ── 2. $param resolves in both WHERE and SET (the 5 Gemini findings) ───────
+
+/// `$threshold` in WHERE and `$newval` in SET must both resolve against the
+/// params map threaded through `execute_unwind_mutate_inner`. Two nodes exist
+/// on either side of the threshold; only the one below it may change.
+///
+/// A implementation that forgets to call `engine.with_params()` (or forgets
+/// to pass params into `resolve_set_value`) would either error on `$threshold`
+/// / `$newval` or silently treat them as NULL — this test would catch either.
+#[test]
+fn unwind_param_where_and_set_value_both_resolve_dollar_param() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {id: 'a', val: 1})").unwrap();
+    db.execute("CREATE (n:Item {id: 'b', val: 100})").unwrap();
+
+    let p = params(vec![
+        (
+            "updates",
+            map_list(vec![
+                vec![("id", Value::String("a".into()))],
+                vec![("id", Value::String("b".into()))],
+            ]),
+        ),
+        ("threshold", Value::Int64(50)),
+        ("newval", Value::Int64(999)),
+    ]);
+
+    db.execute_with_params(
+        "UNWIND $updates AS row MATCH (n:Item {id: row.id}) \
+         WHERE n.val < $threshold SET n.val = $newval",
+        p,
+    )
+    .unwrap();
+
+    // Hand-derived: only 'a' (val=1 < 50) crosses the WHERE threshold.
+    let a = db.execute("MATCH (n:Item {id: 'a'}) RETURN n.val").unwrap();
+    assert_eq!(a.rows, vec![vec![Value::Int64(999)]]);
+    let b = db.execute("MATCH (n:Item {id: 'b'}) RETURN n.val").unwrap();
+    assert_eq!(
+        b.rows,
+        vec![vec![Value::Int64(100)]],
+        "'b' (val=100) must not pass WHERE n.val < 50"
+    );
+}
+
+// ── 3. SET n.prop = row.field (PropAccess in SET value, commit aa29e59) ────
+
+/// Regression guard for commit aa29e59: the parser used to reject non-literal
+/// SET values, which broke `SET n.score = row.score`. Each row carries a
+/// *different* field value so a broken implementation that fell back to a
+/// single shared literal (or NULL) would be caught immediately.
+#[test]
+fn unwind_set_value_from_row_prop_access() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Doc {id: 'd1', rank: 0})").unwrap();
+    db.execute("CREATE (n:Doc {id: 'd2', rank: 0})").unwrap();
+
+    let p = params(vec![(
+        "rows",
+        map_list(vec![
+            vec![
+                ("id", Value::String("d1".into())),
+                ("rank", Value::Int64(7)),
+            ],
+            vec![
+                ("id", Value::String("d2".into())),
+                ("rank", Value::Int64(42)),
+            ],
+        ]),
+    )]);
+
+    db.execute_with_params(
+        "UNWIND $rows AS row MATCH (n:Doc {id: row.id}) SET n.rank = row.rank",
+        p,
+    )
+    .unwrap();
+
+    let check = db
+        .execute("MATCH (n:Doc) RETURN n.id, n.rank ORDER BY n.id")
+        .unwrap();
+    assert_eq!(
+        check.rows,
+        vec![
+            vec![Value::String("d1".into()), Value::Int64(7)],
+            vec![Value::String("d2".into()), Value::Int64(42)],
+        ],
+        "each node must receive its own row's rank, not a shared/last-row value"
+    );
+}
+
+// ── 4. UNWIND MATCH DELETE (node) ───────────────────────────────────────────
+
+#[test]
+fn unwind_param_delete_removes_only_matched_nodes() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {id: 'a'})").unwrap();
+    db.execute("CREATE (n:Item {id: 'b'})").unwrap();
+    db.execute("CREATE (n:Item {id: 'c'})").unwrap();
+
+    let p = params(vec![(
+        "ids",
+        map_list(vec![
+            vec![("id", Value::String("a".into()))],
+            vec![("id", Value::String("b".into()))],
+        ]),
+    )]);
+
+    db.execute_with_params("UNWIND $ids AS row MATCH (n:Item {id: row.id}) DELETE n", p)
+        .unwrap();
+
+    let remaining = db.execute("MATCH (n:Item) RETURN n.id").unwrap();
+    assert_eq!(
+        remaining.rows,
+        vec![vec![Value::String("c".into())]],
+        "only 'c' (never named in the UNWIND list) should survive"
+    );
+}
+
+/// DETACH DELETE via UNWIND must also remove incident edges (not just the
+/// node), and the CSR cache must be invalidated so a later scan doesn't see
+/// a stale edge. A plain (non-detach) DELETE on a node with edges would leave
+/// dangling edge records — this test would fail if `has_detach_delete` /
+/// `invalidate_csr_map` wiring were dropped.
+#[test]
+fn unwind_param_detach_delete_removes_node_and_edges() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (a:P {id: 'a'})").unwrap();
+    db.execute("CREATE (b:P {id: 'b'})").unwrap();
+    db.execute("MATCH (a:P {id: 'a'}), (b:P {id: 'b'}) CREATE (a)-[:KNOWS]->(b)")
+        .unwrap();
+
+    let p = params(vec![(
+        "ids",
+        map_list(vec![vec![("id", Value::String("a".into()))]]),
+    )]);
+
+    db.execute_with_params(
+        "UNWIND $ids AS row MATCH (n:P {id: row.id}) DETACH DELETE n",
+        p,
+    )
+    .unwrap();
+
+    let nodes = db.execute("MATCH (n:P) RETURN n.id").unwrap();
+    assert_eq!(nodes.rows, vec![vec![Value::String("b".into())]]);
+
+    let edges = db
+        .execute("MATCH (x:P)-[r:KNOWS]->(y:P) RETURN x.id, y.id")
+        .unwrap();
+    assert!(
+        edges.rows.is_empty(),
+        "the KNOWS edge must be gone once its source node is detach-deleted, got {:?}",
+        edges.rows
+    );
+}
+
+// ── 5. UNWIND MATCH DELETE on an edge pattern: documented restriction ──────
+
+/// `scan_match_mutate` (shared by both the plain and UNWIND mutate paths)
+/// explicitly rejects any pattern with a relationship hop:
+/// "MATCH...SET/DELETE currently supports only single-node patterns (no
+/// relationships)". Unlike the plain `MATCH (a)-[r]->(b) DELETE r` path
+/// (`execute_match_mutate`), the UNWIND path never calls
+/// `is_edge_delete_mutation` / `scan_match_mutate_edges` at all — so
+/// `UNWIND ... MATCH (a)-[r:REL]->(b) DELETE r` cannot reach the edge-delete
+/// code path and always errors instead of silently misbehaving. This test
+/// pins that current (safe, if incomplete) behaviour.
+#[test]
+fn unwind_match_delete_edge_pattern_errors_instead_of_silently_misbehaving() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (a:P {id: 'a'})").unwrap();
+    db.execute("CREATE (b:P {id: 'b'})").unwrap();
+    db.execute("MATCH (a:P {id: 'a'}), (b:P {id: 'b'}) CREATE (a)-[:KNOWS]->(b)")
+        .unwrap();
+
+    let p = params(vec![(
+        "ids",
+        map_list(vec![vec![("id", Value::String("a".into()))]]),
+    )]);
+
+    let r = db.execute_with_params(
+        "UNWIND $ids AS row MATCH (a:P {id: row.id})-[r:KNOWS]->(b:P) DELETE r",
+        p,
+    );
+    let err = r.expect_err("edge-hop patterns are not supported on the UNWIND mutate path");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("single-node patterns"),
+        "expected the scan_match_mutate 'single-node patterns' error, got: {msg}"
+    );
+
+    // The edge must still exist — the query must have failed before any write.
+    let edges = db
+        .execute("MATCH (x:P)-[r:KNOWS]->(y:P) RETURN x.id, y.id")
+        .unwrap();
+    assert_eq!(
+        edges.rows,
+        vec![vec![Value::String("a".into()), Value::String("b".into())]],
+        "a rejected mutation must not have touched the edge"
+    );
+}
+
+// ── 6. DELETE ... RETURN — the second headline feature ─────────────────────
+
+/// `build_mutate_return` only special-cases `count(n)` / `count(*)`; any
+/// other RETURN expression after a mutation falls back to an empty result
+/// (the doc comment calls this "deferred to a future engine extension").
+/// This is the plain (non-UNWIND) path.
+#[test]
+fn match_delete_return_count_reports_correct_count() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {id: 'a'})").unwrap();
+    db.execute("CREATE (n:Item {id: 'b'})").unwrap();
+    db.execute("CREATE (n:Item {id: 'c'})").unwrap();
+
+    let r = db
+        .execute("MATCH (n:Item) WHERE n.id <> 'c' DELETE n RETURN count(n)")
+        .unwrap();
+    assert_eq!(r.columns, vec!["count(n)".to_string()]);
+    assert_eq!(r.rows, vec![vec![Value::Int64(2)]]);
+
+    let remaining = db.execute("MATCH (n:Item) RETURN n.id").unwrap();
+    assert_eq!(remaining.rows, vec![vec![Value::String("c".into())]]);
+}
+
+/// Same feature, but through the UNWIND pipeline, and with `total_mutated`
+/// accumulated across multiple UNWIND rows (not just one MATCH scan). Also
+/// exercises "element matching no node" (`zzz`) in the same list to confirm
+/// it contributes 0 to the count rather than erroring the whole statement.
+#[test]
+fn unwind_delete_return_count_sums_across_rows() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {id: 'a'})").unwrap();
+    db.execute("CREATE (n:Item {id: 'b'})").unwrap();
+    db.execute("CREATE (n:Item {id: 'c'})").unwrap();
+
+    let p = params(vec![(
+        "ids",
+        map_list(vec![
+            vec![("id", Value::String("a".into()))],
+            vec![("id", Value::String("b".into()))],
+            vec![("id", Value::String("zzz".into()))], // matches nothing
+        ]),
+    )]);
+
+    let r = db
+        .execute_with_params(
+            "UNWIND $ids AS row MATCH (n:Item {id: row.id}) DELETE n RETURN count(n)",
+            p,
+        )
+        .unwrap();
+    assert_eq!(r.rows, vec![vec![Value::Int64(2)]]);
+
+    let remaining = db.execute("MATCH (n:Item) RETURN n.id").unwrap();
+    assert_eq!(remaining.rows, vec![vec![Value::String("c".into())]]);
+}
+
+/// Non-count RETURN after an UNWIND DELETE: per `build_mutate_return`'s doc
+/// comment, only `count(n)`/`count(*)` are honoured — `RETURN n` must not
+/// error, but must return an empty projection rather than the deleted node.
+#[test]
+fn unwind_delete_return_non_count_expr_yields_empty_result() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {id: 'a'})").unwrap();
+
+    let p = params(vec![(
+        "ids",
+        map_list(vec![vec![("id", Value::String("a".into()))]]),
+    )]);
+
+    let r = db
+        .execute_with_params(
+            "UNWIND $ids AS row MATCH (n:Item {id: row.id}) DELETE n RETURN n",
+            p,
+        )
+        .unwrap();
+    assert!(
+        r.rows.is_empty(),
+        "RETURN n (non-count) after a mutation is documented as unsupported \
+         and must fall back to empty, not error and not project the node"
+    );
+
+    // The delete itself must still have taken effect.
+    let remaining = db.execute("MATCH (n:Item) RETURN n.id").unwrap();
+    assert!(remaining.rows.is_empty());
+}
+
+// ── 7. Empty list / no-match element — must not error ───────────────────────
+
+#[test]
+fn unwind_empty_param_list_is_a_no_op() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {id: 'a', val: 1})").unwrap();
+
+    let p = params(vec![("ids", Value::List(vec![]))]);
+    let r = db
+        .execute_with_params(
+            "UNWIND $ids AS row MATCH (n:Item {id: row.id}) SET n.val = 99",
+            p,
+        )
+        .unwrap();
+    assert!(r.rows.is_empty());
+
+    let check = db.execute("MATCH (n:Item {id: 'a'}) RETURN n.val").unwrap();
+    assert_eq!(
+        check.rows,
+        vec![vec![Value::Int64(1)]],
+        "empty UNWIND list must leave existing data untouched"
+    );
+}
+
+#[test]
+fn unwind_element_matching_no_node_does_not_error() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {id: 'exists', val: 1})")
+        .unwrap();
+
+    let p = params(vec![(
+        "ids",
+        map_list(vec![
+            vec![("id", Value::String("exists".into()))],
+            vec![("id", Value::String("missing".into()))],
+        ]),
+    )]);
+    let r = db
+        .execute_with_params(
+            "UNWIND $ids AS row MATCH (n:Item {id: row.id}) SET n.val = 5",
+            p,
+        )
+        .unwrap();
+    assert!(
+        r.rows.is_empty(),
+        "no RETURN clause => empty result, not an error"
+    );
+
+    let check = db
+        .execute("MATCH (n:Item {id: 'exists'}) RETURN n.val")
+        .unwrap();
+    assert_eq!(check.rows, vec![vec![Value::Int64(5)]]);
+}
+
+// ── 8. Durability: mutation must survive a reopen ───────────────────────────
+
+/// SET via the UNWIND pipeline must be durable: after `tx.commit()`, dropping
+/// the `GraphDb` and reopening the same path must show the mutated value.
+/// This is the check that catches a mutation applied only to an in-memory
+/// snapshot that never reached the WAL.
+#[test]
+fn unwind_set_survives_reopen() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+
+    {
+        let db = GraphDb::open(&path).unwrap();
+        db.execute("CREATE (n:Item {id: 'a', val: 1})").unwrap();
+        let p = params(vec![(
+            "ids",
+            map_list(vec![vec![("id", Value::String("a".into()))]]),
+        )]);
+        db.execute_with_params(
+            "UNWIND $ids AS row MATCH (n:Item {id: row.id}) SET n.val = 777",
+            p,
+        )
+        .unwrap();
+        // db dropped at end of this block.
+    }
+
+    let db2 = GraphDb::open(&path).unwrap();
+    let check = db2
+        .execute("MATCH (n:Item {id: 'a'}) RETURN n.val")
+        .unwrap();
+    assert_eq!(
+        check.rows,
+        vec![vec![Value::Int64(777)]],
+        "SET via UNWIND MATCH must be durable across a reopen"
+    );
+}
+
+/// Same durability check for DELETE via the UNWIND pipeline.
+#[test]
+fn unwind_delete_survives_reopen() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+
+    {
+        let db = GraphDb::open(&path).unwrap();
+        db.execute("CREATE (n:Item {id: 'a'})").unwrap();
+        db.execute("CREATE (n:Item {id: 'b'})").unwrap();
+        let p = params(vec![(
+            "ids",
+            map_list(vec![vec![("id", Value::String("a".into()))]]),
+        )]);
+        db.execute_with_params("UNWIND $ids AS row MATCH (n:Item {id: row.id}) DELETE n", p)
+            .unwrap();
+    }
+
+    let db2 = GraphDb::open(&path).unwrap();
+    let remaining = db2.execute("MATCH (n:Item) RETURN n.id").unwrap();
+    assert_eq!(
+        remaining.rows,
+        vec![vec![Value::String("b".into())]],
+        "DELETE via UNWIND MATCH must be durable across a reopen"
+    );
+}
+
+// ── 9. Documented visibility limitation ─────────────────────────────────────
+
+/// `execute_unwind_mutate_inner`'s doc comment states: "each UNWIND row is
+/// scanned against committed storage — earlier rows' mutations within the
+/// same transaction are NOT visible to later rows' MATCH scans." This test
+/// pins exactly that semantic with a WHERE clause whose truth value would
+/// flip if row-to-row visibility existed.
+///
+/// Setup: one node, val=1. Two UNWIND rows both target it, both guarded by
+/// `WHERE n.val < 5`.
+///   - If mutations WERE visible across rows: row 1 sets val=100, so row 2's
+///     WHERE (100 < 5) would be false — only 1 node mutated, final val=100.
+///   - Per the documented (actual) behaviour: both rows evaluate WHERE against
+///     the same pre-transaction snapshot (val=1 < 5, true for both), so both
+///     apply their SET — final val is row 2's value (last write wins), and
+///     the mutation count is 2, not 1.
+#[test]
+fn unwind_rows_do_not_see_earlier_rows_mutations_within_same_statement() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {id: 'a', val: 1})").unwrap();
+
+    let p = params(vec![(
+        "updates",
+        map_list(vec![
+            vec![
+                ("id", Value::String("a".into())),
+                ("out", Value::Int64(100)),
+            ],
+            vec![
+                ("id", Value::String("a".into())),
+                ("out", Value::Int64(200)),
+            ],
+        ]),
+    )]);
+
+    let r = db
+        .execute_with_params(
+            "UNWIND $updates AS row MATCH (n:Item {id: row.id}) \
+             WHERE n.val < 5 SET n.val = row.out RETURN count(n)",
+            p,
+        )
+        .unwrap();
+
+    // Both rows matched (per the documented same-snapshot semantics), not just
+    // the first one. If the engine ever gains row-to-row visibility, this
+    // count would drop to 1 and this assertion would need updating alongside
+    // the doc comment.
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::Int64(2)]],
+        "both UNWIND rows must see the pre-statement snapshot (val=1), not each \
+         other's writes — see execute_unwind_mutate_inner's visibility doc comment"
+    );
+
+    let check = db.execute("MATCH (n:Item {id: 'a'}) RETURN n.val").unwrap();
+    assert_eq!(
+        check.rows,
+        vec![vec![Value::Int64(200)]],
+        "last UNWIND row to write wins"
+    );
+}
+
+// ── 10. KNOWN BUG (found while writing this suite, not one of the original
+//         5 Gemini findings): a pattern property that references the UNWIND
+//         alias directly (`{id: row}`) instead of via PropAccess (`{id:
+//         row.id}`) silently matches and mutates EVERY node of the label,
+//         instead of erroring or matching nothing. ────────────────────────
+//
+// Root cause (traced against source, not guessed):
+//   - `resolve_pattern_props`/`row_expr_to_literal` (db.rs) only resolve
+//     `Expr::PropAccess { var, prop }` against the UNWIND row. A bare
+//     `Expr::Var("row")` pattern-prop value is left untouched.
+//   - The unresolved `Expr::Var("row")` then reaches
+//     `sparrowdb_execution::engine::mod::eval_expr`, which for `Expr::Var`
+//     does `vals.get(v.as_str()).cloned().unwrap_or(Value::Null)` — "row" is
+//     never a `$`-prefixed key in the params/dollar_params map, so this
+//     always evaluates to `Value::Null`.
+//   - `matches_prop_filter_static` (engine/mod.rs) then treats a `Value::Null`
+//     filter as an automatic pass ("null filter passes (param-like
+//     behaviour)"), for EVERY candidate node — the inline property filter
+//     becomes a no-op and every live node of the label is returned as
+//     "matching".
+//
+// Verified empirically (not asserted from a single anecdotal run): with 3
+// nodes of label :Item and a `$ids` list naming only one of them, `UNWIND
+// $ids AS row MATCH (n:Item {id: row}) SET n.val = 5` sets val=5 on ALL
+// THREE nodes, not just the named one.
+//
+// This is a silent-data-corruption footgun in a *mutation* context (unlike a
+// read-only MATCH misfire, this overwrites/deletes rows the caller never
+// asked for) and is a very natural mistake to make — `UNWIND list AS x
+// MATCH (n {prop: x})` is the standard Neo4j idiom when x is a scalar; here
+// it silently requires `x.field` because the row is always a Map. Per the
+// task's ground rule ("never bend a test to fit observed behaviour"), this
+// test asserts the CORRECT Cypher semantics (only the named node changes)
+// and is left `#[ignore]`, pointing at a bug rather than passing as if
+// nothing were wrong. Team lead: please file this as its own issue —
+// recommend either (a) rejecting non-PropAccess pattern-prop values that
+// reference the UNWIND alias at parse/bind time, or (b) making
+// `matches_prop_filter_static` treat an *unresolved variable* filter as "no
+// match" rather than "always match".
+#[test]
+#[ignore = "SPA-415 follow-up: {id: row} (bare alias, no .field) in an UNWIND \
+            MATCH pattern silently matches every node of the label instead of \
+            erroring or matching none — see the comment above this test"]
+fn unwind_pattern_prop_bare_alias_var_must_not_match_every_node() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {id: 'a', val: 1})").unwrap();
+    db.execute("CREATE (n:Item {id: 'b', val: 1})").unwrap();
+    db.execute("CREATE (n:Item {id: 'c', val: 1})").unwrap();
+
+    let p = params(vec![(
+        "ids",
+        map_list(vec![vec![("id", Value::String("a".into()))]]),
+    )]);
+
+    // NOTE: `{id: row}` — bare alias, not `row.id`. `row` is bound to a Map,
+    // so this is nonsensical as written, but it must not silently degrade
+    // into "no filter at all".
+    db.execute_with_params(
+        "UNWIND $ids AS row MATCH (n:Item {id: row}) SET n.val = 5",
+        p,
+    )
+    .unwrap();
+
+    let check = db
+        .execute("MATCH (n:Item) RETURN n.id, n.val ORDER BY n.id")
+        .unwrap();
+    // Correct Cypher-derived expectation: either nothing matches (row is a
+    // Map, not comparable to a string id) or, generously, only 'a' via some
+    // future coercion — but 'b' and 'c' must never change.
+    assert_ne!(
+        check.rows,
+        vec![
+            vec![Value::String("a".into()), Value::Int64(5)],
+            vec![Value::String("b".into()), Value::Int64(5)],
+            vec![Value::String("c".into()), Value::Int64(5)],
+        ],
+        "BUG: the property filter degraded to match-all and mutated every node"
+    );
+}

--- a/crates/sparrowdb/tests/spa_415_unwind_match_mutate.rs
+++ b/crates/sparrowdb/tests/spa_415_unwind_match_mutate.rs
@@ -657,3 +657,61 @@ fn unwind_pattern_prop_bare_alias_var_must_not_match_every_node() {
         "BUG: the property filter degraded to match-all and mutated every node"
     );
 }
+
+// ── #468: the read pipeline must survive the SPA-415 dispatch ───────────────
+//
+// `parse_unwind` pre-consumes MATCH (and now WHERE) to look ahead for
+// SET/DELETE. Two ways that broke the read path, both regressions against
+// behaviour that worked on 6254f91:
+//
+//   1. The patterns were handed to `parse_pipeline_continuation` as
+//      `leading_match` while `leading_unwind` was also set.
+//      `execute_pipeline_inner` picks the leading clause with an `if / else if`
+//      chain testing `leading_unwind` first, so the MATCH arm was unreachable
+//      and the pattern was dropped silently — every row projected NULL.
+//   2. Dispatching on `Token::Where` sent every read carrying a predicate into
+//      the mutation tail, which rejected it outright.
+//
+// Both are asserted on values derived by hand from the fixture below, not from
+// what the engine currently returns.
+
+#[test]
+fn unwind_match_return_binds_the_pattern_variable() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:Item {id: 'a', v: 5})").unwrap();
+    db.execute("CREATE (:Item {id: 'b', v: 1})").unwrap();
+    db.execute("CREATE (:Item {id: 'c', v: 9})").unwrap();
+
+    // 'c' is the control: never named, so it must not appear.
+    let r = db
+        .execute("UNWIND ['a', 'b'] AS x MATCH (n:Item {id: x}) RETURN n.id")
+        .expect("UNWIND ... MATCH ... RETURN must parse and execute");
+
+    assert_eq!(
+        r.rows,
+        vec![
+            vec![Value::String("a".into())],
+            vec![Value::String("b".into())],
+        ],
+        "#468: MATCH was dropped — rows project NULL when the pattern variable never binds"
+    );
+}
+
+#[test]
+fn unwind_match_where_return_applies_the_predicate() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:Item {id: 'a', v: 5})").unwrap();
+    db.execute("CREATE (:Item {id: 'b', v: 1})").unwrap();
+
+    // Both ids are named; only 'a' has v > 3, so the predicate is what
+    // distinguishes a working WHERE from one that was never applied.
+    let r = db
+        .execute("UNWIND ['a', 'b'] AS x MATCH (n:Item {id: x}) WHERE n.v > 3 RETURN n.id")
+        .expect("#468: a read pipeline with WHERE must not be routed to the mutation tail");
+
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::String("a".into())]],
+        "#468: WHERE must filter the read pipeline; 'b' has v=1 and must not survive"
+    );
+}

--- a/crates/sparrowdb/tests/vector_index.rs
+++ b/crates/sparrowdb/tests/vector_index.rs
@@ -431,3 +431,47 @@ fn create_vector_index_dot_product_metric() {
     let results = arc.read().expect("r").search(&[1.0, 1.0], 1, 10);
     assert_eq!(results[0].0, 1, "highest dot product should be node 1");
 }
+
+/// #410 fixed silent HNSW data loss on `MATCH … SET n.emb = $vec`: the property
+/// was written and the index left untouched, so the vector was invisible to
+/// search forever. SPA-415 added `UNWIND … MATCH … SET`, a second entry point to
+/// the same mutation, and it must not reopen that hole.
+///
+/// Mirrors `set_vector_param_populates_hnsw` exactly, through the UNWIND path.
+#[test]
+fn unwind_match_set_vector_param_populates_hnsw() {
+    let (_dir, db) = make_db();
+
+    db.create_vector_index("Memory", "embedding", 4, "cosine")
+        .expect("create index");
+    db.execute("CREATE (n:Memory {id: 'k1'})")
+        .expect("CREATE node");
+
+    let emb: Vec<f32> = vec![0.1, 0.2, 0.3, 0.4];
+    let mut params = std::collections::HashMap::new();
+    params.insert(
+        "rows".to_string(),
+        Value::List(vec![Value::Map(vec![(
+            "id".to_string(),
+            Value::String("k1".to_string()),
+        )])]),
+    );
+    params.insert("emb".to_string(), Value::Vector(emb.clone()));
+    db.execute_with_params(
+        "UNWIND $rows AS row MATCH (n:Memory {id: row.id}) SET n.embedding = $emb",
+        params,
+    )
+    .expect("UNWIND SET with vector param must not error");
+
+    let arc = db
+        .get_vector_index("Memory", "embedding")
+        .expect("index must exist");
+    let idx = arc.read().expect("read lock");
+    let results = idx.search(&emb, 5, 20);
+    assert!(
+        !results.is_empty(),
+        "vectorSearch after UNWIND MATCH SET must return the inserted node — \
+         an empty HNSW means the property was written and the index skipped (#410 class)"
+    );
+    assert_eq!(results.len(), 1, "exactly one node should be in the index");
+}

--- a/crates/sparrowdb/tests/vector_index.rs
+++ b/crates/sparrowdb/tests/vector_index.rs
@@ -475,3 +475,65 @@ fn unwind_match_set_vector_param_populates_hnsw() {
     );
     assert_eq!(results.len(), 1, "exactly one node should be in the index");
 }
+
+/// `SET n.emb = $a, n.emb = $b` parses into two `Mutation::Set` sharing the same
+/// prop — `parse_set_items_inner` is a bare comma loop with no duplicate guard,
+/// and nothing downstream rejects it.
+///
+/// `tx.set_property` is last-write-wins, and so is the MATCH…SET vector path
+/// (which calls `idx.insert` per mutation, in order). The UNWIND accumulator must
+/// agree with both, or the stored property and the HNSW index silently disagree —
+/// the #410 class this maintenance exists to prevent.
+///
+/// Asserted on the INDEX, not the property: the property was never the broken
+/// half. `$b` is the nearest neighbour to itself, so a first-write-wins
+/// accumulator returns `$a`'s node ordering and fails this.
+#[test]
+fn unwind_duplicate_set_same_prop_indexes_the_last_vector() {
+    let (_dir, db) = make_db();
+    db.create_vector_index("Memory", "embedding", 4, "cosine")
+        .expect("create index");
+    db.execute("CREATE (n:Memory {id: 'k1'})").expect("CREATE");
+
+    // Deliberately near-orthogonal so nearest-neighbour cannot confuse them.
+    let a: Vec<f32> = vec![1.0, 0.0, 0.0, 0.0];
+    let b: Vec<f32> = vec![0.0, 1.0, 0.0, 0.0];
+
+    let mut params = std::collections::HashMap::new();
+    params.insert(
+        "rows".to_string(),
+        Value::List(vec![Value::Map(vec![(
+            "id".to_string(),
+            Value::String("k1".to_string()),
+        )])]),
+    );
+    params.insert("a".to_string(), Value::Vector(a.clone()));
+    params.insert("b".to_string(), Value::Vector(b.clone()));
+
+    db.execute_with_params(
+        "UNWIND $rows AS row MATCH (n:Memory {id: row.id}) SET n.embedding = $a, n.embedding = $b",
+        params,
+    )
+    .expect("duplicate SET on one prop must not error");
+
+    let arc = db
+        .get_vector_index("Memory", "embedding")
+        .expect("index must exist");
+    let idx = arc.read().expect("read lock");
+
+    // Exactly one node was matched, so exactly one vector may be indexed.
+    let hits_b = idx.search(&b, 5, 20);
+    assert_eq!(hits_b.len(), 1, "one matched node => one indexed vector");
+
+    // The indexed vector must be $b (the last write), so querying $b scores
+    // better than querying $a. With cosine on orthogonal vectors, an index
+    // holding $a scores 0 against $b.
+    let score_b = hits_b[0].1;
+    let score_a = idx.search(&a, 5, 20)[0].1;
+    assert!(
+        score_b > score_a,
+        "index must hold the LAST vector ($b) to agree with the stored property; \
+         got score_b={score_b} score_a={score_a} — first-write-wins leaves the \
+         property as $b while the index holds $a"
+    );
+}


### PR DESCRIPTION
Rebase of **#411 by @evuk79** onto current `main`, with the missing test coverage and two regression fixes. Their four commits are preserved with original authorship; #411 should be closed in favour of this once merged, with credit to them.

## What #411 delivered

`UNWIND $list AS x MATCH (n {…}) SET/DELETE …` plus `DELETE … RETURN count()`. The params plumbing is correct — `params` is threaded through `execute_unwind_mutate_inner`, `engine.with_params()`, and `resolve_set_value` (commit `8a08721`), which satisfies all five high-priority findings from the June review. Those threads were never resolved on #411, so its "6 unresolved" count was bookkeeping, not outstanding work.

## What this branch adds

**Tests (`62a6931`).** #411 shipped 576 lines across `ast.rs`/`binder.rs`/`parser.rs`/`engine/mod.rs`/`db.rs` with **zero tests**. New `crates/sparrowdb/tests/spa_415_unwind_match_mutate.rs`, 16 tests, e2e against a real `GraphDb` on a tempdir:

- literal-list and `$param` paths, with a control node that must stay untouched
- `$param` resolving in **both** the WHERE clause and a SET value
- `SET n.prop = row.field` with a different value per row (guards `aa29e59`)
- DELETE, DETACH DELETE, `DELETE … RETURN count()` accumulated across rows
- empty list, no-match element, non-`count()` RETURN limitation
- **durability**: mutate → drop `GraphDb` → reopen → assert on disk
- the documented same-snapshot visibility semantic, asserted so it fails if that semantic ever changes

**Regression fix (`8995ab6`, closes #468).** #411 broke `UNWIND … MATCH … RETURN`, which worked on `6254f91`. Two distinct faults in the new dispatch:

1. Patterns were passed as `leading_match` while `leading_unwind` was also set. `execute_pipeline_inner` picks the leading clause with an `if / else if` chain testing `leading_unwind` first, so the MATCH arm was unreachable and the pattern was dropped silently — `spa_237_unwind_match` returned `["null", "null"]`. Fixed by handing the MATCH over as a `PipelineStage::Match`, the shape `parse_pipeline_continuation`'s own loop produced pre-SPA-415, rather than editing the shared `if/else if` and changing behaviour for every pipeline in the engine.
2. Dispatching on `Token::Where` routed every *read* carrying a predicate into the mutation tail, which rejected it. `UNWIND ['a','b'] AS x MATCH (n:Item {id: x}) WHERE n.v > 3 RETURN n.id` returns `[["a"]]` on main and errored on the branch. WHERE is legal in both shapes, so it is now parsed once up front and the read/mutate decision is made on SET/DELETE/DETACH.

Both regression tests were confirmed to **fail against the pre-fix parser** (`62a6931`) with those exact symptoms.

## Results

| suite | result |
|---|---|
| `spa_415_unwind_match_mutate` | 16 passed, 1 ignored (#467) |
| `spa_237_unwind_match` | 6 passed — back to parity with main |
| `spa_155_unwind_param` | 4 passed |
| `uc7_unwind` | 12 passed |
| `gap_10_parameterized_queries` | 12 passed |
| `sparrowdb-cypher` | all passed |

`cargo fmt` and `cargo clippy -p sparrowdb -p sparrowdb-cypher --all-targets --keep-going` clean.

## Known issue, deliberately not fixed here

The one ignored test documents **#467**: `matches_prop_filter_static` treats a `Null` filter as always-passing, so `MATCH (n:Item {id: row})` with a bare alias (rather than `row.id`) matches **every** node of the label — on a `SET`, it writes to all of them. The fail-open is pre-existing; this feature merely supplies a reachable path to it. Filed separately so it gets the wider audit it needs rather than a narrow patch here.

Closes #468. Supersedes #411.