### PR TITLE
fix(server): make mutation dispatch total, fixing bare CALL{} panic (closes #502)

### DIFF
--- a/crates/sparrowdb-cypher/src/ast.rs
+++ b/crates/sparrowdb-cypher/src/ast.rs
@@ -611,6 +611,16 @@ impl Statement {
     /// not define `UNION` over mutating branches, so the binder rejects a
     /// `UNION` with a mutating side at bind time (see `bind()` in
     /// `binder.rs`) rather than trying to route it through the write path.
+    ///
+    /// The `false` arm is intentionally exhaustive (no `_` wildcard): every
+    /// non-mutating variant is listed by name, matching the equally-exhaustive
+    /// mutation dispatch in `sparrowdb::GraphDb::dispatch_mutation`. Adding a
+    /// new `Statement` variant to the AST is therefore a compile error in
+    /// *both* places until it is deliberately classified in both — the two
+    /// silently drifting apart is exactly what produced issue #478 (`Union`
+    /// missing here) and issue #502 (`CallSubquery` classified `true` here
+    /// but missing its own arm in the dispatch, so it hit that match's old
+    /// `_ => unreachable!()` and panicked on ordinary user input).
     pub fn is_mutation(&self) -> bool {
         match self {
             Statement::Merge(_)
@@ -626,7 +636,21 @@ impl Statement {
             // the braces is routed through the write-transaction path rather than
             // being silently dispatched via the read path and failing late.
             Statement::CallSubquery { subquery, .. } => subquery.is_mutation(),
-            _ => false,
+            Statement::Match(_)
+            | Statement::MatchWith(_)
+            | Statement::Unwind(_)
+            | Statement::OptionalMatch(_)
+            | Statement::MatchOptionalMatch(_)
+            | Statement::Union(_)
+            | Statement::Checkpoint
+            | Statement::Optimize
+            | Statement::Call(_)
+            | Statement::Pipeline(_)
+            | Statement::CreateIndex { .. }
+            | Statement::CreateConstraint { .. }
+            | Statement::CreateFulltextIndex { .. }
+            | Statement::CreateVectorIndex { .. }
+            | Statement::DropIndex { .. } => false,
         }
     }
 }

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -554,17 +554,7 @@ impl GraphDb {
         }
 
         if Engine::is_mutation(&bound.inner) {
-            match bound.inner {
-                Statement::Merge(ref m) => self.execute_merge(m),
-                Statement::MatchMergeRel(ref mm) => self.execute_match_merge_rel(mm),
-                Statement::MatchMutate(ref mm) => self.execute_match_mutate(mm),
-                Statement::UnwindMatchMutate(ref umm) => self.execute_unwind_match_mutate(umm),
-                Statement::MatchCreate(ref mc) => self.execute_match_create(mc, None),
-                // Standalone CREATE with edges — must go through WriteTx so
-                // create_edge can register the rel type and write the WAL.
-                Statement::Create(ref c) => self.execute_create_standalone(c, None),
-                _ => unreachable!(),
-            }
+            self.dispatch_mutation(bound.inner, None, None)
         } else {
             let _span = info_span!("sparrowdb.query").entered();
 
@@ -641,15 +631,7 @@ impl GraphDb {
         if Engine::is_mutation(&bound.inner) {
             // Mutations don't use the read pipeline — fall through to the
             // standard mutation paths (write transactions are unaffected).
-            match bound.inner {
-                Statement::Merge(ref m) => self.execute_merge(m),
-                Statement::MatchMergeRel(ref mm) => self.execute_match_merge_rel(mm),
-                Statement::MatchMutate(ref mm) => self.execute_match_mutate(mm),
-                Statement::UnwindMatchMutate(ref umm) => self.execute_unwind_match_mutate(umm),
-                Statement::MatchCreate(ref mc) => self.execute_match_create(mc, None),
-                Statement::Create(ref c) => self.execute_create_standalone(c, None),
-                _ => unreachable!(),
-            }
+            self.dispatch_mutation(bound.inner, None, None)
         } else {
             let _span = info_span!("sparrowdb.query_chunked").entered();
 
@@ -756,18 +738,7 @@ impl GraphDb {
             // Thread the deadline into mutation code paths so that
             // MATCH…SET / MATCH…DELETE / MATCH…CREATE honour the caller's
             // timeout instead of running unbounded (fixes #310).
-            return match bound.inner {
-                Statement::Merge(ref m) => self.execute_merge(m),
-                Statement::MatchMutate(ref mm) => self.execute_match_mutate_deadline(mm, deadline),
-                Statement::UnwindMatchMutate(ref umm) => {
-                    self.execute_unwind_match_mutate_deadline(umm, deadline)
-                }
-                Statement::MatchCreate(ref mc) => {
-                    self.execute_match_create_deadline(mc, deadline, None)
-                }
-                Statement::Create(ref c) => self.execute_create_standalone(c, None),
-                _ => unreachable!(),
-            };
+            return self.dispatch_mutation(bound.inner, Some(deadline), None);
         }
 
         let _span = info_span!("sparrowdb.query_with_timeout").entered();
@@ -1261,26 +1232,11 @@ impl GraphDb {
         }
         if Engine::is_mutation(&bound.inner) {
             // Route mutations through params-aware helpers (SPA-218).
-            use sparrowdb_cypher::ast::Statement as Stmt;
-            return match bound.inner {
-                Stmt::Merge(ref m) => self.execute_merge_with_params(m, &params),
-                Stmt::MatchMutate(ref mm) => self.execute_match_mutate_with_params(mm, &params),
-                Stmt::UnwindMatchMutate(ref umm) => {
-                    self.execute_unwind_match_mutate_with_params(umm, &params)
-                }
-                // SPA-480 (S0): standalone CREATE and MATCH...CREATE now resolve
-                // $param property values via resolve_create_prop_value, closing
-                // the last Cypher-injection gap — a CREATE built from untrusted
-                // text no longer requires string interpolation.
-                Stmt::Create(ref c) => self.execute_create_standalone(c, Some(&params)),
-                Stmt::MatchCreate(ref mc) => self.execute_match_create(mc, Some(&params)),
-                _ => Err(Error::InvalidArgument(
-                    "execute_with_params: parameterized MATCH...MERGE relationship and CALL \
-                     subquery mutations are not yet supported; use MERGE, MATCH...SET, or \
-                     CREATE with $params"
-                        .into(),
-                )),
-            };
+            // SPA-480 (S0): standalone CREATE and MATCH...CREATE now resolve
+            // $param property values via resolve_create_prop_value, closing
+            // the last Cypher-injection gap — a CREATE built from untrusted
+            // text no longer requires string interpolation.
+            return self.dispatch_mutation(bound.inner, None, Some(&params));
         }
 
         let _span = info_span!("sparrowdb.query_with_params").entered();
@@ -1302,6 +1258,116 @@ impl GraphDb {
 
         tracing::debug!(rows = result.rows.len(), "query_with_params complete");
         Ok(result)
+    }
+
+    /// Route a statement already classified `Statement::is_mutation() == true`
+    /// to its transactional executor.
+    ///
+    /// This is the single dispatch point shared by [`Self::execute`],
+    /// [`Self::execute_chunked`], [`Self::execute_with_timeout`], and
+    /// [`Self::execute_with_params`] — each used to carry its own hand-written
+    /// copy of this match, and the copies had already drifted independently:
+    /// `execute_with_timeout`'s copy was missing the `MatchMergeRel` arm
+    /// entirely (a panic via the `_ => unreachable!()` fallthrough on any
+    /// `MATCH … MERGE (a)-[r:TYPE]->(b)` query run through it), and only
+    /// `execute_with_params`'s copy had already been hardened against a bare
+    /// `CALL { <mutation> }` (`Statement::CallSubquery`) with a real error
+    /// instead of `unreachable!()`. Both gaps are the same defect class as
+    /// issue #502 (a bare `CALL { CREATE (...) }` panicking at the old
+    /// `_ => unreachable!()` in `execute`/`execute_chunked`): `is_mutation()`
+    /// classifies a statement shape as a mutation, but nothing enforces that
+    /// every dispatch site that gates on it was updated to handle that shape.
+    /// `deadline` is `Some` only from `execute_with_timeout`; `params` is
+    /// `Some` only from `execute_with_params` — no caller currently supplies
+    /// both, and no combination here is invented that a caller didn't already
+    /// have before this refactor.
+    ///
+    /// The non-mutation arm below is intentionally exhaustive (no `_`
+    /// wildcard): every `Statement` variant that
+    /// [`sparrowdb_cypher::ast::Statement::is_mutation`] classifies as
+    /// non-mutating is listed by name. Adding a new `Statement` variant to
+    /// the AST is therefore a compile error in *both* that match and this one
+    /// until it is deliberately classified in both places — the two silently
+    /// drifting apart is exactly how #478 (`Union`) and #502 (`CallSubquery`)
+    /// happened.
+    fn dispatch_mutation(
+        &self,
+        stmt: sparrowdb_cypher::ast::Statement,
+        deadline: Option<std::time::Instant>,
+        params: Option<&HashMap<String, sparrowdb_execution::Value>>,
+    ) -> Result<QueryResult> {
+        use sparrowdb_cypher::ast::Statement;
+
+        match stmt {
+            Statement::Merge(ref m) => match params {
+                Some(p) => self.execute_merge_with_params(m, p),
+                None => self.execute_merge(m),
+            },
+            Statement::MatchMergeRel(ref mm) => match params {
+                Some(_) => Err(Error::InvalidArgument(
+                    "execute_with_params: parameterized MATCH...MERGE relationship \
+                     mutations are not yet supported; use MERGE, MATCH...SET, or \
+                     CREATE with $params"
+                        .into(),
+                )),
+                None => self.execute_match_merge_rel(mm),
+            },
+            Statement::MatchMutate(ref mm) => match (deadline, params) {
+                (Some(d), _) => self.execute_match_mutate_deadline(mm, d),
+                (None, Some(p)) => self.execute_match_mutate_with_params(mm, p),
+                (None, None) => self.execute_match_mutate(mm),
+            },
+            Statement::UnwindMatchMutate(ref umm) => match (deadline, params) {
+                (Some(d), _) => self.execute_unwind_match_mutate_deadline(umm, d),
+                (None, Some(p)) => self.execute_unwind_match_mutate_with_params(umm, p),
+                (None, None) => self.execute_unwind_match_mutate(umm),
+            },
+            Statement::MatchCreate(ref mc) => match deadline {
+                Some(d) => self.execute_match_create_deadline(mc, d, None),
+                None => self.execute_match_create(mc, params),
+            },
+            // Standalone CREATE with edges — must go through WriteTx so
+            // create_edge can register the rel type and write the WAL.
+            // No deadline-aware variant exists; a timeout-bounded caller gets
+            // the same (unbounded) behaviour it always has.
+            Statement::Create(ref c) => self.execute_create_standalone(c, params),
+            // CALL { } wrapping a mutation (`CALL { CREATE ... }`,
+            // `CALL { MERGE ... }`, etc.): no transactional executor exists
+            // yet for an arbitrary subquery body. Reject with the same
+            // explanation the read-path subquery guard already gives a
+            // mutating `CALL { }` body embedded in a pipeline stage (see
+            // `execute_read_stmt_with_bindings` in
+            // `sparrowdb-execution/src/engine/subquery.rs`) — issue #502 was
+            // this same shape reaching the old `_ => unreachable!()` instead.
+            Statement::CallSubquery { ref subquery, .. } => Err(Error::InvalidArgument(format!(
+                "CALL {{ }}: mutating statement kind not supported inside CALL {{ }}: {:?}",
+                std::mem::discriminant(subquery.as_ref())
+            ))),
+            // Every remaining variant is classified `is_mutation() == false`
+            // and must never reach this function — every caller gates on
+            // `Engine::is_mutation` before calling `dispatch_mutation`. If
+            // this branch is ever hit, `Statement::is_mutation` and this
+            // match have drifted out of sync with each other.
+            other @ (Statement::Match(_)
+            | Statement::MatchWith(_)
+            | Statement::Unwind(_)
+            | Statement::OptionalMatch(_)
+            | Statement::MatchOptionalMatch(_)
+            | Statement::Union(_)
+            | Statement::Checkpoint
+            | Statement::Optimize
+            | Statement::Call(_)
+            | Statement::Pipeline(_)
+            | Statement::CreateIndex { .. }
+            | Statement::CreateConstraint { .. }
+            | Statement::CreateFulltextIndex { .. }
+            | Statement::CreateVectorIndex { .. }
+            | Statement::DropIndex { .. }) => unreachable!(
+                "dispatch_mutation called with a non-mutating statement {:?} — \
+                 Statement::is_mutation() and dispatch_mutation() have drifted out of sync",
+                std::mem::discriminant(&other)
+            ),
+        }
     }
 
     /// Internal: execute a MERGE statement by opening a write transaction.
@@ -3052,7 +3118,20 @@ impl GraphDb {
                 Ok(QueryResult::empty(vec![]))
             }
 
-            _ => Err(Error::Unimplemented),
+            // CALL { } wrapping a mutation inside a batched statement: same
+            // restriction, and same message, as the non-batch path in
+            // `dispatch_mutation` (issue #502).
+            Statement::CallSubquery { ref subquery, .. } => Err(Error::InvalidArgument(format!(
+                "CALL {{ }}: mutating statement kind not supported inside CALL {{ }}: {:?}",
+                std::mem::discriminant(subquery.as_ref())
+            ))),
+            // Every remaining variant is non-mutating and must never reach
+            // this function — `execute_batch` only calls it when
+            // `Engine::is_mutation` is true for the statement.
+            other => Err(Error::InvalidArgument(format!(
+                "execute_batch_mutation called with a non-mutating statement kind: {:?}",
+                std::mem::discriminant(&other)
+            ))),
         }
     }
 

--- a/crates/sparrowdb/tests/regression_502_call_subquery_mutation_dispatch.rs
+++ b/crates/sparrowdb/tests/regression_502_call_subquery_mutation_dispatch.rs
@@ -1,0 +1,251 @@
+//! Regression guards for issue #502 — a bare top-level `CALL { <mutation> }`
+//! statement panicked instead of erroring or executing.
+//!
+//! Found while independently verifying the #478 fix. `Statement::is_mutation`
+//! classifies `Statement::CallSubquery { subquery, .. }` as a mutation
+//! whenever its inner `subquery` is itself a mutation (recursively), so
+//! `GraphDb::execute`'s `if Engine::is_mutation(&bound.inner) { … }` branch
+//! was entered for a bare `CALL { CREATE (:M1 {z:1}) }`. But the match inside
+//! that branch had explicit arms only for `Merge`, `MatchMergeRel`,
+//! `MatchMutate`, `UnwindMatchMutate`, `MatchCreate`, and `Create` — no arm
+//! for `CallSubquery` — and fell through to `_ => unreachable!()`, which is
+//! reachable on ordinary user input and panics the calling thread.
+//!
+//! Same defect class as #478 (classification says "route to the write path"
+//! but the write path was never actually wired up for that shape), just one
+//! level removed: #478 was a *read*-path gap (reports success, writes
+//! nothing), #502 is a *write*-dispatch gap (never reports anything, panics).
+//!
+//! Independently, `execute_with_timeout`'s copy of this same match was
+//! missing the `MatchMergeRel` arm entirely — a second, unrelated instance of
+//! the identical defect class, found while fixing this one. Both are fixed by
+//! replacing the three independently-drifting copies of this match
+//! (`execute`, `execute_chunked`, `execute_with_timeout`) — plus hardening
+//! `execute_with_params`'s and `execute_batch_mutation`'s pre-existing (but
+//! differently worded) guards — with a single shared `GraphDb::dispatch_mutation`
+//! whose non-mutation fallback arm is exhaustively listed (no `_` wildcard),
+//! so a variant `Statement::is_mutation` classifies as `true` without a
+//! matching arm here is a compile error, not a runtime panic.
+//!
+//! A panic crosses the test-harness thread boundary as a `thread '...' panicked`
+//! message plus the test being marked FAILED; `std::panic::catch_unwind` (with
+//! the panic hook silenced so the pre-fix runs below don't spam stderr) lets
+//! us assert "did not panic" without abort-on-panic settings.
+//!
+//! Every expected value below is derived by hand from the fixture the test
+//! itself builds, not recorded from the code's current output.
+
+use sparrowdb::GraphDb;
+use std::panic::{self, AssertUnwindSafe};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn open_db(dir: &std::path::Path) -> GraphDb {
+    GraphDb::open(dir).expect("open db")
+}
+
+/// Reopen `dir` as a fresh `GraphDb` handle and count `:Label` nodes via a
+/// plain read query. Used after `drop`-ing the handle under test, so the
+/// count reflects only what is actually durable on disk.
+fn count_label_after_reopen(dir: &std::path::Path, label: &str) -> i64 {
+    let db = GraphDb::open(dir).expect("reopen db");
+    let result = db
+        .execute(&format!("MATCH (n:{label}) RETURN count(n)"))
+        .expect("count query must succeed");
+    match result.rows[0][0] {
+        sparrowdb_execution::Value::Int64(n) => n,
+        ref other => panic!("expected Int64 count, got {other:?}"),
+    }
+}
+
+/// Run `f` with the default panic hook silenced, so a pre-fix panic in these
+/// tests doesn't print a `thread '...' panicked at ...` backtrace to stderr
+/// on every run — we still observe and assert on whether it panicked via the
+/// returned `Result`.
+fn run_catching_panic<F, T>(f: F) -> std::thread::Result<T>
+where
+    F: FnOnce() -> T,
+{
+    let prev_hook = panic::take_hook();
+    panic::set_hook(Box::new(|_info| {}));
+    let result = panic::catch_unwind(AssertUnwindSafe(f));
+    panic::set_hook(prev_hook);
+    result
+}
+
+// ── Test 1: bare top-level CALL { CREATE ... } must not panic ────────────────
+
+#[test]
+fn bare_call_subquery_create_does_not_panic() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    let outcome = run_catching_panic(|| db.execute("CALL { CREATE (:M1 {z: 1}) }"));
+
+    assert!(
+        outcome.is_ok(),
+        "bare CALL {{ CREATE ... }} must not panic the calling thread (issue #502)"
+    );
+    let result = outcome.unwrap();
+    assert!(
+        result.is_err(),
+        "bare CALL {{ CREATE ... }} has no transactional executor yet — it must \
+         error cleanly, not silently succeed while writing nothing (the #478 shape), \
+         got: {:?}",
+        result
+    );
+    let msg = format!("{:?}", result.unwrap_err());
+    assert!(
+        msg.contains("CALL") && msg.to_lowercase().contains("mutat"),
+        "error must explain that CALL {{ }} cannot wrap a mutation, got: {msg}"
+    );
+
+    drop(db);
+
+    assert_eq!(
+        count_label_after_reopen(dir.path(), "M1"),
+        0,
+        "rejected CALL {{ CREATE }} must not have durably created any M1 node"
+    );
+}
+
+// ── Test 2: bare top-level CALL { MERGE ... } — a different mutation shape ──
+
+#[test]
+fn bare_call_subquery_merge_does_not_panic() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    let outcome = run_catching_panic(|| db.execute("CALL { MERGE (:M3 {z: 3}) }"));
+
+    assert!(
+        outcome.is_ok(),
+        "bare CALL {{ MERGE ... }} must not panic the calling thread"
+    );
+    let result = outcome.unwrap();
+    assert!(
+        result.is_err(),
+        "bare CALL {{ MERGE ... }} must error cleanly like CALL {{ CREATE ... }}, got: {:?}",
+        result
+    );
+
+    drop(db);
+
+    assert_eq!(
+        count_label_after_reopen(dir.path(), "M3"),
+        0,
+        "rejected CALL {{ MERGE }} must not have durably created any M3 node"
+    );
+}
+
+// ── Test 3: the same rejection, and the same message, via every entry point ──
+//
+// Before this fix, `execute`/`execute_chunked`/`execute_with_timeout` each
+// carried an independently drifting copy of the mutation dispatch: the first
+// two panicked on this exact input, `execute_with_timeout` also panicked (via
+// its own copy's `_ => unreachable!()`), and `execute_with_params` alone had
+// already been hardened — but with different wording ("parameterized
+// MATCH...MERGE relationship and CALL subquery mutations are not yet
+// supported"). All four now share one dispatch function and must answer
+// identically.
+
+#[test]
+fn call_subquery_create_rejected_consistently_across_entry_points() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    let cypher = "CALL { CREATE (:M4 {z: 4}) }";
+
+    let via_execute = db.execute(cypher);
+    let via_chunked = db.execute_chunked(cypher);
+    let via_timeout = db.execute_with_timeout(cypher, std::time::Duration::from_secs(5));
+    let via_params = db.execute_with_params(cypher, std::collections::HashMap::new());
+
+    for (name, result) in [
+        ("execute", &via_execute),
+        ("execute_chunked", &via_chunked),
+        ("execute_with_timeout", &via_timeout),
+        ("execute_with_params", &via_params),
+    ] {
+        assert!(
+            result.is_err(),
+            "{name}: CALL {{ CREATE ... }} must be rejected, got Ok: {:?}",
+            result
+        );
+    }
+
+    // Same wording from every entry point — not four different explanations
+    // for the same restriction.
+    let msg_execute = format!("{:?}", via_execute.unwrap_err());
+    let msg_chunked = format!("{:?}", via_chunked.unwrap_err());
+    let msg_timeout = format!("{:?}", via_timeout.unwrap_err());
+    let msg_params = format!("{:?}", via_params.unwrap_err());
+    assert_eq!(
+        msg_execute, msg_chunked,
+        "execute and execute_chunked must give the identical error for the identical input"
+    );
+    assert_eq!(
+        msg_execute, msg_timeout,
+        "execute and execute_with_timeout must give the identical error for the identical input"
+    );
+    assert_eq!(
+        msg_execute, msg_params,
+        "execute and execute_with_params must give the identical error for the identical input"
+    );
+
+    drop(db);
+
+    assert_eq!(
+        count_label_after_reopen(dir.path(), "M4"),
+        0,
+        "none of the four rejected calls may have durably created an M4 node"
+    );
+}
+
+// ── Test 4: MatchMergeRel through execute_with_timeout — found while fixing #502 ─
+//
+// `execute_with_timeout`'s pre-fix match had arms for Merge, MatchMutate,
+// UnwindMatchMutate, MatchCreate, and Create, but not MatchMergeRel — a
+// second, independent instance of the same "is_mutation says yes, dispatch
+// has no arm" defect, unrelated to CALL { }. `MATCH ... MERGE (a)-[r:T]->(b)`
+// run through execute_with_timeout hit that same `_ => unreachable!()`.
+
+#[test]
+fn match_merge_rel_through_execute_with_timeout_does_not_panic() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    db.execute("CREATE (:P5 {name: 'A'})").unwrap();
+    db.execute("CREATE (:P5 {name: 'B'})").unwrap();
+
+    // MATCH ... MERGE (a)-[r:TYPE]->(b) does not accept a trailing RETURN
+    // clause (confirmed against spa_233_merge_relationship.rs's usage).
+    let cypher = "MATCH (a:P5 {name: 'A'}), (b:P5 {name: 'B'}) MERGE (a)-[r:LINKED5]->(b)";
+    let outcome =
+        run_catching_panic(|| db.execute_with_timeout(cypher, std::time::Duration::from_secs(5)));
+
+    assert!(
+        outcome.is_ok(),
+        "MATCH ... MERGE relationship through execute_with_timeout must not panic"
+    );
+    let result = outcome.unwrap();
+    assert!(
+        result.is_ok(),
+        "MATCH ... MERGE relationship through execute_with_timeout must succeed \
+         (it already worked through plain execute()), got: {:?}",
+        result
+    );
+
+    drop(db);
+
+    // Hand-derived: MERGE creates exactly one LINKED5 edge A->B.
+    let db2 = GraphDb::open(dir.path()).expect("reopen db");
+    let check = db2
+        .execute("MATCH (:P5 {name: 'A'})-[:LINKED5]->(:P5 {name: 'B'}) RETURN count(*)")
+        .expect("count query must succeed");
+    assert_eq!(
+        check.rows[0][0],
+        sparrowdb_execution::Value::Int64(1),
+        "exactly one LINKED5 edge must have been durably created"
+    );
+}


