### PR TITLE
fix(cypher): parameterized CREATE closes last Cypher-injection gap (S0, #480)

### DIFF
--- a/crates/sparrowdb-node/src/lib.rs
+++ b/crates/sparrowdb-node/src/lib.rs
@@ -580,6 +580,12 @@ impl SparrowDB {
     /// (`GraphDb::execute_with_params`) has supported this since SPA-218; this
     /// binding simply exposes it to JS callers.
     ///
+    /// **`CREATE` support (SPA-480):** standalone `CREATE` and
+    /// `MATCH ... CREATE` — including edge properties — now accept `$param`
+    /// values, closing the last gap in the parameterized-query story: a
+    /// `CREATE` built from untrusted input no longer needs string
+    /// interpolation to bind a runtime value.
+    ///
     /// ```typescript
     /// const emb = Array.from(new Float32Array(768))  // your model output
     /// db.executeWithParams(

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -9,8 +9,8 @@ use crate::helpers::{
     build_label_row_counts_from_disk, collect_maintenance_params, dir_size_bytes, eval_expr_merge,
     exec_value_to_storage, expr_to_value, expr_to_value_with_params, fnv1a_col_id,
     is_edge_delete_mutation, is_reserved_label, literal_to_value, load_constraints,
-    load_vector_indexes, open_csr_map, save_constraints, storage_value_to_exec, try_open_csr_map,
-    VectorIndexHealth,
+    load_vector_indexes, open_csr_map, resolve_create_prop_value, save_constraints,
+    storage_value_to_exec, try_open_csr_map, VectorIndexHealth,
 };
 use crate::read_tx::ReadTx;
 use crate::types::{DbInner, NodeVersions, PendingOp, VersionStore, WriteBuffer, WriteGuard};
@@ -559,10 +559,10 @@ impl GraphDb {
                 Statement::MatchMergeRel(ref mm) => self.execute_match_merge_rel(mm),
                 Statement::MatchMutate(ref mm) => self.execute_match_mutate(mm),
                 Statement::UnwindMatchMutate(ref umm) => self.execute_unwind_match_mutate(umm),
-                Statement::MatchCreate(ref mc) => self.execute_match_create(mc),
+                Statement::MatchCreate(ref mc) => self.execute_match_create(mc, None),
                 // Standalone CREATE with edges — must go through WriteTx so
                 // create_edge can register the rel type and write the WAL.
-                Statement::Create(ref c) => self.execute_create_standalone(c),
+                Statement::Create(ref c) => self.execute_create_standalone(c, None),
                 _ => unreachable!(),
             }
         } else {
@@ -646,8 +646,8 @@ impl GraphDb {
                 Statement::MatchMergeRel(ref mm) => self.execute_match_merge_rel(mm),
                 Statement::MatchMutate(ref mm) => self.execute_match_mutate(mm),
                 Statement::UnwindMatchMutate(ref umm) => self.execute_unwind_match_mutate(umm),
-                Statement::MatchCreate(ref mc) => self.execute_match_create(mc),
-                Statement::Create(ref c) => self.execute_create_standalone(c),
+                Statement::MatchCreate(ref mc) => self.execute_match_create(mc, None),
+                Statement::Create(ref c) => self.execute_create_standalone(c, None),
                 _ => unreachable!(),
             }
         } else {
@@ -762,8 +762,10 @@ impl GraphDb {
                 Statement::UnwindMatchMutate(ref umm) => {
                     self.execute_unwind_match_mutate_deadline(umm, deadline)
                 }
-                Statement::MatchCreate(ref mc) => self.execute_match_create_deadline(mc, deadline),
-                Statement::Create(ref c) => self.execute_create_standalone(c),
+                Statement::MatchCreate(ref mc) => {
+                    self.execute_match_create_deadline(mc, deadline, None)
+                }
+                Statement::Create(ref c) => self.execute_create_standalone(c, None),
                 _ => unreachable!(),
             };
         }
@@ -827,9 +829,16 @@ impl GraphDb {
         Ok(QueryResult::empty(vec![]))
     }
 
+    /// `params` is `Some` only when called from [`Self::execute_with_params`];
+    /// it makes `$param` property values resolvable via
+    /// [`resolve_create_prop_value`] (SPA-480/S0). When `None` (plain
+    /// `execute()` / `execute_with_timeout()`), a `$param` reference in a
+    /// CREATE property is rejected with a clear error rather than silently
+    /// written as `0`.
     fn execute_create_standalone(
         &self,
         create: &sparrowdb_cypher::ast::CreateStatement,
+        params: Option<&HashMap<String, sparrowdb_execution::Value>>,
     ) -> Result<QueryResult> {
         // Pre-flight: verify that every variable referenced by an edge is
         // declared as a named node in this CREATE clause.  Doing this before
@@ -895,27 +904,7 @@ impl GraphDb {
                 .props
                 .iter()
                 .map(|entry| {
-                    let val = match &entry.value {
-                        sparrowdb_cypher::ast::Expr::Literal(
-                            sparrowdb_cypher::ast::Literal::Null,
-                        ) => Err(sparrowdb_common::Error::InvalidArgument(format!(
-                            "CREATE property '{}' is null; use a concrete value",
-                            entry.key
-                        ))),
-                        sparrowdb_cypher::ast::Expr::Literal(
-                            sparrowdb_cypher::ast::Literal::Param(p),
-                        ) => Err(sparrowdb_common::Error::InvalidArgument(format!(
-                            "CREATE property '{}' references parameter ${p}; runtime parameters are not yet supported in standalone CREATE",
-                            entry.key
-                        ))),
-                        sparrowdb_cypher::ast::Expr::Literal(lit) => {
-                            Ok(literal_to_value(lit))
-                        }
-                        _ => Err(sparrowdb_common::Error::InvalidArgument(format!(
-                            "CREATE property '{}' must be a literal value (int, float, bool, or string)",
-                            entry.key
-                        ))),
-                    }?;
+                    let val = resolve_create_prop_value(&entry.key, &entry.value, params)?;
                     Ok((entry.key.clone(), val))
                 })
                 .collect::<Result<Vec<_>>>()?;
@@ -1104,20 +1093,13 @@ impl GraphDb {
                     "CREATE edge references unresolved variable '{right_var}'"
                 ))
             })?;
-            // Convert rel_pat.props (AST PropEntries) to HashMap<String, Value>.
+            // Convert rel_pat.props (AST PropEntries) to HashMap<String, Value>,
+            // resolving $param references the same way node props are (SPA-480).
             let edge_props: HashMap<String, Value> = rel_pat
                 .props
                 .iter()
                 .map(|pe| {
-                    let val = match &pe.value {
-                        sparrowdb_cypher::ast::Expr::Literal(lit) => literal_to_value(lit),
-                        _ => {
-                            return Err(sparrowdb_common::Error::InvalidArgument(format!(
-                                "CREATE edge property '{}' must be a literal value",
-                                pe.key
-                            )))
-                        }
-                    };
+                    let val = resolve_create_prop_value(&pe.key, &pe.value, params)?;
                     Ok((pe.key.clone(), val))
                 })
                 .collect::<Result<HashMap<_, _>>>()?;
@@ -1286,9 +1268,16 @@ impl GraphDb {
                 Stmt::UnwindMatchMutate(ref umm) => {
                     self.execute_unwind_match_mutate_with_params(umm, &params)
                 }
+                // SPA-480 (S0): standalone CREATE and MATCH...CREATE now resolve
+                // $param property values via resolve_create_prop_value, closing
+                // the last Cypher-injection gap — a CREATE built from untrusted
+                // text no longer requires string interpolation.
+                Stmt::Create(ref c) => self.execute_create_standalone(c, Some(&params)),
+                Stmt::MatchCreate(ref mc) => self.execute_match_create(mc, Some(&params)),
                 _ => Err(Error::InvalidArgument(
-                    "execute_with_params: parameterized MATCH...CREATE and standalone CREATE \
-                     are not yet supported; use MERGE or MATCH...SET with $params"
+                    "execute_with_params: parameterized MATCH...MERGE relationship and CALL \
+                     subquery mutations are not yet supported; use MERGE, MATCH...SET, or \
+                     CREATE with $params"
                         .into(),
                 )),
             };
@@ -2121,9 +2110,13 @@ impl GraphDb {
     ///
     /// If the MATCH finds no rows the CREATE is a no-op (no edges created,
     /// no error — SPA-168).
+    /// `params` is `Some` only when called from [`Self::execute_with_params`];
+    /// it makes `$param` edge-property values resolvable via
+    /// [`resolve_create_prop_value`] (SPA-480/S0).
     fn execute_match_create(
         &self,
         mc: &sparrowdb_cypher::ast::MatchCreateStatement,
+        params: Option<&HashMap<String, sparrowdb_execution::Value>>,
     ) -> Result<QueryResult> {
         // Acquire the write lock first so no concurrent writer can commit
         // between the scan and the edge creation.
@@ -2198,15 +2191,7 @@ impl GraphDb {
                     .props
                     .iter()
                     .map(|pe| {
-                        let val = match &pe.value {
-                            sparrowdb_cypher::ast::Expr::Literal(lit) => literal_to_value(lit),
-                            _ => {
-                                return Err(Error::InvalidArgument(format!(
-                                    "CREATE edge property '{}' must be a literal value",
-                                    pe.key
-                                )))
-                            }
-                        };
+                        let val = resolve_create_prop_value(&pe.key, &pe.value, params)?;
                         Ok((pe.key.clone(), val))
                     })
                     .collect::<Result<HashMap<_, _>>>()?;
@@ -2223,10 +2208,14 @@ impl GraphDb {
     }
 
     /// Deadline-aware variant of [`execute_match_create`] (fixes #310).
+    ///
+    /// `params` is `Some` only when called from [`Self::execute_with_params`]
+    /// (SPA-480/S0); see [`execute_match_create`](Self::execute_match_create).
     fn execute_match_create_deadline(
         &self,
         mc: &sparrowdb_cypher::ast::MatchCreateStatement,
         deadline: std::time::Instant,
+        params: Option<&HashMap<String, sparrowdb_execution::Value>>,
     ) -> Result<QueryResult> {
         let mut tx = self.begin_write()?;
 
@@ -2273,15 +2262,7 @@ impl GraphDb {
                     .props
                     .iter()
                     .map(|pe| {
-                        let val = match &pe.value {
-                            sparrowdb_cypher::ast::Expr::Literal(lit) => literal_to_value(lit),
-                            _ => {
-                                return Err(Error::InvalidArgument(format!(
-                                    "CREATE edge property '{}' must be a literal value",
-                                    pe.key
-                                )))
-                            }
-                        };
+                        let val = resolve_create_prop_value(&pe.key, &pe.value, params)?;
                         Ok((pe.key.clone(), val))
                     })
                     .collect::<Result<HashMap<_, _>>>()?;

--- a/crates/sparrowdb/src/helpers.rs
+++ b/crates/sparrowdb/src/helpers.rs
@@ -107,6 +107,90 @@ pub(crate) fn expr_to_value_with_params(
     }
 }
 
+/// Resolve a CREATE-clause property value expression (node or edge) to a
+/// storage `Value`, optionally substituting a bound `$parameter`.
+///
+/// Shared by standalone `CREATE` and `MATCH...CREATE`, for both node and
+/// edge properties, so a `$param` in any CREATE-clause property position is
+/// governed by one set of rules:
+///
+/// * A literal `null` is always rejected — CREATE has never accepted an
+///   explicit null property (see the pre-existing check this replaces). A
+///   `$param` that resolves to null is rejected the same way rather than
+///   redefined to mean "omit the property": one null convention for this
+///   call site, not two.
+/// * `$param` is resolved from `params` when supplied. When `params` is
+///   `None` (the plain, non-parameterized `execute()` / `execute_with_timeout()`
+///   paths), a `$param` reference is rejected with a clear error instead of
+///   silently written as `Value::Int64(0)` — the failure mode
+///   `exec_value_to_storage`'s catch-all is prone to (#475); this resolver
+///   never delegates to it.
+/// * A resolved parameter value must be a storage scalar (int, float, bool,
+///   string). `List` / `Map` / `Vector` / `NodeRef` / `EdgeRef` have no
+///   representation in a property column and are rejected rather than
+///   silently coerced to `0`.
+pub(crate) fn resolve_create_prop_value(
+    key: &str,
+    expr: &sparrowdb_cypher::ast::Expr,
+    params: Option<&HashMap<String, sparrowdb_execution::Value>>,
+) -> crate::Result<Value> {
+    use sparrowdb_cypher::ast::{Expr, Literal};
+    use sparrowdb_execution::Value as EV;
+
+    match expr {
+        Expr::Literal(Literal::Null) => Err(Error::InvalidArgument(format!(
+            "CREATE property '{key}' is null; use a concrete value"
+        ))),
+        Expr::Literal(Literal::Param(p)) => {
+            let Some(params) = params else {
+                return Err(Error::InvalidArgument(format!(
+                    "CREATE property '{key}' references parameter ${p}; use \
+                     GraphDb::execute_with_params to bind runtime parameters"
+                )));
+            };
+            match params.get(p.as_str()) {
+                None => Err(Error::InvalidArgument(format!(
+                    "parameter ${p} was referenced in the query but not supplied"
+                ))),
+                Some(EV::Null) => Err(Error::InvalidArgument(format!(
+                    "CREATE property '{key}' is bound to parameter ${p}, which is null; \
+                     use a concrete value"
+                ))),
+                Some(EV::Int64(n)) => Ok(Value::Int64(*n)),
+                Some(EV::Float64(f)) => Ok(Value::Float(*f)),
+                Some(EV::Bool(b)) => Ok(Value::Int64(if *b { 1 } else { 0 })),
+                Some(EV::String(s)) => Ok(Value::Bytes(s.as_bytes().to_vec())),
+                Some(other) => Err(Error::InvalidArgument(format!(
+                    "CREATE property '{key}' is bound to parameter ${p}, whose value ({other:?}) \
+                     is a {} and cannot be stored as a scalar property; only int, float, bool, \
+                     and string parameters may be used in CREATE",
+                    exec_value_kind(other),
+                ))),
+            }
+        }
+        Expr::Literal(lit) => Ok(literal_to_value(lit)),
+        _ => Err(Error::InvalidArgument(format!(
+            "CREATE property '{key}' must be a literal value or $parameter"
+        ))),
+    }
+}
+
+fn exec_value_kind(v: &sparrowdb_execution::Value) -> &'static str {
+    use sparrowdb_execution::Value as EV;
+    match v {
+        EV::Null => "null",
+        EV::Int64(_) => "int",
+        EV::Float64(_) => "float",
+        EV::Bool(_) => "bool",
+        EV::String(_) => "string",
+        EV::NodeRef(_) => "node reference",
+        EV::EdgeRef(_) => "edge reference",
+        EV::List(_) => "list",
+        EV::Map(_) => "map",
+        EV::Vector(_) => "vector",
+    }
+}
+
 pub(crate) fn exec_value_to_storage(v: &sparrowdb_execution::Value) -> Value {
     use sparrowdb_execution::Value as EV;
     match v {

--- a/crates/sparrowdb/tests/security_480_parameterized_create.rs
+++ b/crates/sparrowdb/tests/security_480_parameterized_create.rs
@@ -1,0 +1,498 @@
+//! Security + fidelity tests for SPA-480 (S0): parameterized `CREATE`.
+//!
+//! Closes the last gap in the Cypher-injection story. `execute_with_params`
+//! already covered MATCH/MERGE/SET (0.1.22/0.1.23); `CREATE` — the exact
+//! shape of the original exploit — previously errored with "parameterized
+//! MATCH...CREATE and standalone CREATE are not yet supported". This file
+//! proves:
+//!
+//! 1. The original exploit (`CREATE (:User {name: "${evil}"})` built via
+//!    string interpolation) is dead when the equivalent query is built with
+//!    `execute_with_params` instead — for a battery of injection payloads,
+//!    not just the one in the bug report.
+//! 2. Every scalar parameter type (string, int, float, bool) round-trips
+//!    through parameterized `CREATE` unchanged, derived by hand from the
+//!    fixture (never captured from program output — see
+//!    feedback_derive_expected_from_source in project memory).
+//! 3. `null`/`List`/`Map` parameters bound into a CREATE property are
+//!    rejected with a clear error rather than silently coerced to
+//!    `Value::Int64(0)` (the #475 failure mode).
+//! 4. Edge properties in both standalone `CREATE` and `MATCH...CREATE`
+//!    accept `$param` the same way node properties do.
+//!
+//! Pre-fix behaviour (this repo's parent commit, before SPA-480): every
+//! `execute_with_params` test below that targets `CREATE` or `MATCH...CREATE`
+//! fails with `Error::InvalidArgument("... not yet supported ...")` rather
+//! than injecting — i.e. pre-fix the attack surface was closed by refusing
+//! to run, not by being safely parameterized. The meaningful proof that this
+//! fix is real is `interpolated_form_actually_injects_demonstrating_the_bug`
+//! below: the *interpolated* equivalent injects on both the parent commit
+//! and this one (interpolation was never something this fix could patch —
+//! it hands the attacker string straight to the parser), while the
+//! parameterized form injects on neither, because pre-fix it errors and
+//! post-fix it treats the value as inert data.
+
+use sparrowdb::open;
+use sparrowdb_execution::types::Value;
+use std::collections::HashMap;
+
+fn make_db() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+fn params(pairs: &[(&str, Value)]) -> HashMap<String, Value> {
+    pairs
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.clone()))
+        .collect()
+}
+
+// ── Security: the original exploit, verbatim ──────────────────────────────────
+
+/// The exact scenario from the bug report:
+/// ```js
+/// const evil = '", role: "admin';
+/// db.execute(`CREATE (:User {name: "${evil}"})`);
+/// // -> node with name:"" AND an attacker-created role:"admin" property
+/// ```
+/// Parameterized, the same attacker string must land as one literal `name`
+/// property and must not create a `role` property.
+#[test]
+fn injection_payload_stored_as_literal_no_role_property_created() {
+    let (_dir, db) = make_db();
+    let evil = "\", role: \"admin";
+
+    db.execute_with_params(
+        "CREATE (:User {name: $name})",
+        params(&[("name", Value::String(evil.to_string()))]),
+    )
+    .expect("parameterized CREATE with attacker string must succeed, not inject");
+
+    let rows = db
+        .execute("MATCH (n:User) RETURN n.name")
+        .expect("MATCH")
+        .rows;
+    assert_eq!(rows.len(), 1, "exactly one User node must exist");
+    assert_eq!(
+        rows[0][0],
+        Value::String(evil.to_string()),
+        "name must equal the literal attacker string, unmodified"
+    );
+
+    let role_rows = db
+        .execute("MATCH (n:User) RETURN n.role")
+        .expect("MATCH")
+        .rows;
+    assert_eq!(role_rows.len(), 1);
+    assert_eq!(
+        role_rows[0][0],
+        Value::Null,
+        "no role property must have been created by the injection payload"
+    );
+}
+
+/// A payload containing `}` and `)` must not close the property map or
+/// the CREATE clause early.
+#[test]
+fn injection_payload_with_closing_brace_and_paren() {
+    let (_dir, db) = make_db();
+    let evil = "x\"}) CREATE (:Pwned {y:\"1";
+
+    db.execute_with_params(
+        "CREATE (:User {name: $name})",
+        params(&[("name", Value::String(evil.to_string()))]),
+    )
+    .expect("parameterized CREATE must succeed");
+
+    let rows = db
+        .execute("MATCH (n:User) RETURN n.name")
+        .expect("MATCH")
+        .rows;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], Value::String(evil.to_string()));
+
+    let pwned = db.execute("MATCH (n:Pwned) RETURN n").expect("MATCH").rows;
+    assert_eq!(
+        pwned.len(),
+        0,
+        "the embedded second CREATE clause must never have executed"
+    );
+}
+
+/// A payload containing an embedded newline must not be treated as a
+/// statement separator.
+#[test]
+fn injection_payload_with_newline() {
+    let (_dir, db) = make_db();
+    let evil = "line one\nCREATE (:Pwned)\nline two";
+
+    db.execute_with_params(
+        "CREATE (:User {name: $name})",
+        params(&[("name", Value::String(evil.to_string()))]),
+    )
+    .expect("parameterized CREATE must succeed");
+
+    let rows = db
+        .execute("MATCH (n:User) RETURN n.name")
+        .expect("MATCH")
+        .rows;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], Value::String(evil.to_string()));
+    assert_eq!(
+        db.execute("MATCH (n:Pwned) RETURN n").unwrap().rows.len(),
+        0
+    );
+}
+
+/// A payload containing a `//` comment sequence must not truncate the rest
+/// of the statement text at parse time (there is no statement text left to
+/// truncate — the value is bound data).
+#[test]
+fn injection_payload_with_comment_sequence() {
+    let (_dir, db) = make_db();
+    let evil = "innocent // CREATE (:Pwned) RETURN n";
+
+    db.execute_with_params(
+        "CREATE (:User {name: $name})",
+        params(&[("name", Value::String(evil.to_string()))]),
+    )
+    .expect("parameterized CREATE must succeed");
+
+    let rows = db
+        .execute("MATCH (n:User) RETURN n.name")
+        .expect("MATCH")
+        .rows;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], Value::String(evil.to_string()));
+    assert_eq!(
+        db.execute("MATCH (n:Pwned) RETURN n").unwrap().rows.len(),
+        0
+    );
+}
+
+/// A payload containing a double quote (the Cypher string delimiter used by
+/// the exploit's `CREATE (:User {name: "..."})` shape).
+#[test]
+fn injection_payload_with_double_quote() {
+    let (_dir, db) = make_db();
+    let evil = "a\"b\"c";
+
+    db.execute_with_params(
+        "CREATE (:User {name: $name})",
+        params(&[("name", Value::String(evil.to_string()))]),
+    )
+    .expect("parameterized CREATE must succeed");
+
+    let rows = db
+        .execute("MATCH (n:User) RETURN n.name")
+        .expect("MATCH")
+        .rows;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], Value::String(evil.to_string()));
+}
+
+/// A payload containing a single quote (the alternate Cypher string
+/// delimiter).
+#[test]
+fn injection_payload_with_single_quote() {
+    let (_dir, db) = make_db();
+    let evil = "a'b'c";
+
+    db.execute_with_params(
+        "CREATE (:User {name: $name})",
+        params(&[("name", Value::String(evil.to_string()))]),
+    )
+    .expect("parameterized CREATE must succeed");
+
+    let rows = db
+        .execute("MATCH (n:User) RETURN n.name")
+        .expect("MATCH")
+        .rows;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], Value::String(evil.to_string()));
+}
+
+/// A payload that is a complete, syntactically valid second statement must
+/// not execute as one — no `:Pwned` node must exist afterward.
+#[test]
+fn injection_payload_full_second_statement_no_pwned_node() {
+    let (_dir, db) = make_db();
+    let evil = "x\"}) CREATE (:Pwned {y:\"1";
+
+    db.execute_with_params(
+        "CREATE (:User {name: $name})",
+        params(&[("name", Value::String(evil.to_string()))]),
+    )
+    .expect("parameterized CREATE must succeed");
+
+    assert_eq!(
+        db.execute("MATCH (n:Pwned) RETURN n").unwrap().rows.len(),
+        0,
+        "no :Pwned node must exist"
+    );
+    assert_eq!(
+        db.execute("MATCH (n:User) RETURN n").unwrap().rows.len(),
+        1,
+        "exactly one :User node must exist — the second CREATE never ran"
+    );
+}
+
+// ── Security: prove the interpolated form is a genuinely different bug ────────
+
+/// This is the negative control. String interpolation was never something
+/// `execute_with_params` could patch — it hands the attacker string straight
+/// to the Cypher parser before `execute_with_params` (or even `execute`) is
+/// ever called. This test documents that the interpolated form still injects
+/// (as designed — parameterization is the fix, not disabling interpolation)
+/// while the parameterized form of the identical payload, tested above,
+/// does not. This is the comparison the task asked for: proof that the
+/// meaningful difference is parameterization, not some incidental change in
+/// how strings are escaped.
+#[test]
+fn interpolated_form_actually_injects_demonstrating_the_bug() {
+    let (_dir, db) = make_db();
+    let evil = "\", role: \"admin";
+
+    // The exact vulnerable pattern from the bug report: naive string
+    // interpolation into a Cypher literal, executed via plain `execute()`.
+    let cypher = format!("CREATE (:User {{name: \"{evil}\"}})");
+    db.execute(&cypher)
+        .expect("the interpolated (vulnerable) form parses and runs");
+
+    let rows = db
+        .execute("MATCH (n:User) RETURN n.name, n.role")
+        .expect("MATCH")
+        .rows;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0][0],
+        Value::String(String::new()),
+        "interpolation truncated the name to an empty string, as the bug report describes"
+    );
+    assert_eq!(
+        rows[0][1],
+        Value::String("admin".to_string()),
+        "interpolation let the attacker inject a role:\"admin\" property — \
+         this is the vulnerability that parameterized CREATE exists to avoid"
+    );
+}
+
+// ── Type fidelity: round-trip, values derived by hand from the fixture ────────
+
+#[test]
+fn roundtrip_string_param() {
+    let (_dir, db) = make_db();
+    db.execute_with_params(
+        "CREATE (:Item {label: $v})",
+        params(&[("v", Value::String("hello world".to_string()))]),
+    )
+    .expect("CREATE with string param");
+    let rows = db.execute("MATCH (n:Item) RETURN n.label").unwrap().rows;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], Value::String("hello world".to_string()));
+}
+
+#[test]
+fn roundtrip_int_param() {
+    let (_dir, db) = make_db();
+    db.execute_with_params(
+        "CREATE (:Item {count: $v})",
+        params(&[("v", Value::Int64(-42))]),
+    )
+    .expect("CREATE with int param");
+    let rows = db.execute("MATCH (n:Item) RETURN n.count").unwrap().rows;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], Value::Int64(-42));
+}
+
+#[test]
+fn roundtrip_float_param() {
+    let (_dir, db) = make_db();
+    db.execute_with_params(
+        "CREATE (:Item {ratio: $v})",
+        params(&[("v", Value::Float64(12.375))]),
+    )
+    .expect("CREATE with float param");
+    let rows = db.execute("MATCH (n:Item) RETURN n.ratio").unwrap().rows;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], Value::Float64(12.375));
+}
+
+/// Booleans are stored as `Int64(1)`/`Int64(0)` and read back the same way —
+/// this is the pre-existing, documented round-trip behaviour for booleans
+/// everywhere else in the codebase (`literal_to_value`); parameterized
+/// CREATE deliberately matches it rather than inventing a divergent
+/// convention. Fixing the underlying `Bool -> Int64` round-trip is out of
+/// scope for SPA-480.
+#[test]
+fn roundtrip_bool_param_matches_existing_int64_convention() {
+    let (_dir, db) = make_db();
+    db.execute_with_params(
+        "CREATE (:Item {active: $v})",
+        params(&[("v", Value::Bool(true))]),
+    )
+    .expect("CREATE with bool param");
+    let rows = db.execute("MATCH (n:Item) RETURN n.active").unwrap().rows;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0][0],
+        Value::Int64(1),
+        "bool true round-trips as Int64(1), matching literal_to_value's convention"
+    );
+}
+
+// ── Null / List / Map handling (#475 adjacency) ────────────────────────────────
+
+/// A `$param` bound to `Value::Null` must be rejected with a clear error,
+/// never silently written as `Value::Int64(0)` (the #475 failure mode).
+/// This mirrors the pre-existing behaviour for a literal `null` in CREATE
+/// (`CREATE (:X {p: null})` already errors on main) — one null convention,
+/// not two.
+#[test]
+fn null_param_in_create_property_is_rejected_not_coerced_to_zero() {
+    let (_dir, db) = make_db();
+    let result = db.execute_with_params("CREATE (:Item {v: $v})", params(&[("v", Value::Null)]));
+    assert!(
+        result.is_err(),
+        "a null-valued $param in a CREATE property must error"
+    );
+
+    // No node must have been created — the write must not have partially
+    // succeeded with a coerced 0.
+    assert_eq!(
+        db.execute("MATCH (n:Item) RETURN n").unwrap().rows.len(),
+        0,
+        "the CREATE must not have run at all, not run with v silently set to 0"
+    );
+}
+
+/// A `$param` bound to `Value::List` cannot be represented in a scalar
+/// property column and must be rejected, never silently coerced to 0.
+#[test]
+fn list_param_in_create_property_is_rejected_not_coerced_to_zero() {
+    let (_dir, db) = make_db();
+    let result = db.execute_with_params(
+        "CREATE (:Item {v: $v})",
+        params(&[("v", Value::List(vec![Value::Int64(1), Value::Int64(2)]))]),
+    );
+    assert!(
+        result.is_err(),
+        "a List-valued $param in a CREATE property must error"
+    );
+    assert_eq!(db.execute("MATCH (n:Item) RETURN n").unwrap().rows.len(), 0);
+}
+
+/// A `$param` bound to `Value::Map` cannot be represented in a scalar
+/// property column and must be rejected, never silently coerced to 0.
+#[test]
+fn map_param_in_create_property_is_rejected_not_coerced_to_zero() {
+    let (_dir, db) = make_db();
+    let result = db.execute_with_params(
+        "CREATE (:Item {v: $v})",
+        params(&[("v", Value::Map(vec![("k".to_string(), Value::Int64(1))]))]),
+    );
+    assert!(
+        result.is_err(),
+        "a Map-valued $param in a CREATE property must error"
+    );
+    assert_eq!(db.execute("MATCH (n:Item) RETURN n").unwrap().rows.len(), 0);
+}
+
+/// A `$param` referenced by the query but not supplied in the map must
+/// error clearly rather than defaulting to anything.
+#[test]
+fn unbound_param_in_create_property_errors() {
+    let (_dir, db) = make_db();
+    let result = db.execute_with_params("CREATE (:Item {v: $missing})", HashMap::new());
+    assert!(result.is_err(), "unbound $param must error");
+}
+
+/// A literal `$param` used with plain `execute()` (no params map) must
+/// still error clearly, exactly as it did before SPA-480 — this path is
+/// unreachable via the public API (params only arrive through
+/// `execute_with_params`), but the resolver must fail closed rather than
+/// silently zero the property if it is ever reached.
+#[test]
+fn param_reference_via_plain_execute_without_params_errors() {
+    let (_dir, db) = make_db();
+    let result = db.execute("CREATE (:Item {v: $v})");
+    assert!(
+        result.is_err(),
+        "a $param reference with no params map supplied must error, not write 0"
+    );
+    assert_eq!(db.execute("MATCH (n:Item) RETURN n").unwrap().rows.len(), 0);
+}
+
+// ── Edge properties (standalone CREATE and MATCH...CREATE) ────────────────────
+
+/// Standalone `CREATE (a)-[:R {weight: $w}]->(b)` with both endpoints new in
+/// the same statement.
+#[test]
+fn standalone_create_edge_property_param_roundtrips() {
+    let (_dir, db) = make_db();
+    db.execute_with_params(
+        "CREATE (a:Node {name: 'A'})-[:LINK {weight: $w}]->(b:Node {name: 'B'})",
+        params(&[("w", Value::Int64(7))]),
+    )
+    .expect("standalone CREATE with edge $param");
+
+    let rows = db
+        .execute("MATCH (:Node {name: 'A'})-[r:LINK]->(:Node {name: 'B'}) RETURN r.weight")
+        .expect("MATCH edge")
+        .rows;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], Value::Int64(7));
+}
+
+/// `MATCH ... CREATE` with a `$param` in the CREATE-clause edge property.
+#[test]
+fn match_create_edge_property_param_roundtrips() {
+    let (_dir, db) = make_db();
+    db.execute("CREATE (:Node {name: 'A'})").unwrap();
+    db.execute("CREATE (:Node {name: 'B'})").unwrap();
+
+    db.execute_with_params(
+        "MATCH (a:Node {name: 'A'}), (b:Node {name: 'B'}) \
+         CREATE (a)-[:LINK {weight: $w}]->(b)",
+        params(&[("w", Value::Float64(2.5))]),
+    )
+    .expect("MATCH...CREATE with edge $param");
+
+    let rows = db
+        .execute("MATCH (:Node {name: 'A'})-[r:LINK]->(:Node {name: 'B'}) RETURN r.weight")
+        .expect("MATCH edge")
+        .rows;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], Value::Float64(2.5));
+}
+
+/// An injection payload bound into an edge property (via `MATCH...CREATE`)
+/// must land as literal data, the same guarantee proven for node properties
+/// above.
+#[test]
+fn match_create_edge_property_param_injection_payload_stored_literally() {
+    let (_dir, db) = make_db();
+    db.execute("CREATE (:Node {name: 'A'})").unwrap();
+    db.execute("CREATE (:Node {name: 'B'})").unwrap();
+    let evil = "x\"}]->(b) CREATE (:Pwned {y:\"1";
+
+    db.execute_with_params(
+        "MATCH (a:Node {name: 'A'}), (b:Node {name: 'B'}) \
+         CREATE (a)-[:LINK {label: $l}]->(b)",
+        params(&[("l", Value::String(evil.to_string()))]),
+    )
+    .expect("MATCH...CREATE with edge $param injection payload");
+
+    let rows = db
+        .execute("MATCH (:Node {name: 'A'})-[r:LINK]->(:Node {name: 'B'}) RETURN r.label")
+        .expect("MATCH edge")
+        .rows;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], Value::String(evil.to_string()));
+    assert_eq!(
+        db.execute("MATCH (n:Pwned) RETURN n").unwrap().rows.len(),
+        0
+    );
+}

--- a/npm/sparrowdb/index.d.ts
+++ b/npm/sparrowdb/index.d.ts
@@ -302,6 +302,17 @@ export declare class SparrowDB {
    * Previously the property was stored but the HNSW file was not updated —
    * a silent data-loss bug surfaced by KMSmcp channel message #202.
    *
+   * **`CREATE` support (SPA-480):** standalone `CREATE (:Label {prop: $p})`
+   * and `MATCH ... CREATE` (including edge properties, e.g.
+   * `CREATE (a)-[:R {weight: $w}]->(b)`) now accept `$param` values. This
+   * closes the last gap in the parameterized-query story: building a
+   * `CREATE` from untrusted input via `executeWithParams` no longer
+   * requires string interpolation, so a value like `'", role: "admin'` is
+   * stored as a literal property value instead of being able to inject
+   * Cypher syntax. Previously these statements threw
+   * `"parameterized MATCH...CREATE and standalone CREATE are not yet
+   * supported"`.
+   *
    * ```typescript
    * const emb = Array.from(new Float32Array(768))  // your model output
    * db.executeWithParams(


### PR DESCRIPTION
## Summary

`execute_with_params` already covered MATCH/MERGE/SET (0.1.22/0.1.23), but standalone `CREATE` and `MATCH...CREATE` — the exact statement shape used in the reported exploit — errored with `"parameterized MATCH...CREATE and standalone CREATE are not yet supported"`. This closes that gap.

```js
const evil = '", role: "admin';
db.execute(`CREATE (:User {name: "${evil}"})`);
// -> node with name:"" AND an attacker-created role:"admin" property
```

is now avoidable with:

```js
db.executeWithParams("CREATE (:User {name: $name})", { name: evil });
// -> node with name:'", role: "admin' and NO role property
```

- Standalone `CREATE (:Label {prop: $param})`
- `MATCH ... CREATE` with `$param` in the CREATE clause
- `$param` in edge properties too, for both forms (`CREATE (a)-[:R {weight: $w}]->(b)`)

## Why the restriction existed, and what changed

Node-prop resolution explicitly rejected `Literal::Param` with an error; edge-prop resolution had no params path at all (`literal_to_value` only). Both were replaced by a single shared resolver, `resolve_create_prop_value` (`crates/sparrowdb/src/helpers.rs`), used by node props and edge props in both standalone `CREATE` and `MATCH...CREATE`:

- `$param` resolves against the bound params map when `execute_with_params` supplies one. When `params` is `None` (plain `execute()` / `execute_with_timeout()`), a `$param` reference still errors clearly — unchanged behavior there.
- A resolved parameter value must be a storage scalar (int, float, bool, string). `List`/`Map`/`Vector`/`NodeRef`/`EdgeRef` are rejected with a clear error rather than silently coerced to `Value::Int64(0)` — the #475 failure mode. This resolver never delegates to `exec_value_to_storage`'s lossy catch-all, so it doesn't inherit that bug.
- A `$param` resolving to `Null` is rejected with the same message as an explicit `null` literal in `CREATE` (already disallowed pre-fix) — one null convention for this call site, not two, rather than inventing "null means omit the property."

## Testing

`crates/sparrowdb/tests/security_480_parameterized_create.rs` — all e2e against a real `GraphDb` on a `tempfile::TempDir`, no unit-only tests:

- **Security (8 tests):** the original exploit payload, plus payloads containing `}`/`)`, a newline, a `//` comment sequence, both quote styles, and a full second `CREATE (:Pwned ...)` statement — all land as inert string data; no extra property, no extra node.
- **Negative control:** `interpolated_form_actually_injects_demonstrating_the_bug` — the *interpolated* form of the identical payload still injects (parameterization is the fix, not disabling interpolation).
- **Type fidelity (4 tests):** string/int/float round-trip exactly; bool round-trips as `Int64(1)`/`Int64(0)`, matching the pre-existing convention everywhere else in the codebase (not changed here — out of scope).
- **Null/List/Map (5 tests):** all rejected with a clear error, never coerced to 0; confirmed no partial write occurred.
- **Edge properties (4 tests):** round-trip and an injection payload for both standalone `CREATE`-with-edge and `MATCH...CREATE`.

**Confirmed against the pre-fix parent commit** (`a68ec69`, checked out in a scratch worktree): 14 of the 20 tests — every one that actually exercises the new capability — fail there with the old `"not yet supported"` error. The other 6 pass on both commits by design (they only assert rejection behavior or use plain `execute()`, which the fix doesn't touch).

Also ran the full CREATE/MERGE/param regression surface (`gap_10_parameterized_queries`, `match_after_create`, `merge_node`, `spa_168/182/183/211/215/233/235_234/243`, `regression_483`) — 80 tests, all pass.

## Checks

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p sparrowdb -p sparrowdb-execution -p sparrowdb-cypher --all-targets --keep-going` clean
- [x] `cargo check -p sparrowdb` passes
- [x] `cargo build --workspace --exclude sparrowdb-ruby` passes (sparrowdb-node, sparrowdb-python bindings included)
- [x] No `Value` enum changes — no ruby/node/python binding surface changes needed
- [x] `npm/sparrowdb/index.d.ts` updated (CREATE support note); mirrored in `sparrowdb-node`'s Rust doc comment

## Could not verify

- Did not attempt to build/test `sparrowdb-ruby` (documented broken locally against this machine's Ruby; CI pins Ruby 3.3 separately).
- Booleans still round-trip as `Int64(1)`/`Int64(0)` rather than `Bool` — pre-existing, explicitly out of scope per the task, unchanged by this PR.
- Did not audit `execute_batch`/`execute_batch_mutation` (crates/sparrowdb/src/db.rs, the `Statement::Create` arm around line 2790) — a separate, older execution path that inlines its own literal-only CREATE logic and has no params argument at all. It already rejects `$param` cleanly (no silent-zero risk), so it's not part of the `execute_with_params` injection story this issue is about, but it does NOT get the new parameterized-CREATE capability. Flagging in case that path is expected to gain it later.
- `MATCH...CREATE` with node creation (not just edges) remains `Error::Unimplemented` — pre-existing limitation (SPA-183 era), unrelated to params, untouched by this PR.
- `MATCH...MERGE` relationship (`MatchMergeRel`) and mutations inside `CALL { }` subqueries still fall through `execute_with_params`'s generic "not yet supported" error — out of scope for S0, but the error message was updated to stop claiming CREATE is unsupported (it now correctly names only the two remaining gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE