### PR TITLE
fix(cypher): reject UNION over a mutating clause (closes #478)

### DIFF
--- a/crates/sparrowdb-cypher/src/ast.rs
+++ b/crates/sparrowdb-cypher/src/ast.rs
@@ -594,3 +594,39 @@ pub enum Statement {
         name: String,
     },
 }
+
+impl Statement {
+    /// Returns `true` if executing this statement can durably mutate graph
+    /// state, and therefore must be routed through the transactional
+    /// `WriteTx` path rather than the read-only engine dispatch.
+    ///
+    /// This is the single source of truth for that classification — do not
+    /// duplicate this match elsewhere. A statement shape that can reach a
+    /// mutation but is missing here is a silent-data-loss bug: the caller
+    /// takes the read-only path, executes a `CREATE`/`MERGE`/`SET`/`DELETE`
+    /// against a non-transactional `NodeStore`, and reports success while
+    /// nothing durable happens (issue #478).
+    ///
+    /// `Union` is deliberately *not* listed as a mutation here: Cypher does
+    /// not define `UNION` over mutating branches, so the binder rejects a
+    /// `UNION` with a mutating side at bind time (see `bind()` in
+    /// `binder.rs`) rather than trying to route it through the write path.
+    pub fn is_mutation(&self) -> bool {
+        match self {
+            Statement::Merge(_)
+            | Statement::MatchMergeRel(_)
+            | Statement::MatchMutate(_)
+            | Statement::UnwindMatchMutate(_)
+            | Statement::MatchCreate(_) => true,
+            // All standalone CREATE statements must go through the
+            // write-transaction path to ensure WAL durability and correct
+            // single-writer semantics, regardless of whether edges are present.
+            Statement::Create(_) => true,
+            // Recursively check CALL { } subqueries so that a mutation inside
+            // the braces is routed through the write-transaction path rather than
+            // being silently dispatched via the read path and failing late.
+            Statement::CallSubquery { subquery, .. } => subquery.is_mutation(),
+            _ => false,
+        }
+    }
+}

--- a/crates/sparrowdb-cypher/src/binder.rs
+++ b/crates/sparrowdb-cypher/src/binder.rs
@@ -64,7 +64,25 @@ pub fn bind(stmt: Statement, catalog: &Catalog) -> Result<BoundStatement> {
         Statement::OptionalMatch(_) => {}
         Statement::MatchOptionalMatch(mom) => bind_match_optional_match(mom, catalog)?,
         // UNION: bind both sides independently.
+        //
+        // Cypher does not define UNION over mutating clauses. Reject here
+        // rather than letting a mutating branch (CREATE, MERGE, MATCH...SET,
+        // MATCH...DELETE) reach the read-only engine dispatch: that path runs
+        // against a non-transactional NodeStore, so the statement would
+        // report success while durably writing nothing (issue #478). This
+        // check must run on *both* sides — `UNION` is left/right-symmetric
+        // and a mutation can appear on either branch, or nested arbitrarily
+        // deep in a `UNION`-of-`UNION` chain (each nested `Union` is bound
+        // recursively via this same arm, so nesting is covered for free).
         Statement::Union(u) => {
+            if u.left.is_mutation() || u.right.is_mutation() {
+                return Err(sparrowdb_common::Error::InvalidArgument(
+                    "UNION cannot contain a mutating clause (CREATE, MERGE, \
+                     MATCH ... SET, MATCH ... DELETE); each UNION branch must \
+                     be a read-only query"
+                        .into(),
+                ));
+            }
             bind((*u.left).clone(), catalog)?;
             bind((*u.right).clone(), catalog)?;
         }

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -1084,23 +1084,12 @@ impl Engine {
         }
     }
 