### PR DESCRIPTION
## Summary

Stacked on #501 — this branches from `fix/issue-478-union-create` because it uses the `Statement::is_mutation` single-source-of-truth method introduced there. Please merge #501 first (or merge this into it and let it ride along).

A bare top-level `CALL { CREATE (:M1 {z:1}) }` panicked:

```
thread '...' panicked at crates/sparrowdb/src/db.rs:566:22:
internal error: entered unreachable code
```

`Statement::is_mutation` correctly classifies a `CallSubquery` wrapping a mutation as a mutation — so `GraphDb::execute` correctly *avoids* the read-path bug (#478's shape: report success, write nothing). But its own mutation-dispatch match had explicit arms only for `Merge`, `MatchMergeRel`, `MatchMutate`, `UnwindMatchMutate`, `MatchCreate`, `Create` — no arm for `CallSubquery` — and fell through to `_ => unreachable!()`, which is reachable on ordinary user input.

Exact same defect class as #478: classification says "route to the write path," but nothing enforced that the write-path dispatch actually has a matching arm.

## What I found while verifying this

`execute`, `execute_chunked`, and `execute_with_timeout` each carried their own **hand-written copy** of this dispatch match. They had already drifted apart independently of this issue:

- `execute_with_timeout`'s copy was separately missing the `MatchMergeRel` arm entirely — a **second, unrelated instance** of the identical defect class (any `MATCH ... MERGE (a)-[r:TYPE]->(b)` run through `execute_with_timeout` also panicked at the same `unreachable!()`).
- `execute_with_params`'s copy alone had already been hardened against a bare `CALL { <mutation> }` — but with different wording ("parameterized MATCH...MERGE relationship and CALL subquery mutations are not yet supported") than the other three would need for consistency.
- `execute_batch_mutation` (used by `execute_batch`) already had a non-panicking `_ => Err(Error::Unimplemented)` catch-all, but with a generic, unhelpful message.

Three of five dispatch sites panicked, one had a different message, one had a vague message — five independently-maintained copies of the same match, already disagreeing with each other before I touched anything.

## Fix

1. **One dispatch point.** Replaced the three drifting inline matches (`execute`, `execute_chunked`, `execute_with_timeout`) with calls to a single new `GraphDb::dispatch_mutation(stmt, deadline, params)`, and routed `execute_with_params` through it too (preserving its exact prior behavior for every existing combination). `execute_batch_mutation` keeps its own match (different execution mode — a shared `&mut WriteTx` across a batch of statements — not a clean fit for the same function) but now gives the same message for the `CallSubquery` case.
2. **Exhaustive, not `_ => unreachable!()`.** `dispatch_mutation`'s non-mutation fallback arm lists every `Statement` variant that `Statement::is_mutation()` classifies `false` by name — no wildcard. Paired with making `Statement::is_mutation` in `sparrowdb-cypher::ast` equally exhaustive (also no wildcard, from #501's work). **Adding a new `Statement` variant to the AST is now a compile error in both places** until it's deliberately classified in both — this is the "retire the whole class" version, not just a patch for `CallSubquery`.
3. **Consistent answer.** A bare `CALL { <mutation> }` now returns the identical `InvalidArgument` message from all four entry points (`execute`, `execute_chunked`, `execute_with_timeout`, `execute_with_params`), matching the wording the read-path subquery guard (`subquery.rs::execute_read_stmt_with_bindings`) already uses for a mutating `CALL { }` embedded in a pipeline stage.

