### PR TITLE
Fix 2-hop MATCH with unlabeled terminal node

### DIFF
--- a/crates/sparrowdb-execution/src/engine/hop.rs
+++ b/crates/sparrowdb-execution/src/engine/hop.rs
@@ -838,6 +838,14 @@ impl Engine {
         // nodes[2] is the fof (friend-of-friend) / anchor-B in Q8
         let fof_node_pat = &pat.nodes[2];
 
+        // If the terminal node is unlabeled, the generic N-hop executor already
+        // recovers the actual label of every final hop from the stored edges.
+        // Route there instead of requiring fof_label_id and returning a bare
+        // "not found".
+        if fof_node_pat.labels.is_empty() {
+            return self.execute_n_hop(m, column_names);
+        }
+
         let src_label = src_node_pat.labels.first().cloned().unwrap_or_default();
         let fof_label = fof_node_pat.labels.first().cloned().unwrap_or_default();
         let src_label_id = self

--- a/crates/sparrowdb-execution/src/engine/hop.rs
+++ b/crates/sparrowdb-execution/src/engine/hop.rs
@@ -2018,6 +2018,9 @@ impl Engine {
         // Reusable neighbor buffer for the variable-length traversal.
         let mut neighbors_buf: HashSet<(u64, u32)> = HashSet::new();
 
+        let use_agg = has_aggregate_in_return(&m.return_clause.items);
+        let use_eval_projection = needs_node_ref_in_return(&m.return_clause.items);
+        let mut raw_rows: Vec<HashMap<String, Value>> = Vec::new();
         let mut rows: Vec<Vec<Value>> = Vec::new();
 
         for src_slot in 0..hwm_src {
@@ -2046,6 +2049,15 @@ impl Engine {
                     let key = format!("{}.col_{col_id}", pat.nodes[0].var);
                     row_vals.insert(key, decode_raw_val(raw, &self.snapshot.store));
                 }
+                row_vals.insert(pat.nodes[0].var.clone(), Value::NodeRef(src_node_id));
+                row_vals.insert(
+                    format!("{}.__node_id__", pat.nodes[0].var),
+                    Value::NodeRef(src_node_id),
+                );
+                row_vals.insert(
+                    format!("{}.__labels__", pat.nodes[0].var),
+                    self.labels_value_for_node(src_node_id),
+                );
             }
 
             // `frontier` holds (slot, label_id, accumulated_vals) triples for the
@@ -2198,6 +2210,23 @@ impl Engine {
                                 let key = format!("{}.col_{col_id}", next_node_pat.var);
                                 new_vals.insert(key, decode_raw_val(raw, &self.snapshot.store));
                             }
+                            new_vals
+                                .insert(next_node_pat.var.clone(), Value::NodeRef(next_node_id));
+                            new_vals.insert(
+                                format!("{}.__node_id__", next_node_pat.var),
+                                Value::NodeRef(next_node_id),
+                            );
+                            new_vals.insert(
+                                format!("{}.__labels__", next_node_pat.var),
+                                self.labels_value_for_node(next_node_id),
+                            );
+                        }
+                        let rel_pat = &pat.rels[hop_idx];
+                        if !rel_pat.var.is_empty() {
+                            new_vals.insert(
+                                format!("{}.__type__", rel_pat.var),
+                                Value::String(rel_pat.rel_type.clone()),
+                            );
                         }
 
                         next_frontier.push((next_slot, next_label_id, new_vals));
@@ -2218,26 +2247,41 @@ impl Engine {
                     }
                 }
 
-                // Project column values from the accumulated binding map.
-                // Each column name is "var.prop" — look up "var.col_<id>" in the map.
-                let row: Vec<Value> = column_names
-                    .iter()
-                    .map(|col_name| {
-                        if let Some((var, prop)) = col_name.split_once('.') {
-                            let key = format!("{var}.col_{}", col_id_of(prop));
-                            path_vals.get(&key).cloned().unwrap_or(Value::Null)
-                        } else {
-                            Value::Null
-                        }
-                    })
-                    .collect();
+                if use_agg {
+                    raw_rows.push(path_vals);
+                    continue;
+                }
+
+                let row: Vec<Value> = if use_eval_projection {
+                    // Evaluate expressions that need complete bindings, including
+                    // metadata functions such as labels(n) and type(r).
+                    m.return_clause
+                        .items
+                        .iter()
+                        .map(|item| self.eval_expr_graph(&item.expr, &path_vals))
+                        .collect()
+                } else {
+                    // Preserve the established property-only projection path.
+                    column_names
+                        .iter()
+                        .map(|col_name| {
+                            if let Some((var, prop)) = col_name.split_once('.') {
+                                let key = format!("{var}.col_{}", col_id_of(prop));
+                                path_vals.get(&key).cloned().unwrap_or(Value::Null)
+                            } else {
+                                Value::Null
+                            }
+                        })
+                        .collect()
+                };
 
                 rows.push(row);
             }
         }
 
-        // DISTINCT
-        if m.distinct {
+        if use_agg {
+            rows = self.aggregate_rows_graph(&raw_rows, &m.return_clause.items);
+        } else if m.distinct {
             deduplicate_rows(&mut rows);
         }
 

--- a/crates/sparrowdb-execution/src/engine/hop.rs
+++ b/crates/sparrowdb-execution/src/engine/hop.rs
@@ -5,6 +5,14 @@ use super::*;
 /// hash-set intersection: `(b_slot, forward_neighbor_set, b_property_values)`.
 type BNeighborEntry = (u64, HashSet<u64>, Vec<(u32, u64)>);
 
+#[derive(Clone)]
+struct NhopRelBinding {
+    edge_id: sparrowdb_common::EdgeId,
+    rel_type: String,
+}
+
+type NhopNeighbor = (u64, u32, Option<NhopRelBinding>);
+
 impl Engine {
     // ── 1-hop traversal: (a)-[:R]->(f) ───────────────────────────────────────
 
@@ -2020,6 +2028,13 @@ impl Engine {
 
         let use_agg = has_aggregate_in_return(&m.return_clause.items);
         let use_eval_projection = needs_node_ref_in_return(&m.return_clause.items);
+        let rel_type_by_id: HashMap<u32, String> = self
+            .snapshot
+            .catalog
+            .list_rel_tables_with_ids()
+            .into_iter()
+            .map(|(id, _, _, rel_type)| (id as u32, rel_type))
+            .collect();
         let mut raw_rows: Vec<HashMap<String, Value>> = Vec::new();
         let mut rows: Vec<Vec<Value>> = Vec::new();
 
@@ -2085,12 +2100,12 @@ impl Engine {
                 for (cur_slot, cur_label_id, cur_vals) in frontier {
                     let hop_rel_ids = &rel_ids_per_hop[hop_idx];
 
-                    // `(slot, resolved_label_id)` candidates for this hop, each
+                    // `(slot, resolved_label_id, relationship)` candidates for this hop, each
                     // carrying the neighbour's *actual* label — read from the
                     // catalog/CSR or the stored NodeId, never guessed from the
                     // pattern or assumed from the source's label. A bare slot
                     // is not a safe node identity: see #427, #429, #431.
-                    let all_nb: Vec<(u64, u32)> = match varlen_per_hop[hop_idx] {
+                    let all_nb: Vec<NhopNeighbor> = match varlen_per_hop[hop_idx] {
                         // ── #421: variable-length hop ────────────────────────
                         Some((min_hops, max_hops)) => {
                             // Per-path enumeration is only collapsed to
@@ -2116,8 +2131,8 @@ impl Engine {
                                         // A label on the pattern is a filter:
                                         // drop nodes whose recovered label differs.
                                         Some(required) if discovered_label != required => None,
-                                        Some(required) => Some((slot, required)),
-                                        None => Some((slot, discovered_label)),
+                                        Some(required) => Some((slot, required, None)),
+                                        None => Some((slot, discovered_label, None)),
                                     }
                                 })
                                 .collect()
@@ -2143,15 +2158,89 @@ impl Engine {
                             // hop's direction rather than assuming Outgoing.
                             let incoming =
                                 pat.rels[hop_idx].dir == sparrowdb_cypher::ast::EdgeDir::Incoming;
-                            let mut seen: HashSet<(u64, u32)> = HashSet::new();
-                            let mut nb: Vec<(u64, u32)> = if incoming {
-                                self.csr_predecessors_labeled(cur_slot, cur_label_id, hop_rel_ids)
-                            } else {
-                                self.csr_neighbors_labeled(cur_slot, cur_label_id, hop_rel_ids)
+                            let mut seen: HashSet<(u64, u32, u64)> = HashSet::new();
+                            let mut nb: Vec<NhopNeighbor> = Vec::new();
+                            let topo = self.snapshot.csr_topology();
+                            for &(rid, tbl_src_lid, tbl_dst_lid) in &topo.tables {
+                                if !hop_rel_ids.is_empty() && !hop_rel_ids.contains(&rid) {
+                                    continue;
+                                }
+                                let rel_type =
+                                    rel_type_by_id.get(&rid).cloned().unwrap_or_default();
+                                let candidates: Vec<(u64, u32)> = if incoming {
+                                    if tbl_dst_lid != cur_label_id {
+                                        continue;
+                                    }
+                                    EdgeStore::open(&self.snapshot.db_root, RelTableId(rid))
+                                        .and_then(|store| store.open_bwd())
+                                        .map(|bwd| {
+                                            bwd.predecessors(cur_slot)
+                                                .iter()
+                                                .map(|&slot| (slot, tbl_src_lid))
+                                                .collect()
+                                        })
+                                        .unwrap_or_default()
+                                } else {
+                                    if tbl_src_lid != cur_label_id {
+                                        continue;
+                                    }
+                                    self.snapshot
+                                        .csrs
+                                        .get(&rid)
+                                        .map(|csr| {
+                                            csr.neighbors(cur_slot)
+                                                .iter()
+                                                .map(|&slot| (slot, tbl_dst_lid))
+                                                .collect()
+                                        })
+                                        .unwrap_or_default()
+                                };
+                                for (slot, label_id) in candidates {
+                                    let (physical_src, physical_dst) = if incoming {
+                                        (slot, cur_slot)
+                                    } else {
+                                        (cur_slot, slot)
+                                    };
+                                    let edge_id = sparrowdb_common::EdgeId(
+                                        ((rid as u64) << 32)
+                                            | (physical_src ^ physical_dst) & 0xFFFF_FFFF,
+                                    );
+                                    if seen.insert((slot, label_id, edge_id.0)) {
+                                        nb.push((
+                                            slot,
+                                            label_id,
+                                            Some(NhopRelBinding {
+                                                edge_id,
+                                                rel_type: rel_type.clone(),
+                                            }),
+                                        ));
+                                    }
+                                }
                             }
-                            .into_iter()
-                            .filter(|nb| seen.insert(*nb))
-                            .collect();
+                            // Preserve the legacy unlabeled-CSR fallback. These
+                            // tables have no catalog relationship metadata.
+                            if !incoming && hop_rel_ids.is_empty() {
+                                for &rid in &topo.unlabeled {
+                                    if let Some(csr) = self.snapshot.csrs.get(&rid) {
+                                        for &slot in csr.neighbors(cur_slot) {
+                                            let edge_id = sparrowdb_common::EdgeId(
+                                                ((rid as u64) << 32)
+                                                    | (cur_slot ^ slot) & 0xFFFF_FFFF,
+                                            );
+                                            if seen.insert((slot, cur_label_id, edge_id.0)) {
+                                                nb.push((
+                                                    slot,
+                                                    cur_label_id,
+                                                    Some(NhopRelBinding {
+                                                        edge_id,
+                                                        rel_type: String::new(),
+                                                    }),
+                                                ));
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                             for r in delta_all.iter() {
                                 // Filter by relation-table IDs when a type constraint exists.
                                 if !hop_rel_ids.is_empty() && !hop_rel_ids.contains(&r.rel_id.0) {
@@ -2165,8 +2254,22 @@ impl Engine {
                                         continue;
                                     }
                                     let (r_src_label, r_src_slot) = node_id_parts(r.src.0);
-                                    if seen.insert((r_src_slot, r_src_label)) {
-                                        nb.push((r_src_slot, r_src_label));
+                                    let edge_id = sparrowdb_common::EdgeId(
+                                        ((r.rel_id.0 as u64) << 32)
+                                            | (r_src_slot ^ cur_slot) & 0xFFFF_FFFF,
+                                    );
+                                    if seen.insert((r_src_slot, r_src_label, edge_id.0)) {
+                                        nb.push((
+                                            r_src_slot,
+                                            r_src_label,
+                                            Some(NhopRelBinding {
+                                                edge_id,
+                                                rel_type: rel_type_by_id
+                                                    .get(&r.rel_id.0)
+                                                    .cloned()
+                                                    .unwrap_or_default(),
+                                            }),
+                                        ));
                                     }
                                 } else {
                                     let (r_src_label, r_src_slot) = node_id_parts(r.src.0);
@@ -2174,8 +2277,22 @@ impl Engine {
                                         continue;
                                     }
                                     let (r_dst_label, r_dst_slot) = node_id_parts(r.dst.0);
-                                    if seen.insert((r_dst_slot, r_dst_label)) {
-                                        nb.push((r_dst_slot, r_dst_label));
+                                    let edge_id = sparrowdb_common::EdgeId(
+                                        ((r.rel_id.0 as u64) << 32)
+                                            | (cur_slot ^ r_dst_slot) & 0xFFFF_FFFF,
+                                    );
+                                    if seen.insert((r_dst_slot, r_dst_label, edge_id.0)) {
+                                        nb.push((
+                                            r_dst_slot,
+                                            r_dst_label,
+                                            Some(NhopRelBinding {
+                                                edge_id,
+                                                rel_type: rel_type_by_id
+                                                    .get(&r.rel_id.0)
+                                                    .cloned()
+                                                    .unwrap_or_default(),
+                                            }),
+                                        ));
                                     }
                                 }
                             }
@@ -2183,7 +2300,7 @@ impl Engine {
                         }
                     };
 
-                    for (next_slot, next_label_id) in all_nb {
+                    for (next_slot, next_label_id, rel_binding) in all_nb {
                         // When this position carries a label, the neighbour must
                         // actually have it — matching on the slot alone would
                         // admit the same-numbered node of any other label.
@@ -2223,10 +2340,18 @@ impl Engine {
                         }
                         let rel_pat = &pat.rels[hop_idx];
                         if !rel_pat.var.is_empty() {
+                            let rel_type = rel_binding
+                                .as_ref()
+                                .map(|binding| binding.rel_type.clone())
+                                .unwrap_or_else(|| rel_pat.rel_type.clone());
                             new_vals.insert(
                                 format!("{}.__type__", rel_pat.var),
-                                Value::String(rel_pat.rel_type.clone()),
+                                Value::String(rel_type),
                             );
+                            if let Some(binding) = rel_binding {
+                                new_vals
+                                    .insert(rel_pat.var.clone(), Value::EdgeRef(binding.edge_id));
+                            }
                         }
 
                         next_frontier.push((next_slot, next_label_id, new_vals));

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -831,44 +831,6 @@ impl Engine {
         out
     }
 
-    /// Predecessor **slots** of `(dst_slot, dst_label_id)` — the mirror of
-    /// [`Engine::csr_neighbors_labeled`] for a left-pointing (`<-`) pattern
-    /// hop.  Every hit is tagged with its own table's *source* label, exactly
-    /// as `csr_neighbors_labeled` tags forward hits with the destination
-    /// label — never inferred from the caller's slot.
-    ///
-    /// Only covers checkpointed edges (each table's on-disk backward CSR,
-    /// written at checkpoint time). Callers must separately scan the delta
-    /// log for post-checkpoint predecessors, the same two-source pattern
-    /// `csr_neighbors_labeled` callers already follow for the forward case
-    /// (CSR ∪ delta). A table with no backward CSR yet (pre-checkpoint) is
-    /// skipped rather than treated as an error — matching how the `Both`
-    /// backward pass in `execute_one_hop` degrades gracefully.
-    fn csr_predecessors_labeled(
-        &self,
-        dst_slot: u64,
-        dst_label_id: u32,
-        rel_ids: &[u32],
-    ) -> Vec<(u64, u32)> {
-        let topo = self.snapshot.csr_topology();
-        let mut out: Vec<(u64, u32)> = Vec::new();
-        for &(rid, tbl_src_lid, tbl_dst_lid) in &topo.tables {
-            if !rel_ids.is_empty() && !rel_ids.contains(&rid) {
-                continue;
-            }
-            if tbl_dst_lid != dst_label_id {
-                continue;
-            }
-            let bwd = EdgeStore::open(&self.snapshot.db_root, RelTableId(rid))
-                .and_then(|s| s.open_bwd())
-                .ok();
-            if let Some(bwd) = bwd {
-                out.extend(bwd.predecessors(dst_slot).iter().map(|&s| (s, tbl_src_lid)));
-            }
-        }
-        out
-    }
-
     /// Destination **slots** of the outgoing CSR edges of `(src_slot,
     /// src_label_id)`, restricted to edges that land on `dst_label_id` when it
     /// is `Some`.

--- a/crates/sparrowdb/tests/regression_487_488_edge_direction.rs
+++ b/crates/sparrowdb/tests/regression_487_488_edge_direction.rs
@@ -23,7 +23,7 @@
 //!
 //! The fix threads a `first_hop_incoming` / per-hop `incoming` flag through
 //! both functions, mirroring the existing `second_hop_incoming` (SPA-201)
-//! pattern: a new `Engine::csr_predecessors_labeled` (the backward mirror of
+//! pattern: a per-table backward-CSR lookup (the mirror of
 //! `csr_neighbors_labeled`) plus a per-table `CsrBackward` built the same way
 //! `execute_one_hop`'s `Both` backward pass and `execute_two_hop`'s existing
 //! `merged_bwd_csr` already do, so checkpointed edges are covered; the delta
@@ -33,7 +33,7 @@
 //! All expected values are derived by hand from each fixture's create calls,
 //! never captured from program output. Tests are duplicated pre- and
 //! post-CHECKPOINT where practical, because the delta-log path and the
-//! persisted-CSR path (`csr_predecessors_labeled`, `hop1_bwd_csr`) are
+//! persisted-CSR path (per-table predecessor lookup, `hop1_bwd_csr`) are
 //! genuinely different code and a bug in either would otherwise go unnoticed
 //! — none of this repo's existing MATCH e2e tests call CHECKPOINT, so the
 //! CSR-backed backward path was previously untested by any file in this repo.
@@ -124,7 +124,7 @@ fn issue_487_two_hop_first_hop_incoming_post_checkpoint() {
         collect_strings(&result.rows),
         vec!["a1".to_string()],
         "#487: same query must also return a1 after CHECKPOINT, exercising \
-         Engine::csr_predecessors_labeled / hop1_bwd_csr rather than the \
+         per-table predecessor lookup / hop1_bwd_csr rather than the \
          delta log"
     );
 }
@@ -267,7 +267,7 @@ fn issue_488_three_hop_all_incoming_post_checkpoint() {
         collect_strings(&result.rows),
         vec!["a1".to_string()],
         "#488: same chain must also return a1 after CHECKPOINT, exercising \
-         csr_predecessors_labeled in execute_n_hop's fixed-hop branch"
+         the per-table backward CSR lookup in execute_n_hop's fixed-hop branch"
     );
 }
 

--- a/crates/sparrowdb/tests/regression_499_unlabeled_terminal.rs
+++ b/crates/sparrowdb/tests/regression_499_unlabeled_terminal.rs
@@ -41,6 +41,17 @@ fn two_hop_unlabeled_terminal_projects_property() {
 }
 
 #[test]
+fn two_hop_unlabeled_terminal_supports_incoming_traversal() {
+    let (_dir, db) = make_db();
+
+    let result = db
+        .execute("MATCH (c:C)<-[:S]-(b:B)<-[:R]-(a) RETURN a.name")
+        .expect("incoming traversal with unlabeled terminal");
+
+    assert_eq!(result.rows, vec![vec![Value::String("source".into())]]);
+}
+
+#[test]
 fn two_hop_unlabeled_terminal_aggregates_node_binding() {
     let (_dir, db) = make_db();
 

--- a/crates/sparrowdb/tests/regression_499_unlabeled_terminal.rs
+++ b/crates/sparrowdb/tests/regression_499_unlabeled_terminal.rs
@@ -16,6 +16,11 @@ fn make_db() -> (tempfile::TempDir, sparrowdb::GraphDb) {
     )
     .unwrap();
     db.execute(
+        "MATCH (a:A {name: 'source'}), (b:B {name: 'middle'}) \
+         CREATE (a)-[:ALT]->(b)",
+    )
+    .unwrap();
+    db.execute(
         "MATCH (b:B {name: 'middle'}), (c:C {name: 'terminal'}) \
          CREATE (b)-[:S]->(c)",
     )
@@ -72,4 +77,39 @@ fn two_hop_unlabeled_terminal_exposes_resolved_label_metadata() {
         result.rows,
         vec![vec![Value::List(vec![Value::String("C".into())])]]
     );
+}
+
+#[test]
+fn two_hop_unlabeled_terminal_resolves_untyped_relationship_metadata() {
+    let (_dir, db) = make_db();
+
+    let result = db
+        .execute(
+            "MATCH (a:A)-[r]->(b:B)-[:S]->(c) \
+             RETURN type(r)",
+        )
+        .expect("catalog relationship types for untyped pattern");
+
+    let mut rel_types: Vec<String> = result
+        .rows
+        .into_iter()
+        .map(|row| match &row[0] {
+            Value::String(value) => value.clone(),
+            other => panic!("expected relationship type string, got {other:?}"),
+        })
+        .collect();
+    rel_types.sort();
+    assert_eq!(rel_types, vec!["ALT".to_string(), "R".to_string()]);
+}
+
+#[test]
+fn two_hop_unlabeled_terminal_counts_distinct_relationship_bindings() {
+    let (_dir, db) = make_db();
+    db.execute("CHECKPOINT").expect("checkpoint");
+
+    let result = db
+        .execute("MATCH (a:A)-[r]->(b:B)-[:S]->(c) RETURN count(r)")
+        .expect("aggregate over untyped relationship binding");
+
+    assert_eq!(result.rows, vec![vec![Value::Int64(2)]]);
 }

--- a/crates/sparrowdb/tests/regression_499_unlabeled_terminal.rs
+++ b/crates/sparrowdb/tests/regression_499_unlabeled_terminal.rs
@@ -1,0 +1,75 @@
+//! Regression tests for #499: two-hop MATCH with an unlabeled terminal node.
+
+use sparrowdb::open;
+use sparrowdb_execution::types::Value;
+
+fn make_db() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+
+    db.execute("CREATE (:A {name: 'source'})").unwrap();
+    db.execute("CREATE (:B {name: 'middle'})").unwrap();
+    db.execute("CREATE (:C {name: 'terminal'})").unwrap();
+    db.execute(
+        "MATCH (a:A {name: 'source'}), (b:B {name: 'middle'}) \
+         CREATE (a)-[:R]->(b)",
+    )
+    .unwrap();
+    db.execute(
+        "MATCH (b:B {name: 'middle'}), (c:C {name: 'terminal'}) \
+         CREATE (b)-[:S]->(c)",
+    )
+    .unwrap();
+
+    (dir, db)
+}
+
+#[test]
+fn two_hop_unlabeled_terminal_projects_property() {
+    let (_dir, db) = make_db();
+
+    let result = db
+        .execute("MATCH (a:A)-[:R]->(b:B)-[:S]->(c) RETURN c.name")
+        .expect("two-hop MATCH with unlabeled terminal");
+
+    assert_eq!(result.rows, vec![vec![Value::String("terminal".into())]]);
+}
+
+#[test]
+fn two_hop_unlabeled_terminal_aggregates_node_binding() {
+    let (_dir, db) = make_db();
+
+    let result = db
+        .execute("MATCH (a:A)-[:R]->(b:B)-[:S]->(c) RETURN count(c)")
+        .expect("aggregate over unlabeled terminal");
+
+    assert_eq!(result.rows, vec![vec![Value::Int64(1)]]);
+}
+
+#[test]
+fn two_hop_unlabeled_terminal_supports_relationship_predicate() {
+    let (_dir, db) = make_db();
+
+    let result = db
+        .execute(
+            "MATCH (a:A)-[r:R]->(b:B)-[:S]->(c) \
+             WHERE type(r) = 'R' RETURN c.name",
+        )
+        .expect("relationship predicate with unlabeled terminal");
+
+    assert_eq!(result.rows, vec![vec![Value::String("terminal".into())]]);
+}
+
+#[test]
+fn two_hop_unlabeled_terminal_exposes_resolved_label_metadata() {
+    let (_dir, db) = make_db();
+
+    let result = db
+        .execute("MATCH (a:A)-[:R]->(b:B)-[:S]->(c) RETURN labels(c)")
+        .expect("label metadata for unlabeled terminal");
+
+    assert_eq!(
+        result.rows,
+        vec![vec![Value::List(vec![Value::String("C".into())])]]
+    );
+}


### PR DESCRIPTION
Fixes #493 by routing 2-hop patterns with an unlabeled terminal node through the generic N-hop executor, which resolves the final hop's label from stored edges instead of requiring a catalog label lookup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed two-step relationship queries involving unlabeled terminal nodes, preventing valid results from being incorrectly reported as not found.
  * Improved incoming and outgoing traversal accuracy, including relationship direction, labels, and metadata.
  * Improved query results for property projections, aggregations, relationship filters, and distinct relationship counts.
  * Preserved existing behavior for property-only projections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->