+    /// Delegates to [`Statement::is_mutation`], the single source of truth
+    /// for this classification (see its doc comment — issue #478 was a
+    /// `Statement::Union` variant missing from a match that used to live
+    /// here directly).
     pub fn is_mutation(stmt: &Statement) -> bool {
-        match stmt {
-            Statement::Merge(_)
-            | Statement::MatchMergeRel(_)
-            | Statement::MatchMutate(_)
-            | Statement::UnwindMatchMutate(_)
-            | Statement::MatchCreate(_) => true,
-            // All standalone CREATE statements must go through the
-            // write-transaction path to ensure WAL durability and correct
-            // single-writer semantics, regardless of whether edges are present.
-            Statement::Create(_) => true,
-            // Recursively check CALL { } subqueries so that a mutation inside
-            // the braces is routed through the write-transaction path rather than
-            // being silently dispatched via the read path and failing late.
-            Statement::CallSubquery { subquery, .. } => Self::is_mutation(subquery),
-            _ => false,
-        }
+        stmt.is_mutation()
     }
 }
 

--- a/crates/sparrowdb/tests/regression_478_union_create.rs
+++ b/crates/sparrowdb/tests/regression_478_union_create.rs
@@ -1,0 +1,253 @@
+//! Regression guards for issue #478 — `UNION`-wrapped `CREATE` reports
+//! success and durably writes nothing.
+//!
+//! `Engine::is_mutation` enumerated `Merge`, `MatchMergeRel`, `MatchMutate`,
+//! `MatchCreate`, `Create`, and recursive `CallSubquery` — but not
+//! `Statement::Union`, which fell through to `_ => false`. A query shaped
+//! `CREATE (...) RETURN 1 UNION CREATE (...) RETURN 2` therefore skipped the
+//! mutation gate in `GraphDb::execute`, was dispatched through the read-only
+//! engine, and `execute_union` recursed into the non-transactional
+//! `mutation.rs::execute_create` — which writes against a `NodeStore` opened
+//! for that one read-only call and never durably persists. The statement
+//! returned `Ok` with the expected row count and zero nodes existed
+//! afterwards.
+//!
+//! The fix rejects `UNION` containing a mutating branch at bind time
+//! (`sparrowdb-cypher::binder::bind`), matching the Cypher spec (UNION is
+//! only defined over read queries) rather than trying to route the mutation
+//! through the write-transaction path. `Statement::is_mutation` was also
+//! promoted to a single method on `Statement` (`sparrowdb-cypher::ast`) so
+//! `Engine::is_mutation` and the binder's UNION check share one
+//! classification instead of two enumerations that can drift apart — which
+//! is exactly the shape of bug #478 was.
+//!
+//! The load-bearing assertion in every durability test here is **after
+//! reopening the database from a dropped handle** — querying the same handle
+//! that ran the mutation can pass even when nothing reached disk, which is
+//! how this bug hid in the first place.
+//!
+//! Every expected value below is derived by hand from the fixture the test
+//! itself builds, not recorded from the code's current output.
+
+use sparrowdb::GraphDb;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn open_db(dir: &std::path::Path) -> GraphDb {
+    GraphDb::open(dir).expect("open db")
+}
+
+/// Reopen `dir` as a fresh `GraphDb` handle and count `:Label` nodes via a
+/// plain read query. Used after `drop`-ing the handle that ran the mutation
+/// under test, so the count reflects only what is actually durable on disk.
+fn count_label_after_reopen(dir: &std::path::Path, label: &str) -> i64 {
+    let db = GraphDb::open(dir).expect("reopen db");
+    let result = db
+        .execute(&format!("MATCH (n:{label}) RETURN count(n)"))
+        .expect("count query must succeed");
+    match result.rows[0][0] {
+        sparrowdb_execution::Value::Int64(n) => n,
+        ref other => panic!("expected Int64 count, got {other:?}"),
+    }
+}
+
+// ── Test 1: UNION of two CREATEs must be rejected, not silently no-op ────────
+
+#[test]
+fn union_of_two_creates_is_rejected_not_silently_dropped() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    let result = db.execute(
+        "CREATE (:UnionA {x: 1}) RETURN 1 \
+         UNION \
+         CREATE (:UnionB {y: 2}) RETURN 2",
+    );
+
+    // The defect was: this returned Ok. The fix must make it an error rather
+    // than let it through to durably write nothing.
+    assert!(
+        result.is_err(),
+        "UNION of two CREATEs must be rejected at bind time, got Ok: {:?}",
+        result
+    );
+    let msg = format!("{:?}", result.unwrap_err());
+    assert!(
+        msg.contains("UNION") || msg.to_lowercase().contains("mutat"),
+        "error must explain the UNION/mutation restriction, got: {msg}"
+    );
+
+    drop(db);
+
+    // Zero nodes of either label may exist — not the "wrote nothing but
+    // reported success" shape and not a partial write either.
+    assert_eq!(
+        count_label_after_reopen(dir.path(), "UnionA"),
+        0,
+        "rejected UNION CREATE must not have created any UnionA node"
+    );
+    assert_eq!(
+        count_label_after_reopen(dir.path(), "UnionB"),
+        0,
+        "rejected UNION CREATE must not have created any UnionB node"
+    );
+}
+
+// ── Test 2: UNION mixing a CREATE with a plain MATCH must also be rejected ──
+
+#[test]
+fn union_mixing_create_and_match_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    db.execute("CREATE (:Existing {name: 'Alice'})").unwrap();
+
+    // Left side is a plain read; right side mutates. The mutating side must
+    // still be caught regardless of position.
+    let result = db.execute(
+        "MATCH (n:Existing) RETURN n.name \
+         UNION \
+         CREATE (:MixedCreate {z: 3}) RETURN 'created'",
+    );
+    assert!(
+        result.is_err(),
+        "UNION mixing MATCH with CREATE must be rejected, got Ok: {:?}",
+        result
+    );
+
+    // And the same with the mutation on the left.
+    let result2 = db.execute(
+        "CREATE (:MixedCreate2 {z: 4}) RETURN 'created' \
+         UNION \
+         MATCH (n:Existing) RETURN n.name",
+    );
+    assert!(
+        result2.is_err(),
+        "UNION mixing CREATE (left) with MATCH must be rejected, got Ok: {:?}",
+        result2
+    );
+
+    drop(db);
+
+    assert_eq!(
+        count_label_after_reopen(dir.path(), "MixedCreate"),
+        0,
+        "rejected UNION must not have created a MixedCreate node"
+    );
+    assert_eq!(
+        count_label_after_reopen(dir.path(), "MixedCreate2"),
+        0,
+        "rejected UNION must not have created a MixedCreate2 node"
+    );
+    // The pre-existing node from the plain CREATE above is untouched.
+    assert_eq!(
+        count_label_after_reopen(dir.path(), "Existing"),
+        1,
+        "the plain CREATE that ran before either UNION attempt must be unaffected"
+    );
+}
+
+// ── Test 3: UNION ALL of two CREATEs is rejected the same way ───────────────
+
+#[test]
+fn union_all_of_two_creates_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    let result = db.execute(
+        "CREATE (:UnionAllA {x: 1}) RETURN 1 \
+         UNION ALL \
+         CREATE (:UnionAllB {y: 2}) RETURN 2",
+    );
+    assert!(
+        result.is_err(),
+        "UNION ALL of two CREATEs must be rejected, got Ok: {:?}",
+        result
+    );
+
+    drop(db);
+
+    assert_eq!(
+        count_label_after_reopen(dir.path(), "UnionAllA"),
+        0,
+        "rejected UNION ALL CREATE must not have created any UnionAllA node"
+    );
+    assert_eq!(
+        count_label_after_reopen(dir.path(), "UnionAllB"),
+        0,
+        "rejected UNION ALL CREATE must not have created any UnionAllB node"
+    );
+}
+
+// ── Test 4: a purely read-only UNION must keep working exactly as before ────
+
+#[test]
+fn read_only_union_still_works() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    db.execute("CREATE (:Person {name: 'Alice', age: 30})")
+        .unwrap();
+    db.execute("CREATE (:Person {name: 'Bob', age: 25})")
+        .unwrap();
+    db.execute("CREATE (:Person {name: 'Carol', age: 35})")
+        .unwrap();
+
+    let result = db
+        .execute(
+            "MATCH (n:Person) WHERE n.age > 28 RETURN n.age \
+             UNION ALL \
+             MATCH (n:Person) WHERE n.age < 28 RETURN n.age",
+        )
+        .expect("read-only UNION ALL must still succeed after the #478 fix");
+
+    // Left: Alice(30), Carol(35) = 2 rows; Right: Bob(25) = 1 row → total 3.
+    assert_eq!(
+        result.rows.len(),
+        3,
+        "read-only UNION ALL must be unaffected by the mutation-rejection fix, got {:?}",
+        result.rows
+    );
+}
+
+// ── Test 5: MERGE (a different mutation shape) inside UNION is also rejected ─
+//
+// Unlike CREATE, a UNION-wrapped MERGE already failed before this fix — but
+// with an unrelated, confusing error ("mutation statements must be executed
+// via execute_mutation", from a leftover guard inside the read engine's
+// dispatch, since Merge was never wired into the read engine's match at all).
+// So this test is not a regression guard for the #478 *symptom* (MERGE never
+// silently no-opped), but it does confirm the new bind-time UNION check
+// covers MERGE too — with the correct, UNION-specific explanation — instead
+// of leaving that pre-existing, differently-broken error path in place.
+#[test]
+fn union_with_merge_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    let result = db.execute(
+        "MERGE (:MergedNode {k: 1}) RETURN 1 \
+         UNION \
+         MATCH (n:MergedNode) RETURN n.k",
+    );
+    assert!(
+        result.is_err(),
+        "UNION containing MERGE must be rejected like CREATE, got Ok: {:?}",
+        result
+    );
+    let msg = format!("{:?}", result.unwrap_err());
+    assert!(
+        msg.contains("UNION"),
+        "post-fix, MERGE-in-UNION must be rejected by the new UNION-specific \
+         check (not the old unrelated 'must be executed via execute_mutation' \
+         error), got: {msg}"
+    );
+
+    drop(db);
+
+    assert_eq!(
+        count_label_after_reopen(dir.path(), "MergedNode"),
+        0,
+        "rejected UNION MERGE must not have created any MergedNode node"
+    );
+}


### PR DESCRIPTION
## Summary

`Engine::is_mutation` enumerated `Merge`, `MatchMergeRel`, `MatchMutate`, `UnwindMatchMutate`, `MatchCreate`, `Create`, and recursive `CallSubquery` — but not `Statement::Union`, which fell through to `_ => false`. A query shaped `CREATE (...) RETURN 1 UNION CREATE (...) RETURN 2` skipped the mutation gate in `GraphDb::execute`, was dispatched through the read-only engine, and `execute_union` recursed into the non-transactional `mutation.rs::execute_create`. The statement returned `Ok` and **zero nodes existed on disk afterwards** — silent data loss.

## Direction chosen: reject, don't route

Cypher does not define `UNION` over mutating branches. Rather than adding `Union` to the mutation enumeration and routing it through the write-transaction path (a shape nobody asked for, and one that would need real thought about `WriteTx` semantics across two independently-executed branches), this rejects at **bind time**:

- `sparrowdb-cypher::binder::bind`'s `Statement::Union` arm now checks `u.left.is_mutation() || u.right.is_mutation()` and returns `Err(InvalidArgument(...))` before either side executes. Nesting (`UNION` of `UNION`s) is covered for free since `bind()` recurses into each side.
- `Statement::is_mutation` is promoted to a method on `Statement` itself (`sparrowdb-cypher::ast`) — the single source of truth. `Engine::is_mutation` now just delegates to it. This directly addresses the root cause: the enumeration living in two places (or getting extended ad hoc) is exactly the shape that goes stale, which is how `Union` got missed in the first place.