No transactional executor for arbitrary `CALL { }` subquery bodies exists yet, so this does not attempt to make `CALL { CREATE ... }` actually work — it rejects cleanly instead of panicking or silently writing nothing.

## Testing

New `crates/sparrowdb/tests/regression_502_call_subquery_mutation_dispatch.rs`, e2e against a real `GraphDb`, durability assertions after reopen (same pattern as #501).

- `bare_call_subquery_create_does_not_panic` — `CALL { CREATE ... }` at top level
- `bare_call_subquery_merge_does_not_panic` — `CALL { MERGE ... }`, a different mutation shape
- `call_subquery_create_rejected_consistently_across_entry_points` — same input through all 4 entry points, asserts identical error message
- `match_merge_rel_through_execute_with_timeout_does_not_panic` — the independently-found `MatchMergeRel`-via-`execute_with_timeout` gap, with a durability check that the edge is actually created (since this one *should* succeed, not just avoid panicking)

**All 4 confirmed to fail against the pre-#502-fix commit** (`git stash` of just the #502 diff, keeping #501's fix applied), with the actual panic captured via `std::panic::catch_unwind` + a silenced panic hook:

```
thread 'bare_call_subquery_create_does_not_panic' panicked at .../regression_502_....rs:85:5:
bare CALL { CREATE ... } must not panic the calling thread (issue #502)

thread 'bare_call_subquery_merge_does_not_panic' panicked at crates/sparrowdb/src/db.rs:566:22:
internal error: entered unreachable code
thread 'bare_call_subquery_merge_does_not_panic' panicked at .../regression_502_....rs:121:5:
bare CALL { MERGE ... } must not panic the calling thread

thread 'match_merge_rel_through_execute_with_timeout_does_not_panic' panicked at .../regression_502_....rs:227:5:
MATCH ... MERGE relationship through execute_with_timeout must not panic

test result: FAILED. 0 passed; 4 failed
```

All 4 pass post-fix. Also re-ran the full UNION/CREATE/MERGE/CallSubquery/batch/timeout/parameterized-CREATE neighbourhood (~110 tests: `spa_132_union`, `call_subquery`, `match_after_create`, `merge_node`, `regression_478_union_create`, `security_480_parameterized_create`, `spa_137/168/182/183/211/215/224/233/235_234/243/415`, `regression_483`, `spa_250_batch_write`, `spa_254_query_timeout`) — all pass, no regressions.

`cargo fmt` clean, `cargo clippy -p sparrowdb -p sparrowdb-execution -p sparrowdb-cypher --all-targets --keep-going` clean, `cargo check -p sparrowdb` clean.

## Could not verify

- Did not run the full workspace suite (can exceed 60 min per repo docs) — ran the targeted neighbourhood above instead.
- Did not audit every other call site in `db.rs`/`sparrowdb-execution` for a third independently-drifted copy of a similar dispatch match beyond the 5 I found and checked (`execute`, `execute_chunked`, `execute_with_timeout`, `execute_with_params`, `execute_batch_mutation`) — these were found by grepping for `is_mutation` call sites, which should be exhaustive for this specific pattern, but I did not do a broader search for structurally similar (but differently-named) dispatch matches elsewhere.
- `dispatch_mutation`'s doc comment states no caller currently passes both `deadline: Some` and `params: Some` — true today (verified by reading all 4 call sites), but nothing prevents a future caller from doing so; that combination silently prefers `deadline` for `MatchMutate`/`UnwindMatchMutate` and silently drops `params` for `MatchCreate`. Not a live bug, flagging as a latent footgun if a 5th caller is ever added.

## Test plan
- [x] New regression suite passes post-fix, fails pre-fix (panic output quoted above)
- [x] Existing UNION/CREATE/MERGE/CallSubquery/batch/timeout suites pass with no regressions
- [x] `cargo fmt`, `cargo clippy`, `cargo check -p sparrowdb` clean

Closes #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE