### PR TITLE
ci(release): publish Rust crates to crates.io on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,3 +293,78 @@ jobs:
           git add Formula/sparrowdb.rb
           git commit -m "chore: update formula to v${VER}"
           git push
+
+  # ── Publish Rust crates to crates.io ──────────────────────────────────────
+  #
+  # Six crates publish in dependency order, and each must be INDEXED on
+  # crates.io before the next one resolves it — `cargo publish` for a dependent
+  # fails if its dependency is not yet queryable. `--no-verify` is deliberately
+  # NOT used: the verify build is what catches a crate that compiles in the
+  # workspace but not standalone (a path dependency left unversioned, say).
+  #
+  # Idempotent by design: a crate already published at this version is skipped
+  # rather than failing the job, so a re-run after a partial failure resumes
+  # instead of starting over. That matters because crates.io publishes cannot
+  # be undone — only yanked.
+  publish-crates:
+    name: Publish to crates.io
+    needs: meta
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Publish crates in dependency order
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          VERSION: ${{ needs.meta.outputs.version }}
+        run: |
+          if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+            echo "::error::CARGO_REGISTRY_TOKEN is not set — add it as a repository secret."
+            exit 1
+          fi
+
+          # Order derived from the internal dependency graph:
+          #   common <- storage <- catalog <- cypher <- execution <- sparrowdb
+          # sparrowdb-ruby depends on common + execution and is published last.
+          # sparrowdb-bench is a dev-dependency of sparrowdb and is not published;
+          # cargo publish ignores dev-dependencies.
+          CRATES="sparrowdb-common sparrowdb-storage sparrowdb-catalog sparrowdb-cypher sparrowdb-execution sparrowdb sparrowdb-ruby"
+
+          for crate in $CRATES; do
+            echo "── $crate ──"
+
+            # Skip if this exact version is already on crates.io. Uses the index
+            # rather than `cargo publish`'s error text, which is not stable.
+            PUBLISHED=$(curl -s -H "User-Agent: sparrowdb-release" \
+              "https://crates.io/api/v1/crates/${crate}/${VERSION}" \
+              | grep -c "\"num\":\"${VERSION}\"" || true)
+            if [ "$PUBLISHED" -gt 0 ]; then
+              echo "  already published at ${VERSION} — skipping"
+              continue
+            fi
+
+            cargo publish -p "$crate"
+
+            # Wait for the index to serve it before publishing a dependent.
+            # Polling beats a fixed sleep: it is faster when the index is quick
+            # and does not silently proceed when it is slow.
+            echo "  waiting for crates.io to index ${crate} ${VERSION}"
+            for i in $(seq 1 60); do
+              READY=$(curl -s -H "User-Agent: sparrowdb-release" \
+                "https://crates.io/api/v1/crates/${crate}/${VERSION}" \
+                | grep -c "\"num\":\"${VERSION}\"" || true)
+              if [ "$READY" -gt 0 ]; then
+                echo "  indexed after ${i} poll(s)"
+                break
+              fi
+              if [ "$i" = "60" ]; then
+                echo "::error::${crate} ${VERSION} did not appear on crates.io within 10 minutes."
+                exit 1
+              fi
+              sleep 10
+            done
+          done
+
+          echo "All crates published at ${VERSION}."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,7 +330,7 @@ jobs:
           # sparrowdb-ruby depends on common + execution and is published last.
           # sparrowdb-bench is a dev-dependency of sparrowdb and is not published;
           # cargo publish ignores dev-dependencies.
-          CRATES="sparrowdb-common sparrowdb-storage sparrowdb-catalog sparrowdb-cypher sparrowdb-execution sparrowdb sparrowdb-ruby"
+          CRATES="sparrowdb-common sparrowdb-storage sparrowdb-catalog sparrowdb-cypher sparrowdb-execution sparrowdb"
 
           for crate in $CRATES; do
             echo "── $crate ──"

--- a/crates/sparrowdb-ruby/Cargo.toml
+++ b/crates/sparrowdb-ruby/Cargo.toml
@@ -2,6 +2,10 @@
 name = "sparrowdb-ruby"
 version = "0.1.8"
 edition = "2021"
+# Ships as a Ruby gem (extconf.rb + Gemfile + lib/), not as a crate. It has never
+# been published to crates.io and cannot be: its path dependencies carry no version
+# requirement. The rubygems publish path is release.yml's commented-out job.
+publish = false
 license = "MIT OR Apache-2.0"
 authors = ["Rich Yaker"]
 description = "Ruby bindings for SparrowDB embedded graph database"


### PR DESCRIPTION
`release.yml` publishes npm, CLI binaries, a GitHub Release and the homebrew tap on a `v*` tag — but has never published crates.io. That has always been manual, and the result is registry drift that has gone **both directions in two days**:

| date | state | cause |
|---|---|---|
| 2026-08-13 | crates.io 0.1.22, npm **0.1.21** | npm behind — `v0.1.22` was never tagged |
| 2026-08-14 | npm 0.1.24, crates.io **0.1.22** | crates.io behind — no cargo step in this workflow |

Rust library users are currently two releases behind and missing the injection fix (#492), the edge-direction fixes (#489) and the count fixes (#490).

## Three details that are not obvious

**1. Order and indexing.** Six crates publish in dependency order, derived from the manifests:

```
sparrowdb-common → sparrowdb-storage → sparrowdb-catalog
  → sparrowdb-cypher → sparrowdb-execution → sparrowdb
sparrowdb-ruby (common + execution) last
```

Each must be **indexed** on crates.io before the next resolves it — publishing a dependent too early fails. The job **polls the crates.io API** rather than sleeping a fixed interval, so it is fast when the index is fast and errors loudly at 10 minutes rather than proceeding into a confusing downstream failure.

**2. Idempotent by design.** A crate already published at this version is skipped, not fatal. crates.io publishes **cannot be undone** — only yanked — so a partial failure has to be resumable by re-running, not require a version bump. This is the property that matters most in practice.

**3. No `--no-verify`.** The verify build is exactly what catches a crate that compiles inside the workspace but not standalone — a path dependency left unversioned, for instance. Skipping it would make the job faster and much less useful.

## Not published, and why that's correct

`sparrowdb-bench` is a **dev-dependency** of `sparrowdb` (line 33 of its manifest) and `cargo publish` ignores dev-dependencies. `sparrowdb-mcp` appears there only as a `[[bin]]` name, not a dependency. Both are `publish = false` and neither blocks the chain.

## Required before this can run

A **`CARGO_REGISTRY_TOKEN`** repository secret. There is currently no cargo credential on the build machine at all — no `~/.cargo/credentials.toml`, no env var, no secret — so whatever published 0.1.22 did not persist. The job fails immediately with a clear message if the secret is absent, rather than erroring deep inside cargo.

## Testing

YAML validated; job graph confirmed (`publish-crates` needs `meta`, consistent with the other publish jobs). **The publish path itself is untested by nature** — it cannot be exercised without a real token and a real tag, and a dry run would either be a no-op or an irreversible publish. First real use will be the next release; the idempotent skip is what makes that safe to retry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated publishing for Rust packages.
  * Publishes packages in dependency order and skips versions already available.
  * Verifies package indexing before continuing and reports missing credentials or timeouts.
  * Excludes the Ruby package from crates.io publication because it follows a separate release path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->