## Neighbourhood audit

Checked the full `Statement` variant list against `is_mutation`. Found one more real gap, filed separately rather than fixed here (out of scope per plan): **#500** — `Statement::Pipeline` isn't checked by `is_mutation` at all, and can carry a `PipelineStage::CallSubquery` whose inner statement is a mutation (`MATCH ... WITH ... CALL { CREATE ... } ... RETURN ...`). Confirmed this parses (`parse_call_subquery_stage` calls `parse_statement()` unrestricted) and executes via the same non-transactional `execute_read_stmt` path as this bug.

## `execute_create`'s non-atomicity

`mutation.rs::execute_create` writes the node via `create_node()` before the later FTS block with no rollback on failure — documented as non-transactional. This fix does **not** make that non-atomicity observable: `UNION`-with-`CREATE` is now rejected before `execute_create` is ever reached via that route, so the non-transactional read-path `CREATE` remains unreachable through `UNION`, not made durable. Not relying on that as a safety property — it's a separate latent issue in `mutation.rs`.

## Testing

New `crates/sparrowdb/tests/regression_478_union_create.rs`, e2e against a real `GraphDb` on `tempfile::TempDir`. Every durability assertion is **after `drop`-ing the handle and reopening** — querying the same handle can pass while nothing reached disk, which is how #478 hid.

- `union_of_two_creates_is_rejected_not_silently_dropped` — UNION of two CREATEs
- `union_mixing_create_and_match_is_rejected` — CREATE mixed with plain MATCH, both orderings
- `union_all_of_two_creates_is_rejected` — UNION ALL
- `read_only_union_still_works` — plain read UNION ALL is unaffected
- `union_with_merge_is_rejected` — MERGE (a different mutation shape) is also caught; note this one already errored pre-fix, just via an unrelated confusing message (see test docstring) — this fix replaces that with the correct UNION-specific explanation

All 4 mutation-rejection tests confirmed to **fail against the pre-fix commit** (`git stash` of the 3 source files, tests run against `origin/main`):
```
union_of_two_creates_is_rejected_not_silently_dropped ... FAILED
  "got Ok: Ok(QueryResult { columns: [], rows: [] })"
union_all_of_two_creates_is_rejected ... FAILED
  "got Ok: Ok(QueryResult { columns: [], rows: [] })"
union_mixing_create_and_match_is_rejected ... FAILED
  "got Ok: Ok(QueryResult { columns: [\"n.name\"], rows: [[String(\"Alice\")]] })"
union_with_merge_is_rejected ... FAILED
  "got: InvalidArgument(\"mutation statements must be executed via execute_mutation\")"
```
All 5 pass post-fix. Also ran the existing UNION, CREATE, MERGE, CallSubquery, batch-write, and parameterized-CREATE suites (~100 tests across `spa_132_union`, `call_subquery`, `match_after_create`, `merge_node`, `security_480_parameterized_create`, `spa_137/168/182/183/211/215/224/233/235_234/243/415`) — all pass, no regressions.

`cargo fmt` clean (no diff), `cargo clippy -p sparrowdb -p sparrowdb-execution -p sparrowdb-cypher --all-targets --keep-going` clean, `cargo check -p sparrowdb` clean.

## Could not verify

- Did not run the full workspace suite (`cargo test --workspace --exclude sparrowdb-ruby`) — the repo's own docs note it can exceed 60 minutes; ran targeted UNION/CREATE/MERGE/subquery suites instead (~100 tests, all green). A full run before merge would give broader confidence but wasn't done here.
- Did not independently verify #500 (the Pipeline gap) is otherwise unreachable in production usage — only confirmed it parses and takes the vulnerable code path; did not check whether any current caller composes pipelines with mutating `CALL {}` stages in practice.

## Test plan
- [x] New regression suite passes post-fix, fails pre-fix (quoted above)
- [x] Existing UNION/CREATE/MERGE/subquery suites pass with no regressions
- [x] `cargo fmt`, `cargo clippy`, `cargo check -p sparrowdb` clean

Closes #478. Filed #500 as a follow-up for the Pipeline gap found during the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE