### PR TITLE
fix(engine): pattern-property filters fail closed on unresolvable expressions (closes #467)

### DIFF
--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -1155,6 +1155,19 @@ mod subquery;
 /// query referenced a parameter the caller never supplied, not that the
 /// caller deliberately bound it to null.
 fn is_filter_expr_resolvable(expr: &Expr, params: &HashMap<String, Value>) -> bool {
+    is_filter_expr_resolvable_scoped(expr, params, &[])
+}
+
+/// As [`is_filter_expr_resolvable`], but with a set of locally-bound variable
+/// names — the loop variable of a list predicate (`ANY(x IN … WHERE …)`) is
+/// bound by the comprehension itself, not by the params map, so a bare
+/// `Expr::Var("x")` inside the predicate is legitimately resolvable.
+fn is_filter_expr_resolvable_scoped(
+    expr: &Expr,
+    params: &HashMap<String, Value>,
+    locals: &[&str],
+) -> bool {
+    let rec = |e: &Expr| is_filter_expr_resolvable_scoped(e, params, locals);
     match expr {
         // A literal `$name` — resolvable only if the caller actually supplied it.
         Expr::Literal(Literal::Param(p)) => params.contains_key(&format!("${p}")),
@@ -1175,23 +1188,16 @@ fn is_filter_expr_resolvable(expr: &Expr, params: &HashMap<String, Value>) -> bo
         // duplicated list of known names, which would silently drift as
         // functions are added.
         Expr::FnCall { name, args } => {
-            args.iter().all(|a| is_filter_expr_resolvable(a, params)) && {
+            args.iter().all(&rec) && {
                 let evaluated: Vec<Value> = args.iter().map(|a| eval_expr(a, params)).collect();
                 crate::functions::dispatch_function(name, evaluated).is_ok()
             }
         }
-        Expr::BinOp { left, right, .. } => {
-            is_filter_expr_resolvable(left, params) && is_filter_expr_resolvable(right, params)
-        }
-        Expr::List(items) => items.iter().all(|e| is_filter_expr_resolvable(e, params)),
-        Expr::InList { expr, list, .. } => {
-            is_filter_expr_resolvable(expr, params)
-                && list.iter().all(|e| is_filter_expr_resolvable(e, params))
-        }
-        Expr::Not(e) | Expr::IsNull(e) | Expr::IsNotNull(e) => is_filter_expr_resolvable(e, params),
-        Expr::And(a, b) | Expr::Or(a, b) => {
-            is_filter_expr_resolvable(a, params) && is_filter_expr_resolvable(b, params)
-        }
+        Expr::BinOp { left, right, .. } => rec(left) && rec(right),
+        Expr::List(items) => items.iter().all(&rec),
+        Expr::InList { expr, list, .. } => rec(expr) && list.iter().all(&rec),
+        Expr::Not(e) | Expr::IsNull(e) | Expr::IsNotNull(e) => rec(e),
+        Expr::And(a, b) | Expr::Or(a, b) => rec(a) && rec(b),
         // `CASE WHEN <cond> THEN <val> … [ELSE <val>]` is resolvable iff every
         // condition, every branch value, and the ELSE are.  This one is NOT
         // merely conservative: `MATCH (n:Item {id: CASE WHEN true THEN 1 ELSE 2 END})`
@@ -1201,12 +1207,26 @@ fn is_filter_expr_resolvable(expr: &Expr, params: &HashMap<String, Value>) -> bo
             branches,
             else_expr,
         } => {
-            branches.iter().all(|(cond, val)| {
-                is_filter_expr_resolvable(cond, params) && is_filter_expr_resolvable(val, params)
-            }) && else_expr
-                .as_ref()
-                .is_none_or(|e| is_filter_expr_resolvable(e, params))
+            branches.iter().all(|(cond, val)| rec(cond) && rec(val))
+                && else_expr.as_ref().is_none_or(|e| rec(e))
         }
+        // `ANY/ALL/NONE/SINGLE (x IN <list> WHERE <pred>)` binds `x` itself, so
+        // the predicate is resolvable even though it names a variable absent
+        // from the params map. Omitting this arm dropped the whole expression
+        // into the catch-all below, silently discarding a legitimate row — the
+        // same symptom-free under-match as the CASE WHEN gap above.
+        Expr::ListPredicate {
+            variable,
+            list_expr,
+            predicate,
+            ..
+        } => {
+            let mut inner: Vec<&str> = locals.to_vec();
+            inner.push(variable.as_str());
+            rec(list_expr) && is_filter_expr_resolvable_scoped(predicate, params, &inner)
+        }
+        // A comprehension-bound loop variable is resolvable inside its own body.
+        Expr::Var(v) if locals.contains(&v.as_str()) => true,
         // A bare variable or property access can never be resolved from a
         // params-only map — see the doc comment above.  Everything else
         // (EXISTS, shortestPath, CountStar, list predicates, …) is not

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -1162,7 +1162,24 @@ fn is_filter_expr_resolvable(expr: &Expr, params: &HashMap<String, Value>) -> bo
         // are always resolvable.
         Expr::Literal(_) => true,
         // Function calls / arithmetic are resolvable iff every argument is.
-        Expr::FnCall { args, .. } => args.iter().all(|a| is_filter_expr_resolvable(a, params)),
+        // A function call is resolvable iff every argument is AND the dispatcher
+        // actually accepts the call. Checking the arguments alone is not enough:
+        // the parser accepts any identifier as a function name, and
+        // `eval_expr` turns a dispatcher error into `Value::Null`
+        // (`dispatch_function(...).unwrap_or(Value::Null)`). That Null then hits
+        // the `Value::Null => stored_val.is_none()` arm below, so
+        // `MATCH (n:Item {id: bogus_fn(1)})` matched every node *lacking* `id`
+        // instead of matching nothing.
+        //
+        // The dispatcher itself is the source of truth here rather than a
+        // duplicated list of known names, which would silently drift as
+        // functions are added.
+        Expr::FnCall { name, args } => {
+            args.iter().all(|a| is_filter_expr_resolvable(a, params)) && {
+                let evaluated: Vec<Value> = args.iter().map(|a| eval_expr(a, params)).collect();
+                crate::functions::dispatch_function(name, evaluated).is_ok()
+            }
+        }
         Expr::BinOp { left, right, .. } => {
             is_filter_expr_resolvable(left, params) && is_filter_expr_resolvable(right, params)
         }

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -1136,6 +1136,54 @@ mod subquery;
 
 // ── Free-standing prop-filter helper (usable without &self) ───────────────────
 
+/// Returns `true` when `expr` can be fully resolved against `params` — i.e.
+/// every leaf is a literal, or a `$param` that is actually present in the
+/// params map.
+///
+/// `params` here is always a `dollar_params()`-shaped map: every call site of
+/// `matches_prop_filter_static` (and the `matches_prop_filter` wrapper) passes
+/// only `$`-prefixed runtime parameters, never row-scope bindings.  That means
+/// a bare `Expr::Var` or `Expr::PropAccess` referencing a pattern variable —
+/// including a correlated variable from an outer `MATCH`/`WITH` or an
+/// `UNWIND` alias — can *never* be resolved through this map today, no matter
+/// how the query is written.  Treating that as "unresolvable" (rather than
+/// silently defaulting to `Value::Null`) is what lets the caller fail closed
+/// instead of degrading a pattern-property filter into "match everything"
+/// (issue #467).
+///
+/// A missing `$param` is unresolvable for the same reason: it means the
+/// query referenced a parameter the caller never supplied, not that the
+/// caller deliberately bound it to null.
+fn is_filter_expr_resolvable(expr: &Expr, params: &HashMap<String, Value>) -> bool {
+    match expr {
+        // A literal `$name` — resolvable only if the caller actually supplied it.
+        Expr::Literal(Literal::Param(p)) => params.contains_key(&format!("${p}")),
+        // Constant literals (including an explicit `null` written in the query)
+        // are always resolvable.
+        Expr::Literal(_) => true,
+        // Function calls / arithmetic are resolvable iff every argument is.
+        Expr::FnCall { args, .. } => args.iter().all(|a| is_filter_expr_resolvable(a, params)),
+        Expr::BinOp { left, right, .. } => {
+            is_filter_expr_resolvable(left, params) && is_filter_expr_resolvable(right, params)
+        }
+        Expr::List(items) => items.iter().all(|e| is_filter_expr_resolvable(e, params)),
+        Expr::InList { expr, list, .. } => {
+            is_filter_expr_resolvable(expr, params)
+                && list.iter().all(|e| is_filter_expr_resolvable(e, params))
+        }
+        Expr::Not(e) | Expr::IsNull(e) | Expr::IsNotNull(e) => is_filter_expr_resolvable(e, params),
+        Expr::And(a, b) | Expr::Or(a, b) => {
+            is_filter_expr_resolvable(a, params) && is_filter_expr_resolvable(b, params)
+        }
+        // A bare variable or property access can never be resolved from a
+        // params-only map — see the doc comment above.  Everything else
+        // (CASE, EXISTS, shortestPath, CountStar, list predicates, …) is not
+        // meaningful in a pattern-property position and is conservatively
+        // treated as unresolvable too.
+        _ => false,
+    }
+}
+
 fn matches_prop_filter_static(
     props: &[(u32, u64)],
     filters: &[sparrowdb_cypher::ast::PropEntry],
@@ -1143,6 +1191,14 @@ fn matches_prop_filter_static(
     store: &NodeStore,
 ) -> bool {
     for f in filters {
+        // Fail closed: an unresolvable filter value (unbound variable, a
+        // `$param` the caller never supplied, property access on a var not in
+        // scope, …) must never widen a pattern-property filter into "match
+        // every node of the label" (issue #467). Bail out before evaluating.
+        if !is_filter_expr_resolvable(&f.value, params) {
+            return false;
+        }
+
         let col_id = prop_name_to_col_id(&f.key);
         let stored_val = props.iter().find(|(c, _)| *c == col_id).map(|(_, v)| *v);
 
@@ -1173,7 +1229,13 @@ fn matches_prop_filter_static(
                     matches!(store.decode_raw_value(raw), StoreValue::Float(stored_f) if stored_f == f)
                 })
             }
-            Value::Null => true, // null filter passes (param-like behaviour)
+            // A *resolved* null (an explicit `null` literal, or a `$param`
+            // the caller genuinely bound to null) only matches a node whose
+            // own property is likewise absent — mirroring the `Null == Null`
+            // convention `values_equal` already uses for WHERE-clause
+            // equality elsewhere in this file, rather than matching every
+            // node regardless of its stored value.
+            Value::Null => stored_val.is_none(),
             _ => false,
         };
         if !matches {

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -1175,11 +1175,31 @@ fn is_filter_expr_resolvable(expr: &Expr, params: &HashMap<String, Value>) -> bo
         Expr::And(a, b) | Expr::Or(a, b) => {
             is_filter_expr_resolvable(a, params) && is_filter_expr_resolvable(b, params)
         }
+        // `CASE WHEN <cond> THEN <val> … [ELSE <val>]` is resolvable iff every
+        // condition, every branch value, and the ELSE are.  This one is NOT
+        // merely conservative: `MATCH (n:Item {id: CASE WHEN true THEN 1 ELSE 2 END})`
+        // matched correctly before this guard existed, so lumping it in with the
+        // catch-all below silently dropped a legitimate row (SPA-138).
+        Expr::CaseWhen {
+            branches,
+            else_expr,
+        } => {
+            branches.iter().all(|(cond, val)| {
+                is_filter_expr_resolvable(cond, params) && is_filter_expr_resolvable(val, params)
+            }) && else_expr
+                .as_ref()
+                .is_none_or(|e| is_filter_expr_resolvable(e, params))
+        }
         // A bare variable or property access can never be resolved from a
         // params-only map — see the doc comment above.  Everything else
-        // (CASE, EXISTS, shortestPath, CountStar, list predicates, …) is not
+        // (EXISTS, shortestPath, CountStar, list predicates, …) is not
         // meaningful in a pattern-property position and is conservatively
         // treated as unresolvable too.
+        //
+        // Adding a variant here is only correct when it genuinely cannot be
+        // evaluated from literals and params; anything statically evaluable that
+        // lands in this arm becomes a silent under-match, which is harder to
+        // notice than the over-match this function exists to prevent.
         _ => false,
     }
 }

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -1233,10 +1233,24 @@ fn is_filter_expr_resolvable_scoped(
         // meaningful in a pattern-property position and is conservatively
         // treated as unresolvable too.
         //
-        // Adding a variant here is only correct when it genuinely cannot be
-        // evaluated from literals and params; anything statically evaluable that
-        // lands in this arm becomes a silent under-match, which is harder to
-        // notice than the over-match this function exists to prevent.
+        // THE RULE FOR ADDING A VARIANT HERE: a variant belongs in this arm iff
+        // it has **no all-literal instantiation**. Anything statically evaluable
+        // that lands here becomes a silent under-match — no error, just a
+        // missing row — which is harder to notice than the over-match this
+        // function exists to prevent.
+        //
+        // Three variants have already been fixed after wrongly landing here
+        // (CaseWhen, undispatchable FnCall, ListPredicate). All three were
+        // COMPOUND expressions whose sub-expressions can all be literals, so a
+        // fully-static form exists. The variants that remain are safe for a
+        // structural reason, not a judgement call:
+        //   • PropAccess is `{ var: String, prop: String }` — the base is a bare
+        //     identifier, not an expression, so `$param.field` is not
+        //     representable in the AST at all.
+        //   • Var (non-local) is a leaf that by definition is not in params.
+        //   • NotExists / ExistsSubquery / ShortestPath need graph traversal and
+        //     CountStar needs aggregation; none has a static form.
+        // Check that property when adding variant 19.
         _ => false,
     }
 }

--- a/crates/sparrowdb/tests/regression_467.rs
+++ b/crates/sparrowdb/tests/regression_467.rs
@@ -204,3 +204,56 @@ fn genuinely_null_bound_param_matches_none_when_prop_always_present() {
         r.rows
     );
 }
