### PR TITLE
chore: bump 0.1.23 → 0.1.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.23"
+version = "0.1.24"
 edition = "2021"
 license = "MIT"
 authors = ["Rich Yaker"]
@@ -28,13 +28,13 @@ documentation = "https://docs.rs/sparrowdb"
 readme = "README.md"
 
 [workspace.dependencies]
-sparrowdb-common = { path = "crates/sparrowdb-common", version = "0.1.23" }
-sparrowdb-storage = { path = "crates/sparrowdb-storage", version = "0.1.23" }
-sparrowdb-catalog = { path = "crates/sparrowdb-catalog", version = "0.1.23" }
-sparrowdb-cypher  = { path = "crates/sparrowdb-cypher", version = "0.1.23" }
-sparrowdb-execution = { path = "crates/sparrowdb-execution", version = "0.1.23" }
-sparrowdb = { path = "crates/sparrowdb", version = "0.1.23" }
-sparrowdb-metrics = { path = "crates/sparrowdb-metrics", version = "0.1.23" }
+sparrowdb-common = { path = "crates/sparrowdb-common", version = "0.1.24" }
+sparrowdb-storage = { path = "crates/sparrowdb-storage", version = "0.1.24" }
+sparrowdb-catalog = { path = "crates/sparrowdb-catalog", version = "0.1.24" }
+sparrowdb-cypher  = { path = "crates/sparrowdb-cypher", version = "0.1.24" }
+sparrowdb-execution = { path = "crates/sparrowdb-execution", version = "0.1.24" }
+sparrowdb = { path = "crates/sparrowdb", version = "0.1.24" }
+sparrowdb-metrics = { path = "crates/sparrowdb-metrics", version = "0.1.24" }
 tiny_http         = "0.12"
 tempfile          = "3"
 crc32fast         = "1"

--- a/npm/sparrowdb/package-lock.json
+++ b/npm/sparrowdb/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparrowdb",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparrowdb",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"
@@ -15,11 +15,11 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@sparrowdb/darwin-arm64": "0.1.23",
-        "@sparrowdb/darwin-x64": "0.1.23",
-        "@sparrowdb/linux-arm64-gnu": "0.1.23",
-        "@sparrowdb/linux-x64-gnu": "0.1.23",
-        "@sparrowdb/win32-x64-msvc": "0.1.23"
+        "@sparrowdb/darwin-arm64": "0.1.24",
+        "@sparrowdb/darwin-x64": "0.1.24",
+        "@sparrowdb/linux-arm64-gnu": "0.1.24",
+        "@sparrowdb/linux-x64-gnu": "0.1.24",
+        "@sparrowdb/win32-x64-msvc": "0.1.24"
       }
     },
     "node_modules/@napi-rs/cli": {

--- a/npm/sparrowdb/package.json
+++ b/npm/sparrowdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparrowdb",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Native Node.js/TypeScript bindings for SparrowDB — embedded graph database with Cypher query support",
   "main": "index.js",
   "types": "index.d.ts",
@@ -22,11 +22,11 @@
   },
   "keywords": ["graph", "database", "cypher", "native", "napi"],
   "optionalDependencies": {
-    "@sparrowdb/linux-x64-gnu": "0.1.23",
-    "@sparrowdb/linux-arm64-gnu": "0.1.23",
-    "@sparrowdb/darwin-x64": "0.1.23",
-    "@sparrowdb/darwin-arm64": "0.1.23",
-    "@sparrowdb/win32-x64-msvc": "0.1.23"
+    "@sparrowdb/linux-x64-gnu": "0.1.24",
+    "@sparrowdb/linux-arm64-gnu": "0.1.24",
+    "@sparrowdb/darwin-x64": "0.1.24",
+    "@sparrowdb/darwin-arm64": "0.1.24",
+    "@sparrowdb/win32-x64-msvc": "0.1.24"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4"


### PR DESCRIPTION
Release bump. Closes every finding from the Zora integration report (#480) except the platform-packaging gap (#481).

| PR | closes | |
|---|---|---|
| **#492** | S0 (#480) | parameterized `CREATE` — `executeWithParams` shipped in 0.1.22 but not for CREATE, the exact form of the demonstrated injection |
| **#489** | #486, #487, #488 | edge direction honoured at every hop count. `<-` was inverted at one hop and silently empty at two and three |
| **#490** | #485, #491 | `COUNT`/`db_counts()` exclude deleted nodes — the stale count is what led an integrator to conclude DELETE was a no-op |

Known gap carried forward: `release.yml` builds only `linux-x64` and `darwin-arm64` while `package.json` advertises five platforms (#481).