### PR TITLE
fix(vector): create_vector_index honours its documented no-op across handles

### DIFF
--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -2194,7 +2194,27 @@ impl GraphDb {
         }
         let idx = VectorIndex::new(dimensions, metric);
         let dir = self.inner.path.join("vector_indexes");
-        idx.save(&dir, label, prop).map_err(Error::Io)?;
+        if let Err(e) = idx.save(&dir, label, prop) {
+            // A generation conflict is *proof* the index exists: the file's
+            // counter has advanced past what this handle loaded, which only
+            // happens when another writer created and populated it. The
+            // documented contract for that case is a no-op, so honour it
+            // rather than surfacing an error the caller cannot act on.
+            //
+            // The `contains_key` check above cannot see this — a handle opened
+            // before the index existed has an empty map — so this is the branch
+            // that keeps the contract true across handles.
+            //
+            // Deliberately does NOT insert into the map. This handle's view is
+            // stale, and inserting a fresh empty index here would discard the
+            // other writer's vectors in memory — exactly the data loss the
+            // generation guard just prevented on disk. Leave the map alone and
+            // let the next `GraphDb::open` load the real index.
+            if VectorIndex::is_lost_update(&e) {
+                return Ok(());
+            }
+            return Err(Error::Io(e));
+        }
         self.inner
             .vector_indexes
             .write()

--- a/crates/sparrowdb/tests/regression_483_create_index_noop.rs
+++ b/crates/sparrowdb/tests/regression_483_create_index_noop.rs
@@ -1,0 +1,117 @@
+//! `create_vector_index` documents: "If an index already exists for this
+//! (label, prop) pair, this is a no-op."
+//!
+//! The `contains_key` guard cannot see an index a *different* handle created —
+//! a handle opened before the index existed has an empty map. It therefore fell
+//! through to `idx.save()` with a fresh empty index, which the #441/#442
+//! generation guard correctly refused, surfacing a hard error in the one case
+//! where the function's precondition is most certainly true.
+//!
+//! A generation conflict is proof the index exists, so the contract says no-op.
+
+use sparrowdb::GraphDb;
+use sparrowdb_execution::Value;
+use std::collections::HashMap;
+
+fn populated_index(dir: &std::path::Path) {
+    let b = GraphDb::open(dir).unwrap();
+    b.create_vector_index("M", "emb", 4, "cosine").unwrap();
+    b.execute("CREATE (n:M {id: 'k1'})").unwrap();
+    let mut p = HashMap::new();
+    p.insert("id".to_string(), Value::String("k1".into()));
+    p.insert("emb".to_string(), Value::Vector(vec![1.0, 0.0, 0.0, 0.0]));
+    b.execute_with_params("MATCH (n:M {id: $id}) SET n.emb = $emb", p)
+        .unwrap();
+}
+
+fn index_bytes(dir: &std::path::Path) -> u64 {
+    std::fs::read_dir(dir.join("vector_indexes"))
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.metadata().unwrap().len())
+        .sum()
+}
+
+#[test]
+fn create_vector_index_is_a_noop_for_an_index_another_handle_owns() {
+    let d = tempfile::tempdir().unwrap();
+
+    // `a` opens BEFORE any index exists, so its in-memory map stays empty.
+    let a = GraphDb::open(d.path()).unwrap();
+    populated_index(d.path());
+
+    let before = index_bytes(d.path());
+    assert!(before > 0, "fixture must have written an index file");
+
+    // The documented no-op, across handles.
+    a.create_vector_index("M", "emb", 4, "cosine")
+        .expect("must be a no-op, not an error: the index demonstrably exists");
+
+    assert_eq!(
+        index_bytes(d.path()),
+        before,
+        "the populated index file must be byte-identical — a no-op writes nothing"
+    );
+
+    // The load-bearing assertion. A careless fix "restores" the no-op by
+    // inserting a fresh empty index into this handle's map, which discards the
+    // other writer's vectors in memory — the data loss the generation guard
+    // just prevented on disk. The stale handle must gain nothing.
+    assert!(
+        a.get_vector_index("M", "emb").is_none(),
+        "the stale handle must NOT insert an empty index into its own map; \
+         reopen is what picks up the real one"
+    );
+
+    // Ground truth: the other writer's vector survives a fresh open.
+    let c = GraphDb::open(d.path()).unwrap();
+    let hits = c
+        .get_vector_index("M", "emb")
+        .expect("reopen must load the real index")
+        .read()
+        .unwrap()
+        .search(&[1.0, 0.0, 0.0, 0.0], 5, 20)
+        .len();
+    assert_eq!(hits, 1, "the populated vector must survive");
+}
+
+/// The same-handle path must keep working: a genuine duplicate call is still a
+/// no-op via `contains_key`, without reaching the save at all.
+#[test]
+fn create_vector_index_twice_on_one_handle_is_still_a_noop() {
+    let d = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(d.path()).unwrap();
+    db.create_vector_index("M", "emb", 4, "cosine").unwrap();
+    let before = index_bytes(d.path());
+
+    db.create_vector_index("M", "emb", 4, "cosine")
+        .expect("duplicate create on one handle is a no-op");
+
+    assert_eq!(
+        index_bytes(d.path()),
+        before,
+        "no rewrite on the no-op path"
+    );
+    assert!(
+        db.get_vector_index("M", "emb").is_some(),
+        "the handle that created it must still hold it"
+    );
+}
+
+/// A non-lost-update I/O failure must still surface. Making the target a
+/// directory produces a real write error that is not a generation conflict.
+#[test]
+fn create_vector_index_still_reports_real_io_errors() {
+    let d = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(d.path()).unwrap();
+    let vdir = d.path().join("vector_indexes");
+    std::fs::create_dir_all(&vdir).unwrap();
+    // Occupy the exact file path with a directory.
+    std::fs::create_dir_all(vdir.join("hnsw_M_emb.bin")).unwrap();
+
+    let r = db.create_vector_index("M", "emb", 4, "cosine");
+    assert!(
+        r.is_err(),
+        "a genuine I/O failure must not be swallowed as a no-op; got {r:?}"
+    );
+}


### PR DESCRIPTION
`create_vector_index` documents at `db.rs:2162`:

> If an index already exists for this `(label, prop)` pair, this is a no-op.

Its `contains_key` guard cannot see an index a **different** handle created — a handle opened before the index existed has an empty map — so it fell through to `idx.save()` with a fresh empty index. The #441/#442 generation guard correctly refused that write, but the refusal surfaced as a hard error in exactly the case where the function's precondition is most certainly true:

```
Err("HNSW index generation conflict: …/hnsw_M_emb.bin is at generation 2 but this
     handle loaded generation 0. Another writer has replaced the index since it was
     opened; saving would discard their vectors.")
```

A generation conflict is **proof the index exists** — the counter only advances when another writer populated it. So the contract says no-op, and the current behaviour violates it precisely where the precondition is strongest. This is a contract restoration, not a workaround.

## What changed

Catch that one error via the purpose-built `VectorIndex::is_lost_update` and return `Ok(())`. Every other I/O failure still propagates.

**It deliberately does not insert into the map on that branch.** This handle's view is stale; inserting a fresh empty index would discard the other writer's vectors *in memory* — the same data loss the generation guard just prevented *on disk*. One of the three tests asserts the stale handle's map stays empty, specifically so a later "fix" cannot reintroduce that.

## Verification

No behaviour change on disk — the populated file is byte-identical before and after, and the other writer's vector survives a reopen (asserted on a fresh `GraphDb::open`, not on the writing handle).

Three tests, chosen to guard both directions:

| test | against parent |
|---|---|
| `…is_a_noop_for_an_index_another_handle_owns` | **fails** with the generation error above |
| `…twice_on_one_handle_is_still_a_noop` | passes either way — guards the `contains_key` path |
| `…still_reports_real_io_errors` | passes either way — guards against swallowing genuine failures |

vector_index 16, regression_452 3, vector_index_durability 10, vector_index_load_errors 6. `cargo clippy --all-targets --keep-going` clean.

## Provenance

Found by outside review while analysing lock ordering between `create_vector_index` and `save()`. That analysis also confirmed there is **no lock-order inversion** — `save()` acquires and releases `SaveLock` internally before `create_vector_index` takes `vector_indexes.write()`, so the two orderings cannot deadlock.

The originally-suspected shape — a populated index file truncated to empty — was tested and **does not reproduce**; the generation guard defends it. This PR fixes only the surfaced-error edge that defence left behind.