+
+/// A `CASE WHEN` whose conditions and branch values are all literals IS
+/// statically resolvable, and matched correctly before the fail-closed guard
+/// existed. The first version of that guard had no `CaseWhen` arm, so it fell
+/// into the catch-all and silently dropped the row — an under-match, which is
+/// harder to spot than the over-match the guard exists to prevent.
+///
+/// Expected value derived by hand: `CASE WHEN true THEN 1 ELSE 2 END` is 1, and
+/// exactly one `:Item` has `id = 1`.
+#[test]
+fn case_when_literal_in_pattern_prop_still_matches() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:Item {id: 1})").unwrap();
+    db.execute("CREATE (:Item {id: 2})").unwrap();
+
+    let r = db
+        .execute("MATCH (n:Item {id: CASE WHEN true THEN 1 ELSE 2 END}) RETURN n.id")
+        .expect("a fully-literal CASE WHEN must be resolvable in a pattern-property position");
+
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::Int64(1)]],
+        "CASE WHEN true THEN 1 ELSE 2 END is 1, so exactly the id=1 node must match"
+    );
+
+    // The ELSE branch must be reached, and must not be treated as unresolvable.
+    let r2 = db
+        .execute("MATCH (n:Item {id: CASE WHEN false THEN 1 ELSE 2 END}) RETURN n.id")
+        .expect("the ELSE branch must resolve too");
+    assert_eq!(
+        r2.rows,
+        vec![vec![Value::Int64(2)]],
+        "the ELSE value 2 must select the id=2 node"
+    );
+}
+
+/// The other direction: a CASE carrying an unresolvable sub-expression must
+/// still fail closed rather than widening to every node of the label.
+#[test]
+fn case_when_with_unresolvable_branch_fails_closed() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:Item {id: 1})").unwrap();
+    db.execute("CREATE (:Item {id: 2})").unwrap();
+
+    let r = db
+        .execute("MATCH (n:Item {id: CASE WHEN true THEN unbound_var ELSE 2 END}) RETURN n.id")
+        .expect("should not error");
+    assert!(
+        r.rows.is_empty(),
+        "an unresolvable branch value must fail closed, not match every node; got {:?}",
+        r.rows
+    );
+}

--- a/crates/sparrowdb/tests/regression_467.rs
+++ b/crates/sparrowdb/tests/regression_467.rs
@@ -303,3 +303,80 @@ fn known_function_in_prop_filter_still_matches() {
         "abs(-1) is 1, so only the id=1 node must match"
     );
 }
+
+/// `ANY/ALL/NONE/SINGLE (x IN <list> WHERE <pred>)` is statically evaluable when
+/// the list and predicate are literals — the loop variable is bound by the
+/// comprehension itself, not by the params map. Omitting it from the
+/// resolvability check dropped the whole expression into the catch-all and
+/// silently discarded a legitimate row: the same symptom-free under-match as the
+/// CASE WHEN gap, in the same arm.
+///
+/// Expected values derived by hand: `ANY(x IN [1,2,3] WHERE x > 1)` is true
+/// (2 and 3 qualify), so only the `flag: true` node matches.
+#[test]
+fn list_predicate_literal_in_pattern_prop_still_matches() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:Item {flag: true, tag: 'yes'})")
+        .unwrap();
+    db.execute("CREATE (:Item {flag: false, tag: 'no'})")
+        .unwrap();
+
+    for (q, expect) in [
+        // ANY: 2 > 1 and 3 > 1 -> true
+        (
+            "MATCH (n:Item {flag: ANY(x IN [1,2,3] WHERE x > 1)}) RETURN n.tag",
+            "yes",
+        ),
+        // ALL: every element > 0 -> true
+        (
+            "MATCH (n:Item {flag: ALL(x IN [1,2,3] WHERE x > 0)}) RETURN n.tag",
+            "yes",
+        ),
+        // NONE: no element > 9 -> true
+        (
+            "MATCH (n:Item {flag: NONE(x IN [1,2,3] WHERE x > 9)}) RETURN n.tag",
+            "yes",
+        ),
+        // ANY over an empty-qualifying set -> false, selects the other node
+        (
+            "MATCH (n:Item {flag: ANY(x IN [1,2,3] WHERE x > 9)}) RETURN n.tag",
+            "no",
+        ),
+    ] {
+        let r = db
+            .execute(q)
+            .expect("a literal list predicate must be resolvable");
+        assert_eq!(
+            r.rows,
+            vec![vec![Value::String(expect.to_string())]],
+            "{q}: expected the {expect:?} node"
+        );
+    }
+}
+
+/// The other direction: a list predicate carrying an unresolvable sub-expression
+/// must still fail closed rather than widening to every node of the label.
+#[test]
+fn list_predicate_with_unresolvable_parts_fails_closed() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:Item {flag: true, tag: 'yes'})")
+        .unwrap();
+    db.execute("CREATE (:Item {flag: false, tag: 'no'})")
+        .unwrap();
+
+    for q in [
+        // unbound var in the predicate body (not the loop variable)
+        "MATCH (n:Item {flag: ANY(x IN [1,2,3] WHERE x > unbound_var)}) RETURN n.tag",
+        // unbound var as the list itself
+        "MATCH (n:Item {flag: ANY(x IN unbound_list WHERE x > 1)}) RETURN n.tag",
+        // the loop variable must not leak outside its own comprehension
+        "MATCH (n:Item {flag: x}) RETURN n.tag",
+    ] {
+        let r = db.execute(q).expect("should not error");
+        assert!(
+            r.rows.is_empty(),
+            "{q}: must fail closed, not match every node; got {:?}",
+            r.rows
+        );
+    }
+}

--- a/crates/sparrowdb/tests/regression_467.rs
+++ b/crates/sparrowdb/tests/regression_467.rs
@@ -1,0 +1,206 @@
+//! Regression guard for issue #467 — pattern-property filters fail OPEN when
+//! their value expression cannot be resolved.
+//!
+//! `matches_prop_filter_static` (`crates/sparrowdb-execution/src/engine/mod.rs`)
+//! ended its match arms with `Value::Null => true, // null filter passes
+//! (param-like behaviour)`. Every leaf of a pattern-property filter's value
+//! expression is evaluated with `eval_expr`, which resolves an unknown
+//! variable, an absent `.property` key, or a `$param` the caller never
+//! supplied by falling back to `Value::Null` (see `eval_expr`'s `Expr::Var`
+//! and `Literal::Param` arms). Before the fix, that made "I could not
+//! resolve this filter" indistinguishable from "the filter is null", and
+//! both were treated as "pass" — so an unresolvable filter degraded
+//! `MATCH (n:Label {prop: <unresolvable>})` into "every live node of
+//! `Label`". On a read that over-returns rows nobody asked for; on `SET` or
+//! `DELETE` it silently mutates or removes nodes the query never named
+//! (verified below).
+//!
+//! Two conditions were being conflated:
+//!   1. The filter value is a `$param` the caller genuinely bound to null,
+//!      or an explicit `null` literal written in the query — a real,
+//!      resolvable value.
+//!   2. The filter value could not be resolved at all (missing `$param`,
+//!      an unbound variable, a property access on a variable not in scope).
+//!
+//! Only (1) has any claim to matching anything, and even then only by the
+//! same `Null == Null` convention `values_equal` already uses for
+//! WHERE-clause equality elsewhere in the same file (`engine/mod.rs`) — i.e.
+//! it matches a node whose *own* property is likewise absent, never every
+//! node regardless of its stored value. (2) now fails closed unconditionally
+//! via `is_filter_expr_resolvable`, which is checked before the filter value
+//! is ever evaluated.
+//!
+//! All expected values below are derived by hand from each fixture, not
+//! captured from a prior run.
+
+use sparrowdb::GraphDb;
+use sparrowdb_execution::Value;
+use std::collections::HashMap;
+use tempfile::tempdir;
+
+fn open_db() -> (GraphDb, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    (db, dir)
+}
+
+fn params(pairs: Vec<(&str, Value)>) -> HashMap<String, Value> {
+    pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
+}
+
+// ── 1. Read: a missing $param must not match every node of the label ───────
+//
+// Three nodes exist; `$missing` is never supplied to `execute_with_params`.
+// A control node ('c') exists purely to prove the filter didn't degrade to
+// "no filter at all" — the pre-fix code returned all three.
+
+#[test]
+fn missing_dollar_param_in_read_matches_nothing_not_everything() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {id: 'a'})").unwrap();
+    db.execute("CREATE (n:Item {id: 'b'})").unwrap();
+    db.execute("CREATE (n:Item {id: 'c'})").unwrap(); // control
+
+    let r = db
+        .execute_with_params("MATCH (n:Item {id: $missing}) RETURN n.id", HashMap::new())
+        .unwrap();
+
+    // Hand-derived: no node has an `id` equal to an unresolvable filter —
+    // the correct answer is the empty set, not all three.
+    assert_eq!(
+        r.rows,
+        Vec::<Vec<Value>>::new(),
+        "an unresolvable $param must fail closed (no rows), not match \
+         every node of the label; got {:?}",
+        r.rows
+    );
+}
+
+// ── 2. Mutation: the data-corruption case — SET must not touch every node ──
+//
+// This is the scenario the issue calls out explicitly: on a mutation, the
+// fail-open bug doesn't just over-return rows, it overwrites/deletes rows
+// the caller never named. 'c' is the control: it must retain its original
+// value if the fix holds, and would read 99 (like 'a' and 'b') pre-fix.
+
+#[test]
+fn missing_dollar_param_in_set_leaves_untargeted_nodes_untouched() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {id: 'a', val: 1})").unwrap();
+    db.execute("CREATE (n:Item {id: 'b', val: 1})").unwrap();
+    db.execute("CREATE (n:Item {id: 'c', val: 1})").unwrap(); // control
+
+    db.execute_with_params(
+        "MATCH (n:Item {id: $missing}) SET n.val = 99",
+        HashMap::new(),
+    )
+    .unwrap();
+
+    let check = db
+        .execute("MATCH (n:Item) RETURN n.id, n.val ORDER BY n.id")
+        .unwrap();
+
+    // Hand-derived: nothing matched an unresolvable filter, so every node
+    // must still read val=1 — none may read 99.
+    assert_eq!(
+        check.rows,
+        vec![
+            vec![Value::String("a".into()), Value::Int64(1)],
+            vec![Value::String("b".into()), Value::Int64(1)],
+            vec![Value::String("c".into()), Value::Int64(1)],
+        ],
+        "SET with an unresolvable $param must not write to any node \
+         (data-corruption case), got {:?}",
+        check.rows
+    );
+}
+
+// ── 3. Read: a bare (unbound) variable in a sibling pattern's prop filter ──
+//
+// `a` is a bound node variable (a NodeRef), not a `$param`, referenced bare
+// in a second pattern's inline prop filter. This is unresolvable through
+// `matches_prop_filter_static` today (it only ever receives `$`-keyed
+// params, never row-scope bindings) and must fail closed.
+
+#[test]
+fn bare_var_in_sibling_pattern_prop_filter_matches_nothing() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (a:A {tag: 'x'})").unwrap();
+    db.execute("CREATE (n:Item {id: 'a'})").unwrap();
+    db.execute("CREATE (n:Item {id: 'b'})").unwrap();
+    db.execute("CREATE (n:Item {id: 'c'})").unwrap(); // control
+
+    let r = db
+        .execute("MATCH (a:A), (n:Item {id: a}) RETURN n.id")
+        .unwrap();
+
+    assert_eq!(
+        r.rows,
+        Vec::<Vec<Value>>::new(),
+        "an unbound bare variable in a pattern-prop filter must fail closed, \
+         got {:?}",
+        r.rows
+    );
+}
+
+// ── 4. A genuinely-null-bound $param pins the chosen semantic ──────────────
+//
+// `$t` is *explicitly* supplied and bound to `Value::Null` — this is the
+// "genuinely null" case the fix must not silently break. It follows the
+// same `Null == Null` convention `values_equal` already uses for WHERE
+// equality: it matches only a node whose own property is likewise absent,
+// never a node that has the property set to something else.
+//
+// 'a' has no `tag` property at all (absent); 'b' has `tag: 'x'` (present).
+// Hand-derived: only 'a' should match.
+
+#[test]
+fn genuinely_null_bound_param_matches_only_nodes_with_absent_prop() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {id: 'a'})").unwrap(); // no `tag`
+    db.execute("CREATE (n:Item {id: 'b', tag: 'x'})").unwrap(); // `tag` present
+
+    let r = db
+        .execute_with_params(
+            "MATCH (n:Item {tag: $t}) RETURN n.id ORDER BY n.id",
+            params(vec![("t", Value::Null)]),
+        )
+        .unwrap();
+
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::String("a".into())]],
+        "a $param genuinely bound to null must match only the node whose \
+         own property is likewise absent, not every node and not none; \
+         got {:?}",
+        r.rows
+    );
+}
+
+// ── 5. Same genuinely-null-bound $param, but where NO node qualifies ───────
+//
+// Both nodes have the property set, so a genuinely-null $param must match
+// neither — confirming the fix doesn't silently widen when every candidate
+// has a non-null value.
+
+#[test]
+fn genuinely_null_bound_param_matches_none_when_prop_always_present() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {id: 'a', val: 1})").unwrap();
+    db.execute("CREATE (n:Item {id: 'b', val: 1})").unwrap();
+
+    let r = db
+        .execute_with_params(
+            "MATCH (n:Item {id: $target}) RETURN n.id",
+            params(vec![("target", Value::Null)]),
+        )
+        .unwrap();
+
+    assert_eq!(
+        r.rows,
+        Vec::<Vec<Value>>::new(),
+        "a genuinely-null $param must not match nodes whose property is \
+         always present; got {:?}",
+        r.rows
+    );
+}

--- a/crates/sparrowdb/tests/regression_467.rs
+++ b/crates/sparrowdb/tests/regression_467.rs
@@ -257,3 +257,49 @@ fn case_when_with_unresolvable_branch_fails_closed() {
         r.rows
     );
 }
+
+/// The parser accepts any identifier as a function name, and `eval_expr` turns a
+/// dispatcher error into `Value::Null`. Combined with the `Value::Null =>
+/// stored_val.is_none()` arm, an unknown function in a pattern-property filter
+/// matched every node *lacking* that property.
+///
+/// Fixture: node `a` has `id`, node `b` deliberately does not. An unresolvable
+/// function must match neither — pre-fix it returned `b`.
+#[test]
+fn unknown_function_in_prop_filter_matches_nothing() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:Item {id: 1, other: 10})").unwrap();
+    db.execute("CREATE (:Item {other: 20})").unwrap();
+
+    for q in [
+        "MATCH (n:Item {id: bogus_fn(1)}) RETURN n.other",
+        "MATCH (n:Item {id: nosuchfunction()}) RETURN n.other",
+    ] {
+        let r = db.execute(q).expect("should not error");
+        assert!(
+            r.rows.is_empty(),
+            "{q}: a function the dispatcher rejects must fail closed, not match \
+             the node whose property is absent; got {:?}",
+            r.rows
+        );
+    }
+}
+
+/// The counterpart: a function the dispatcher DOES accept must still resolve and
+/// match normally, so the check above cannot be satisfied by rejecting all calls.
+/// `abs(-1)` is 1, and exactly one `:Item` has `id = 1`.
+#[test]
+fn known_function_in_prop_filter_still_matches() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:Item {id: 1, other: 10})").unwrap();
+    db.execute("CREATE (:Item {id: 2, other: 20})").unwrap();
+
+    let r = db
+        .execute("MATCH (n:Item {id: abs(-1)}) RETURN n.other")
+        .expect("a dispatchable function must resolve");
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::Int64(10)]],
+        "abs(-1) is 1, so only the id=1 node must match"
+    );
+}


### PR DESCRIPTION
## Summary

`matches_prop_filter_static` (`crates/sparrowdb-execution/src/engine/mod.rs`) ended its match arms with:

```rust
Value::Null => true, // null filter passes (param-like behaviour)
```

Every leaf of a pattern-property filter's value expression that couldn't be resolved — a `$param` never supplied, a bare variable not in scope, a property access on an unbound var — falls back to `Value::Null` via `eval_expr`. That `Null` was then treated as an automatic pass, so `MATCH (n:Label {prop: <unresolvable>})` silently degraded into "every live node of `Label`". On a read this over-returns rows; on `SET`/`DELETE` it mutates or removes nodes the query never named.

This fix separates the two conditions that were being conflated:

- **Genuinely bound to null** (an explicit `null` literal, or a `$param` the caller deliberately supplied as null) — now matches only a node whose own property is likewise absent, mirroring the `Null == Null` convention `values_equal` already uses for WHERE-clause equality elsewhere in the same file. It no longer matches every node regardless of stored value.
- **Unresolvable** (missing `$param`, unbound variable, property access on a var not in scope) — now fails closed unconditionally via a new `is_filter_expr_resolvable` check, run *before* the filter value is ever evaluated.

`matches_prop_filter_static` is the single implementation behind every pattern-property filter call site in the engine — scan, hop, path, mutation, and the chunked pipeline all funnel through it or its `matches_prop_filter` wrapper — so this one change closes the hole everywhere it was reachable.

## Audit

| Null-producing path | Reachable today | Confirmed | Query |
|---|---|---|---|
| `$param` absent from params map | Yes | Ran it | `MATCH (n:Item {id: $missing}) RETURN n.id` (missing) |
| `$param` absent, mutation (SET) | Yes | Ran it | `MATCH (n:Item {id: $missing}) SET n.val = 99` — wrote to every node pre-fix |
| Bare unbound `Expr::Var` in sibling pattern-prop position | Yes | Ran it | `MATCH (a:A), (n:Item {id: a}) RETURN n.id` |
| `Expr::PropAccess` cross-pattern correlation | Yes | Ran it | `MATCH (a:A), (n:Item {id: a.tag}) RETURN n.id` |
| Genuinely-null-bound `$param` (control case, not a bug) | Yes | Ran it | pins the chosen semantic in `regression_467.rs` |

All five call sites of `matches_prop_filter_static`/`matches_prop_filter` (mutation.rs, pipeline_exec.rs, scan.rs, expr.rs ×3) pass only `dollar_params()` — never row-scope bindings — so a bare `Expr::Var`/`Expr::PropAccess` referencing an outer pattern variable is *never* resolvable through this function today, regardless of query shape. That's why the fail-closed check is unconditional for those expression kinds rather than attempting (and only partially succeeding at) resolution.

**Sibling path checked and found safe in the failure direction:** `matches_prop_filter_with_binding` (`scan.rs:635`, used by the pipeline `WITH … MATCH` re-traversal stage) has the same conflation for its `Expr::Var` arm, but its match logic (`(None, Value::Null) => true, _ => false`) already fails toward *too few* matches rather than *every* node — confirmed by test, not fixed here (documented as a lower-severity gap, not the #467 vulnerability).

**Related, out of scope:** `value_to_store_value` (`engine/mod.rs:1536`) silently writes `Value::Null` as `StoreValue::Int64(0)` on the `CREATE` prop-write path — a different bug shape (wrong value written vs. wrong nodes matched), not touched here.

## Testing

`crates/sparrowdb/tests/regression_467.rs` — 5 e2e tests against a real `GraphDb` on `tempfile::TempDir`:
1. Read with missing `$param` → empty result, not all 3 nodes.
2. **SET with missing `$param`** → untouched control node, catches the data-corruption case.
3. Bare unbound `Expr::Var` in a sibling pattern's prop filter → empty result.
4. Genuinely-null-bound `$param` vs. a node with an absent property → matches only that node.
5. Genuinely-null-bound `$param` where every candidate has the property set → matches none.

All 5 confirmed to **fail against the pre-fix commit** (`6254f91`, stashing just the engine change) with output matching the reported symptom exactly, e.g.:
```
SET with an unresolvable $param must not write to any node (data-corruption case),
got [[String("a"), Int64(99)], [String("b"), Int64(99)], [String("c"), Int64(99)]]
```

## Blast radius

- `cargo fmt` clean, `cargo clippy -p sparrowdb -p sparrowdb-execution --all-targets --keep-going` clean.
- Targeted suites (all pass, no behaviour changes): `gap_10_parameterized_queries`, `spa_289_multi_label`, `spa157_cypher_mutations`, `spa163_164_read_path`, `uc1_social_graph`, `uc7_unwind`, `spa_299_chunked_pipeline`, `spa_299_phase2/3/4_parity` — 89 tests, 2 pre-existing unrelated `#[ignore]`s.
- Full `cargo test --workspace --exclude sparrowdb-ruby --no-fail-fast` run in progress; will report results as a follow-up comment.
- No existing test in the repo depended on the old "null filter matches every node" behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pattern-property filters now safely return no matches when required parameters, expressions, or functions cannot be resolved.
  * Explicit `null` filters now match only nodes where the specified property is absent.
  * Prevented unresolved filters from unintentionally matching all nodes or modifying data.
  * Fully resolvable conditional expressions and supported functions continue to match as expected.

* **Tests**
  * Added regression coverage for missing parameters, variables, conditional expressions, unknown functions, `null` values, and node mutation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->