### PR TITLE
fix(engine): reject null/non-scalar property values instead of coercing to Int64(0)

### DIFF
--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -1646,32 +1646,53 @@ fn collect_col_ids_from_expr(expr: &Expr, out: &mut Vec<u32>) {
 ///
 /// Integers are stored as `Int64`; strings are stored as `Bytes` (up to 8 bytes
 /// inline, matching the storage layer's encoding in `Value::to_u64`).
+///
+/// Exhaustive on purpose (see [`value_to_store_value`] below, which this
+/// mirrors for the bare-literal case): `Null` and `Param` used to share a
+/// catch-all with every other unhandled variant that produced
+/// `StoreValue::Int64(0)`, indistinguishable on read from a genuinely stored
+/// zero (#473/#475). Currently unreachable in production — kept exhaustive
+/// so it cannot silently regress if it is ever wired up.
 #[allow(dead_code)]
-fn literal_to_store_value(lit: &Literal) -> StoreValue {
+fn literal_to_store_value(lit: &Literal) -> Result<StoreValue> {
     match lit {
-        Literal::Int(n) => StoreValue::Int64(*n),
-        Literal::String(s) => StoreValue::Bytes(s.as_bytes().to_vec()),
-        Literal::Float(f) => StoreValue::Float(*f),
-        Literal::Bool(b) => StoreValue::Int64(if *b { 1 } else { 0 }),
-        Literal::Null | Literal::Param(_) => StoreValue::Int64(0),
+        Literal::Int(n) => Ok(StoreValue::Int64(*n)),
+        Literal::String(s) => Ok(StoreValue::Bytes(s.as_bytes().to_vec())),
+        Literal::Float(f) => Ok(StoreValue::Float(*f)),
+        Literal::Bool(b) => Ok(StoreValue::Int64(if *b { 1 } else { 0 })),
+        Literal::Null => Err(sparrowdb_common::Error::InvalidArgument(
+            "property value is null; use a concrete value".into(),
+        )),
+        Literal::Param(p) => Err(sparrowdb_common::Error::InvalidArgument(format!(
+            "property value references parameter ${p}; use GraphDb::execute_with_params \
+             to bind runtime parameters"
+        ))),
     }
 }
 
 /// Convert an evaluated `Value` to the `StoreValue` used by the node store.
 ///
 /// Used when a node property value is an arbitrary expression (e.g.
-/// `datetime()`), rather than a bare literal.
-fn value_to_store_value(val: Value) -> StoreValue {
+/// `datetime()`), rather than a bare literal. `key` is the property name,
+/// used only to name the offending property in the error message.
+///
+/// Exhaustive over every `Value` variant on purpose: adding a new variant to
+/// that enum must be a compile error here, not a silent fall-through. The
+/// match used to end with several arms mapped to `StoreValue::Int64(0)` —
+/// `Null`, `List`, `Map`, and `Vector` all had no scalar representation and
+/// were coerced anyway, a value indistinguishable on read from a genuinely
+/// stored zero (#473). None of those four (nor `NodeRef`/`EdgeRef`, which
+/// also have no meaningful property representation) can be written silently
+/// anymore — each is rejected with a message naming the offending kind.
+fn value_to_store_value(key: &str, val: Value) -> Result<StoreValue> {
     match val {
-        Value::Int64(n) => StoreValue::Int64(n),
-        Value::Float64(f) => StoreValue::Float(f),
-        Value::Bool(b) => StoreValue::Int64(if b { 1 } else { 0 }),
-        Value::String(s) => StoreValue::Bytes(s.into_bytes()),
-        Value::Null => StoreValue::Int64(0),
-        Value::NodeRef(id) => StoreValue::Int64(id.0 as i64),
-        Value::EdgeRef(id) => StoreValue::Int64(id.0 as i64),
-        Value::List(_) => StoreValue::Int64(0),
-        Value::Map(_) => StoreValue::Int64(0),
+        Value::Int64(n) => Ok(StoreValue::Int64(n)),
+        Value::Float64(f) => Ok(StoreValue::Float(f)),
+        Value::Bool(b) => Ok(StoreValue::Int64(if b { 1 } else { 0 })),
+        Value::String(s) => Ok(StoreValue::Bytes(s.into_bytes())),
+        Value::Null => Err(sparrowdb_common::Error::InvalidArgument(format!(
+            "CREATE property '{key}' is null; use a concrete value"
+        ))),
         // Vector values are managed exclusively by the HNSW vector-index
         // write-path in GraphDb (db.rs), which inserts them directly into the
         // in-memory index and persists the index snapshot to disk.  A vector
@@ -1680,13 +1701,30 @@ fn value_to_store_value(val: Value) -> StoreValue {
         //
         // In practice, vector properties reach GraphDb via $params on the
         // MERGE path, not through the AST literal path that calls this
-        // function.  If a vector value reaches here it is a programming error;
-        // we return a null sentinel (0) rather than panicking so a production
-        // write path does not crash, but the vector data will not be indexed.
-        //
-        // TODO(#394): change the signature to Result<StoreValue> and return
-        // Err(InvalidArgument) here once all callers can propagate errors.
-        Value::Vector(_) => StoreValue::Int64(0),
+        // function. If a vector value reaches here it is a programming error;
+        // we now reject it explicitly (TODO(#394) asked for exactly this)
+        // instead of silently returning a null sentinel that let a production
+        // write path "succeed" while the vector data went unindexed.
+        Value::NodeRef(_) => Err(sparrowdb_common::Error::InvalidArgument(format!(
+            "CREATE property '{key}' is a node reference, which has no scalar storage \
+             representation and cannot be written as a property value"
+        ))),
+        Value::EdgeRef(_) => Err(sparrowdb_common::Error::InvalidArgument(format!(
+            "CREATE property '{key}' is an edge reference, which has no scalar storage \
+             representation and cannot be written as a property value"
+        ))),
+        Value::List(_) => Err(sparrowdb_common::Error::InvalidArgument(format!(
+            "CREATE property '{key}' is a list, which has no scalar storage representation \
+             and cannot be written as a property value"
+        ))),
+        Value::Map(_) => Err(sparrowdb_common::Error::InvalidArgument(format!(
+            "CREATE property '{key}' is a map, which has no scalar storage representation \
+             and cannot be written as a property value"
+        ))),
+        Value::Vector(_) => Err(sparrowdb_common::Error::InvalidArgument(format!(
+            "CREATE property '{key}' is a vector, which has no scalar storage representation \
+             and cannot be written as a property value"
+        ))),
     }
 }
 

--- a/crates/sparrowdb-execution/src/engine/mutation.rs
+++ b/crates/sparrowdb-execution/src/engine/mutation.rs
@@ -872,10 +872,10 @@ impl Engine {
                 .map(|entry| {
                     let col_id = prop_name_to_col_id(&entry.key);
                     let val = eval_expr(&entry.value, &empty_bindings);
-                    let store_val = value_to_store_value(val);
-                    (col_id, store_val)
+                    let store_val = value_to_store_value(&entry.key, val)?;
+                    Ok((col_id, store_val))
                 })
-                .collect();
+                .collect::<Result<Vec<_>>>()?;
 
             // SPA-234: enforce UNIQUE constraints declared via
             // `CREATE CONSTRAINT ON (n:Label) ASSERT n.property IS UNIQUE`.

--- a/crates/sparrowdb-execution/tests/regression_473_engine_execute_create_null.rs
+++ b/crates/sparrowdb-execution/tests/regression_473_engine_execute_create_null.rs
@@ -1,0 +1,75 @@
+//! Regression test for #473 at the level it actually lives: `value_to_store_value`
+//! (`crates/sparrowdb-execution/src/engine/mod.rs`), reached via
+//! `Engine::execute_create` (`engine/mutation.rs`) when `Engine::execute_statement`
+//! is called with a `Statement::Create` directly.
+//!
+//! `GraphDb::execute()` / `execute_with_params()` never reach this function for a
+//! standalone `CREATE` — both intercept `Statement::Create` earlier and call
+//! `execute_create_standalone`, which was already fixed by PR #492
+//! (`resolve_create_prop_value`). `execute_batch_mutation`'s `Statement::Create`
+//! arm (also `sparrowdb/src/db.rs`) is now fixed too (see
+//! `regression_475_473_null_coercion.rs`) and never reaches this function either.
+//! So #473's own text — "currently only reachable via execute_create's
+//! empty-bindings path... exposure today is narrow" — is confirmed here: this
+//! test exercises the Engine directly, the way `sparrowdb-execution`'s other
+//! engine-level tests do (see `regression_421_varlen_plus_hop.rs`), because no
+//! path through the public `GraphDb` API reaches it.
+//!
+//! Pre-fix: `value_to_store_value(val)` mapped `Value::Null` (and
+//! `List`/`Map`/`Vector`/`NodeRef`/`EdgeRef`) to `StoreValue::Int64(0)`.
+//! Post-fix: `value_to_store_value(key, val)` returns
+//! `Err(InvalidArgument)` for all of those, naming the property key and the
+//! offending kind.
+
+use sparrowdb_catalog::catalog::Catalog;
+use sparrowdb_execution::Engine;
+use sparrowdb_storage::node_store::NodeStore;
+
+fn build_engine() -> (tempfile::TempDir, Engine) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().to_path_buf();
+    let store = NodeStore::open(&path).expect("node store");
+    let cat = Catalog::open(&path).expect("catalog");
+    let engine = Engine::new(store, cat, std::collections::HashMap::new(), &path);
+    (dir, engine)
+}
+
+/// A literal `null` property value reaching `Engine::execute_create` directly
+/// (bypassing `GraphDb`, which never routes a standalone CREATE here) must be
+/// rejected, not silently written as `StoreValue::Int64(0)`.
+#[test]
+fn engine_execute_create_null_property_rejected() {
+    let (_dir, mut engine) = build_engine();
+
+    let stmt = sparrowdb_cypher::parse("CREATE (:Item {v: null})").expect("parse");
+    let err = engine
+        .execute_statement(stmt)
+        .expect_err("Engine::execute_create with a null property must be rejected");
+    let msg = err.to_string();
+    assert!(msg.contains("null"), "error '{msg}' should mention null");
+    assert!(
+        msg.contains('v'),
+        "error '{msg}' should name the offending property 'v'"
+    );
+}
+
+/// Control: a genuine literal `0` through the same direct-Engine path must
+/// still round-trip, proving the fix rejects only the unrepresentable
+/// variants and not real zeros.
+#[test]
+fn engine_execute_create_genuine_zero_round_trips() {
+    let (_dir, mut engine) = build_engine();
+
+    let stmt = sparrowdb_cypher::parse("CREATE (:Item {v: 0})").expect("parse");
+    engine
+        .execute_statement(stmt)
+        .expect("Engine::execute_create with a literal 0 must succeed");
+
+    let stmt = sparrowdb_cypher::parse("MATCH (n:Item) RETURN n.v").expect("parse");
+    let result = engine.execute_statement(stmt).expect("MATCH");
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(
+        result.rows[0][0],
+        sparrowdb_execution::types::Value::Int64(0)
+    );
+}

--- a/crates/sparrowdb/src/batch.rs
+++ b/crates/sparrowdb/src/batch.rs
@@ -34,7 +34,18 @@ pub(crate) fn pending_candidates_for(
             // All pattern props must match a corresponding pending prop.
             let all_match = node_props.iter().all(|pe| {
                 let wanted_col = col_id_of(&pe.key);
-                let wanted_val = expr_to_value(&pe.value);
+                // A pattern value with no scalar storage representation (e.g. an
+                // explicit `null` literal) can never equal a pending node's
+                // stored value — treat it as "no match" rather than coercing to
+                // a sentinel that could wrongly equal a real stored value (the
+                // #475/#473 failure mode). This is a MATCH-filter comparison,
+                // not a write, so it intentionally does not propagate an error;
+                // null used as a filter value has its own broader defect
+                // tracked separately by #467.
+                let wanted_val = match expr_to_value(&pe.value) {
+                    Ok(v) => v,
+                    Err(_) => return false,
+                };
                 op_props
                     .iter()
                     .any(|&(c, ref v)| c == wanted_col && *v == wanted_val)

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -8,9 +8,9 @@ use crate::batch::augment_rows_with_pending;
 use crate::helpers::{
     build_label_row_counts_from_disk, collect_maintenance_params, dir_size_bytes, eval_expr_merge,
     exec_value_to_storage, expr_to_value, expr_to_value_with_params, fnv1a_col_id,
-    is_edge_delete_mutation, is_reserved_label, literal_to_value, load_constraints,
-    load_vector_indexes, open_csr_map, resolve_create_prop_value, save_constraints,
-    storage_value_to_exec, try_open_csr_map, VectorIndexHealth,
+    is_edge_delete_mutation, is_reserved_label, load_constraints, load_vector_indexes,
+    open_csr_map, resolve_create_prop_value, save_constraints, storage_value_to_exec,
+    try_open_csr_map, VectorIndexHealth,
 };
 use crate::read_tx::ReadTx;
 use crate::types::{DbInner, NodeVersions, PendingOp, VersionStore, WriteBuffer, WriteGuard};
@@ -1309,8 +1309,8 @@ impl GraphDb {
         let props: HashMap<String, Value> = m
             .props
             .iter()
-            .map(|pe| (pe.key.clone(), expr_to_value(&pe.value)))
-            .collect();
+            .map(|pe| Ok((pe.key.clone(), expr_to_value(&pe.value)?)))
+            .collect::<Result<_>>()?;
         let mut tx = self.begin_write()?;
         // Detect create vs match by observing whether merge_node dirtied a new node.
         let dirty_before = tx.dirty_nodes.len();
@@ -1325,7 +1325,7 @@ impl GraphDb {
         };
         for mutation in on_set_items {
             if let sparrowdb_cypher::ast::Mutation::Set { prop, value, .. } = mutation {
-                let sv = expr_to_value(value);
+                let sv = expr_to_value(value)?;
                 tx.set_property(node_id, prop, sv)?;
             }
         }
@@ -1408,15 +1408,55 @@ impl GraphDb {
         Ok(QueryResult::empty(vec![]))
     }
 
+    /// True when `value` is a `$param` reference bound to `Value::Vector` for
+    /// a property that has a registered HNSW vector index.
+    ///
+    /// A vector has no property-column representation — `exec_value_to_storage`
+    /// rejects it (#475/#473) — but a vector `$param` on a genuinely indexed
+    /// property is a real, tested feature (#410): it is written to the HNSW
+    /// index by a dedicated block, not the property column. Callers use this
+    /// to skip the column write for exactly that one case, so the value
+    /// resolver's rejection only fires for a vector with nowhere to go (no
+    /// index registered for this property at all), not for the indexed case
+    /// this whole write-path exists to support.
+    fn set_value_is_indexed_vector_param(
+        &self,
+        value: &sparrowdb_cypher::ast::Expr,
+        prop: &str,
+        params: &HashMap<String, sparrowdb_execution::Value>,
+    ) -> bool {
+        use sparrowdb_cypher::ast::{Expr, Literal};
+        let Expr::Literal(Literal::Param(p)) = value else {
+            return false;
+        };
+        let Some(v) = params.get(p.as_str()) else {
+            return false;
+        };
+        if v.as_vector().is_none() {
+            return false;
+        }
+        self.inner
+            .vector_indexes
+            .read()
+            .expect("vector_indexes")
+            .keys()
+            .any(|(_, prop_name)| prop_name == prop)
+    }
+
     /// Params-aware MERGE with $param support (SPA-218).
     fn execute_merge_with_params(
         &self,
         m: &sparrowdb_cypher::ast::MergeStatement,
         params: &HashMap<String, sparrowdb_execution::Value>,
     ) -> Result<QueryResult> {
+        // A vector `$param` bound to an indexed property is written to the
+        // HNSW index by the block below, not the merge-key/property columns
+        // — see `set_value_is_indexed_vector_param`. Excluded from `props`
+        // here rather than resolved to a storage `Value`.
         let props: HashMap<String, Value> = m
             .props
             .iter()
+            .filter(|pe| !self.set_value_is_indexed_vector_param(&pe.value, &pe.key, params))
             .map(|pe| {
                 let val = expr_to_value_with_params(&pe.value, params)?;
                 Ok((pe.key.clone(), val))
@@ -1436,6 +1476,9 @@ impl GraphDb {
         };
         for mutation in on_set_items {
             if let sparrowdb_cypher::ast::Mutation::Set { prop, value, .. } = mutation {
+                if self.set_value_is_indexed_vector_param(value, prop, params) {
+                    continue;
+                }
                 let sv = expr_to_value_with_params(value, params)?;
                 tx.set_property(node_id, prop, sv)?;
             }
@@ -1558,6 +1601,13 @@ impl GraphDb {
         for mutation in &mm.mutations {
             match mutation {
                 sparrowdb_cypher::ast::Mutation::Set { prop, value, .. } => {
+                    // A vector `$param` bound to an indexed property has no
+                    // property-column representation — it is written to the
+                    // HNSW index by the dedicated block below instead. Skip
+                    // the column write for this one mutation.
+                    if self.set_value_is_indexed_vector_param(value, prop, params) {
+                        continue;
+                    }
                     let sv = expr_to_value_with_params(value, params)?;
                     for node_id in &matching_ids {
                         tx.set_property(*node_id, prop, sv.clone())?;
@@ -1707,7 +1757,7 @@ impl GraphDb {
             sparrowdb_cypher::ast::Expr::List(items) => items
                 .iter()
                 .map(|e| {
-                    let sv = expr_to_value(e);
+                    let sv = expr_to_value(e)?;
                     Ok(storage_value_to_exec(&sv))
                 })
                 .collect::<Result<Vec<_>>>()?,
@@ -1731,7 +1781,7 @@ impl GraphDb {
             sparrowdb_cypher::ast::Expr::List(items) => items
                 .iter()
                 .map(|e| {
-                    let sv = expr_to_value(e);
+                    let sv = expr_to_value(e)?;
                     Ok(storage_value_to_exec(&sv))
                 })
                 .collect::<Result<Vec<_>>>()?,
@@ -1830,9 +1880,18 @@ impl GraphDb {
             for mutation in &umm.mutations {
                 match mutation {
                     sparrowdb_cypher::ast::Mutation::Set { prop, value, .. } => {
-                        let sv = resolve_set_value(value, &umm.alias, row, params)?;
-                        for node_id in &matching_ids {
-                            tx.set_property(*node_id, prop, sv.clone())?;
+                        // Same skip as `execute_match_mutate_with_params`: a
+                        // vector `$param` bound to an indexed property is
+                        // handled entirely by the accumulation block below
+                        // and must not go through the column-value resolver.
+                        let is_indexed_vector = params
+                            .map(|p| self.set_value_is_indexed_vector_param(value, prop, p))
+                            .unwrap_or(false);
+                        if !is_indexed_vector {
+                            let sv = resolve_set_value(value, &umm.alias, row, params)?;
+                            for node_id in &matching_ids {
+                                tx.set_property(*node_id, prop, sv.clone())?;
+                            }
                         }
 
                         // Vector index write-path — the same maintenance
@@ -1997,7 +2056,7 @@ impl GraphDb {
         for mutation in &mm.mutations {
             match mutation {
                 sparrowdb_cypher::ast::Mutation::Set { prop, value, .. } => {
-                    let sv = expr_to_value(value);
+                    let sv = expr_to_value(value)?;
                     for node_id in &matching_ids {
                         tx.set_property(*node_id, prop, sv.clone())?;
                     }
@@ -2067,7 +2126,7 @@ impl GraphDb {
         for mutation in &mm.mutations {
             match mutation {
                 sparrowdb_cypher::ast::Mutation::Set { prop, value, .. } => {
-                    let sv = expr_to_value(value);
+                    let sv = expr_to_value(value)?;
                     for node_id in &matching_ids {
                         Self::check_deadline(deadline)?;
                         tx.set_property(*node_id, prop, sv.clone())?;
@@ -2806,31 +2865,14 @@ impl GraphDb {
                 for node in &c.nodes {
                     let label = node.labels.first().cloned().unwrap_or_default();
                     let label_id: u32 = tx.get_or_create_label_id(&label)?;
+                    // Delegate to the shared CREATE-prop resolver (params=None: batch
+                    // execution is non-parameterized) rather than a hand-rolled
+                    // Null/Param check — this used to duplicate that logic here.
                     let named_props: Vec<(String, Value)> = node
                         .props
                         .iter()
                         .map(|entry| {
-                            let val = match &entry.value {
-                                sparrowdb_cypher::ast::Expr::Literal(
-                                    sparrowdb_cypher::ast::Literal::Null,
-                                ) => Err(sparrowdb_common::Error::InvalidArgument(format!(
-                                    "CREATE property '{}' is null",
-                                    entry.key
-                                ))),
-                                sparrowdb_cypher::ast::Expr::Literal(
-                                    sparrowdb_cypher::ast::Literal::Param(p),
-                                ) => Err(sparrowdb_common::Error::InvalidArgument(format!(
-                                    "CREATE property '{}' references parameter ${p}",
-                                    entry.key
-                                ))),
-                                sparrowdb_cypher::ast::Expr::Literal(lit) => {
-                                    Ok(literal_to_value(lit))
-                                }
-                                _ => Err(sparrowdb_common::Error::InvalidArgument(format!(
-                                    "CREATE property '{}' must be a literal",
-                                    entry.key
-                                ))),
-                            }?;
+                            let val = resolve_create_prop_value(&entry.key, &entry.value, None)?;
                             Ok((entry.key.clone(), val))
                         })
                         .collect::<Result<Vec<_>>>()?;
@@ -2859,8 +2901,8 @@ impl GraphDb {
                 let props: HashMap<String, Value> = m
                     .props
                     .iter()
-                    .map(|pe| (pe.key.clone(), expr_to_value(&pe.value)))
-                    .collect();
+                    .map(|pe| Ok((pe.key.clone(), expr_to_value(&pe.value)?)))
+                    .collect::<Result<_>>()?;
                 let dirty_before = tx.dirty_nodes.len();
                 let node_id = tx.merge_node(&m.label, props)?;
                 let was_created = tx.dirty_nodes.len() > dirty_before;
@@ -2871,7 +2913,7 @@ impl GraphDb {
                 };
                 for mutation in on_set_items {
                     if let sparrowdb_cypher::ast::Mutation::Set { prop, value, .. } = mutation {
-                        let sv = expr_to_value(value);
+                        let sv = expr_to_value(value)?;
                         tx.set_property(node_id, prop, sv)?;
                     }
                 }
@@ -2898,7 +2940,7 @@ impl GraphDb {
                     for mutation in &mm.mutations {
                         match mutation {
                             sparrowdb_cypher::ast::Mutation::Set { prop, value, .. } => {
-                                let sv = expr_to_value(value);
+                                let sv = expr_to_value(value)?;
                                 for node_id in &matching_ids {
                                     tx.set_property(*node_id, prop, sv.clone())?;
                                 }
@@ -3474,7 +3516,7 @@ fn resolve_set_value(
         if var == alias {
             for (key, val) in row {
                 if key == prop {
-                    return Ok(exec_value_to_storage(val));
+                    return exec_value_to_storage(val);
                 }
             }
         }
@@ -3482,7 +3524,7 @@ fn resolve_set_value(
     // Fall back: use params-aware evaluation when available, otherwise literal-only.
     match params {
         Some(p) => expr_to_value_with_params(value, p),
-        None => Ok(expr_to_value(value)),
+        None => expr_to_value(value),
     }
 }
 

--- a/crates/sparrowdb/src/helpers.rs
+++ b/crates/sparrowdb/src/helpers.rs
@@ -52,25 +52,47 @@ pub fn cypher_escape_string(s: &str) -> String {
 // ── Mutation value helpers ─────────────────────────────────────────────────────
 
 /// Convert a Cypher [`Literal`] to a storage [`Value`].
-pub(crate) fn literal_to_value(lit: &sparrowdb_cypher::ast::Literal) -> Value {
+///
+/// Returns `Err` for `null` and for an unbound `$param` reference (fixes
+/// #475/#473's underlying habit): both used to fall into a catch-all that
+/// silently wrote `Value::Int64(0)`, a value indistinguishable on read from a
+/// genuine stored zero. A literal `null` has never had a defined write
+/// semantic here, so it is rejected rather than given a new meaning; a
+/// `$param` with no bound value is a caller error and must surface as one.
+pub(crate) fn literal_to_value(lit: &sparrowdb_cypher::ast::Literal) -> crate::Result<Value> {
     use sparrowdb_cypher::ast::Literal;
     match lit {
-        Literal::Int(n) => Value::Int64(*n),
+        Literal::Int(n) => Ok(Value::Int64(*n)),
         // Float stored as Value::Float — NodeStore::encode_value writes the full
         // 8 IEEE-754 bytes to the overflow heap (SPA-267).
-        Literal::Float(f) => Value::Float(*f),
-        Literal::Bool(b) => Value::Int64(if *b { 1 } else { 0 }),
-        Literal::String(s) => Value::Bytes(s.as_bytes().to_vec()),
-        Literal::Null | Literal::Param(_) => Value::Int64(0),
+        Literal::Float(f) => Ok(Value::Float(*f)),
+        Literal::Bool(b) => Ok(Value::Int64(if *b { 1 } else { 0 })),
+        Literal::String(s) => Ok(Value::Bytes(s.as_bytes().to_vec())),
+        Literal::Null => Err(Error::InvalidArgument(
+            "property value is null; use a concrete value".into(),
+        )),
+        Literal::Param(p) => Err(Error::InvalidArgument(format!(
+            "property value references parameter ${p}; use GraphDb::execute_with_params \
+             to bind runtime parameters"
+        ))),
     }
 }
 
 /// Convert a Cypher [`Expr`] to a storage [`Value`].
-pub(crate) fn expr_to_value(expr: &sparrowdb_cypher::ast::Expr) -> Value {
+///
+/// Only literal expressions have a defined storage representation; anything
+/// else (a bare variable, a property access, an unsupported function call, …)
+/// previously fell into a catch-all that silently wrote `Value::Int64(0)`.
+/// That is rejected now for the same reason `literal_to_value` rejects
+/// `null` — an unrepresentable value must error, not become a value that
+/// means something else.
+pub(crate) fn expr_to_value(expr: &sparrowdb_cypher::ast::Expr) -> crate::Result<Value> {
     use sparrowdb_cypher::ast::Expr;
     match expr {
         Expr::Literal(lit) => literal_to_value(lit),
-        _ => Value::Int64(0),
+        _ => Err(Error::InvalidArgument(
+            "property value must be a literal or $parameter".into(),
+        )),
     }
 }
 
@@ -84,9 +106,11 @@ pub(crate) fn literal_to_value_with_params(
         Literal::Float(f) => Ok(Value::Float(*f)),
         Literal::Bool(b) => Ok(Value::Int64(if *b { 1 } else { 0 })),
         Literal::String(s) => Ok(Value::Bytes(s.as_bytes().to_vec())),
-        Literal::Null => Ok(Value::Int64(0)),
+        Literal::Null => Err(Error::InvalidArgument(
+            "property value is null; use a concrete value".into(),
+        )),
         Literal::Param(p) => match params.get(p.as_str()) {
-            Some(v) => Ok(exec_value_to_storage(v)),
+            Some(v) => exec_value_to_storage(v),
             None => Err(sparrowdb_common::Error::InvalidArgument(format!(
                 "parameter ${p} was referenced in the query but not supplied"
             ))),
@@ -122,20 +146,24 @@ pub(crate) fn expr_to_value_with_params(
 /// * `$param` is resolved from `params` when supplied. When `params` is
 ///   `None` (the plain, non-parameterized `execute()` / `execute_with_timeout()`
 ///   paths), a `$param` reference is rejected with a clear error instead of
-///   silently written as `Value::Int64(0)` — the failure mode
-///   `exec_value_to_storage`'s catch-all is prone to (#475); this resolver
-///   never delegates to it.
+///   silently written as `Value::Int64(0)`.
 /// * A resolved parameter value must be a storage scalar (int, float, bool,
 ///   string). `List` / `Map` / `Vector` / `NodeRef` / `EdgeRef` have no
 ///   representation in a property column and are rejected rather than
 ///   silently coerced to `0`.
+///
+///   This used to duplicate `exec_value_to_storage`'s per-variant match by
+///   hand, specifically because that function's catch-all silently produced
+///   `Value::Int64(0)` for exactly these cases (#475) and could not be
+///   trusted. Now that `exec_value_to_storage` itself rejects them, this
+///   resolver delegates to it and only adds CREATE-specific error context —
+///   the duplication is gone.
 pub(crate) fn resolve_create_prop_value(
     key: &str,
     expr: &sparrowdb_cypher::ast::Expr,
     params: Option<&HashMap<String, sparrowdb_execution::Value>>,
 ) -> crate::Result<Value> {
     use sparrowdb_cypher::ast::{Expr, Literal};
-    use sparrowdb_execution::Value as EV;
 
     match expr {
         Expr::Literal(Literal::Null) => Err(Error::InvalidArgument(format!(
@@ -152,23 +180,14 @@ pub(crate) fn resolve_create_prop_value(
                 None => Err(Error::InvalidArgument(format!(
                     "parameter ${p} was referenced in the query but not supplied"
                 ))),
-                Some(EV::Null) => Err(Error::InvalidArgument(format!(
-                    "CREATE property '{key}' is bound to parameter ${p}, which is null; \
-                     use a concrete value"
-                ))),
-                Some(EV::Int64(n)) => Ok(Value::Int64(*n)),
-                Some(EV::Float64(f)) => Ok(Value::Float(*f)),
-                Some(EV::Bool(b)) => Ok(Value::Int64(if *b { 1 } else { 0 })),
-                Some(EV::String(s)) => Ok(Value::Bytes(s.as_bytes().to_vec())),
-                Some(other) => Err(Error::InvalidArgument(format!(
-                    "CREATE property '{key}' is bound to parameter ${p}, whose value ({other:?}) \
-                     is a {} and cannot be stored as a scalar property; only int, float, bool, \
-                     and string parameters may be used in CREATE",
-                    exec_value_kind(other),
-                ))),
+                Some(v) => exec_value_to_storage(v).map_err(|e| {
+                    Error::InvalidArgument(format!(
+                        "CREATE property '{key}' is bound to parameter ${p}: {e}"
+                    ))
+                }),
             }
         }
-        Expr::Literal(lit) => Ok(literal_to_value(lit)),
+        Expr::Literal(lit) => literal_to_value(lit),
         _ => Err(Error::InvalidArgument(format!(
             "CREATE property '{key}' must be a literal value or $parameter"
         ))),
@@ -191,14 +210,32 @@ fn exec_value_kind(v: &sparrowdb_execution::Value) -> &'static str {
     }
 }
 
-pub(crate) fn exec_value_to_storage(v: &sparrowdb_execution::Value) -> Value {
+/// Convert a bound `$param` value to a storage [`Value`].
+///
+/// Exhaustive over every [`sparrowdb_execution::Value`] variant on purpose:
+/// adding a new variant to that enum must be a compile error here, not a
+/// silent fall-through. The match used to end `_ => Value::Int64(0)`, which
+/// swallowed `Null`, `List`, `Map`, `Vector`, `NodeRef`, and `EdgeRef` alike
+/// (#475) — indistinguishable on read from a genuinely stored zero. None of
+/// those six have a scalar storage representation, so each is now rejected
+/// with a message naming the offending kind.
+pub(crate) fn exec_value_to_storage(v: &sparrowdb_execution::Value) -> crate::Result<Value> {
     use sparrowdb_execution::Value as EV;
     match v {
-        EV::Int64(n) => Value::Int64(*n),
-        EV::Float64(f) => Value::Float(*f),
-        EV::Bool(b) => Value::Int64(if *b { 1 } else { 0 }),
-        EV::String(s) => Value::Bytes(s.as_bytes().to_vec()),
-        _ => Value::Int64(0),
+        EV::Int64(n) => Ok(Value::Int64(*n)),
+        EV::Float64(f) => Ok(Value::Float(*f)),
+        EV::Bool(b) => Ok(Value::Int64(if *b { 1 } else { 0 })),
+        EV::String(s) => Ok(Value::Bytes(s.as_bytes().to_vec())),
+        EV::Null => Err(Error::InvalidArgument(
+            "property value is null; use a concrete value".into(),
+        )),
+        EV::NodeRef(_) | EV::EdgeRef(_) | EV::List(_) | EV::Map(_) | EV::Vector(_) => {
+            Err(Error::InvalidArgument(format!(
+                "property value is a {}, which has no scalar storage representation \
+                 and cannot be written as a property value",
+                exec_value_kind(v),
+            )))
+        }
     }
 }
 

--- a/crates/sparrowdb/tests/regression_475_473_null_coercion.rs
+++ b/crates/sparrowdb/tests/regression_475_473_null_coercion.rs
@@ -1,0 +1,366 @@
+//! Regression tests for #475 and #473: a null (or other non-scalar) property
+//! value silently written as `Int64(0)` instead of being rejected.
+//!
+//! ```rust,ignore
+//! db.execute("CREATE (:Item {id: 'a', v: 7})")?;
+//! let mut p = HashMap::new();
+//! p.insert("nv".to_string(), Value::Null);
+//! db.execute_with_params("MATCH (n:Item {id: 'a'}) SET n.v = $nv", p)?;
+//! // MATCH (n:Item) RETURN n.id, n.v  ->  [["a", Int64(0)]]  (pre-fix)
+//! ```
+//!
+//! `0` is a legal stored value, so a coerced null was indistinguishable on
+//! read from a genuine stored zero: no error, no way to detect which rows
+//! were silently corrupted, and the original value gone for good.
+//!
+//! ## Chosen semantic: reject, don't coerce and don't silently remove
+//!
+//! `SET n.prop = null` and `CREATE (n {prop: null})` both return
+//! `Err(InvalidArgument)` rather than either (a) writing `0` or (b) treating
+//! null as "remove the property". Removal was considered and rejected for
+//! this fix: the storage layer has no primitive to delete a single property
+//! column for an existing node (`upsert_node_col`/`set_null_bit` only ever
+//! mark a column present, never clear it back to absent), so "null removes
+//! the property" would require a new WAL-able storage operation, a
+//! `WriteTx` enum change, and edits to every one of the ~8 `Mutation::Set`
+//! match arms in `db.rs` — a real feature, not a bug fix, and out of scope
+//! here. Rejecting is also consistent with the CREATE-path precedent PR
+//! #492 already established (`resolve_create_prop_value`): "one null
+//! convention for this call site, not two, rather than inventing 'null
+//! means omit the property'". `List` / `Map` / `Vector` / `NodeRef` /
+//! `EdgeRef` property values are rejected the same way — none of them has a
+//! scalar storage representation either.
+//!
+//! ## Blast radius fixed here
+//!
+//! The catch-all-to-`Int64(0)` pattern existed in six functions, not just
+//! the two named in the issues:
+//! - `exec_value_to_storage` (#475's named function, helpers.rs)
+//! - `value_to_store_value` (#473's named function, sparrowdb-execution)
+//! - `literal_to_store_value` (same crate, dead code, same pattern)
+//! - `literal_to_value` / `expr_to_value` (helpers.rs) — reachable via the
+//!   *non-parameterized* `SET`/`MERGE` paths, a sibling of #475 that
+//!   neither issue's repro exercises (`SET n.v = null` with no `$param`
+//!   at all). Left unfixed, this would have been the same bug reachable
+//!   through a one-token-simpler query.
+//! - `literal_to_value_with_params` (helpers.rs)
+//!
+//! `resolve_create_prop_value`'s `$param` branch used to hand-duplicate
+//! `exec_value_to_storage`'s match specifically because that function's
+//! catch-all could not be trusted. Now that it can, the duplication is
+//! gone — see `helpers.rs`.
+
+use sparrowdb::{open, GraphDb};
+use sparrowdb_execution::types::Value;
+use std::collections::HashMap;
+
+fn make_db() -> (tempfile::TempDir, GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+fn params(pairs: &[(&str, Value)]) -> HashMap<String, Value> {
+    pairs
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.clone()))
+        .collect()
+}
+
+fn item_v(db: &GraphDb, id: &str) -> Value {
+    let rows = db
+        .execute(&format!("MATCH (n:Item {{id: '{id}'}}) RETURN n.v"))
+        .expect("MATCH")
+        .rows;
+    assert_eq!(rows.len(), 1, "exactly one Item with id='{id}'");
+    rows[0][0].clone()
+}
+
+// ── #475: SET n.v = $param(null) ───────────────────────────────────────────
+
+/// The exact reproduction from the issue. Pre-fix: `db.execute_with_params`
+/// returns `Ok`, and the value is silently `Int64(0)` — the caller never
+/// supplied a zero, and the original `7` is gone. Post-fix: the write is
+/// rejected and `v` is still `7`, derived by hand from the CREATE statement
+/// above, not captured from a prior run.
+#[test]
+fn set_null_via_param_rejected_old_value_preserved() {
+    let (_dir, db) = make_db();
+    db.execute("CREATE (:Item {id: 'a', v: 7})").unwrap();
+
+    let err = db
+        .execute_with_params(
+            "MATCH (n:Item {id: 'a'}) SET n.v = $nv",
+            params(&[("nv", Value::Null)]),
+        )
+        .expect_err("SET n.v = $nv (null) must be rejected, not coerced to 0");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("null"),
+        "error '{msg}' should mention the value is null"
+    );
+
+    assert_eq!(
+        item_v(&db, "a"),
+        Value::Int64(7),
+        "the pre-existing value must survive a rejected null SET, not become 0"
+    );
+}
+
+/// Sibling of the above that neither #475 nor #473 named: a *literal* null
+/// with no `$param` involved at all reaches a completely different function
+/// (`literal_to_value`, not `exec_value_to_storage`) but had the exact same
+/// catch-all-to-0 defect.
+#[test]
+fn set_null_literal_no_params_rejected_old_value_preserved() {
+    let (_dir, db) = make_db();
+    db.execute("CREATE (:Item {id: 'a', v: 7})").unwrap();
+
+    let err = db
+        .execute("MATCH (n:Item {id: 'a'}) SET n.v = null")
+        .expect_err("SET n.v = null (literal, no params) must be rejected, not coerced to 0");
+    assert!(err.to_string().contains("null"));
+
+    assert_eq!(
+        item_v(&db, "a"),
+        Value::Int64(7),
+        "the pre-existing value must survive a rejected literal-null SET"
+    );
+}
+
+// ── #475 sibling: non-scalar $param values on SET ──────────────────────────
+
+#[test]
+fn set_list_param_rejected_old_value_preserved() {
+    let (_dir, db) = make_db();
+    db.execute("CREATE (:Item {id: 'a', v: 7})").unwrap();
+
+    let err = db
+        .execute_with_params(
+            "MATCH (n:Item {id: 'a'}) SET n.v = $nv",
+            params(&[("nv", Value::List(vec![Value::Int64(1), Value::Int64(2)]))]),
+        )
+        .expect_err("SET n.v = $nv (list) must be rejected, not coerced to 0");
+    assert!(err.to_string().contains("list"), "error: {err}");
+    assert_eq!(item_v(&db, "a"), Value::Int64(7));
+}
+
+#[test]
+fn set_map_param_rejected_old_value_preserved() {
+    let (_dir, db) = make_db();
+    db.execute("CREATE (:Item {id: 'a', v: 7})").unwrap();
+
+    let err = db
+        .execute_with_params(
+            "MATCH (n:Item {id: 'a'}) SET n.v = $nv",
+            params(&[("nv", Value::Map(vec![("k".to_string(), Value::Int64(1))]))]),
+        )
+        .expect_err("SET n.v = $nv (map) must be rejected, not coerced to 0");
+    assert!(err.to_string().contains("map"), "error: {err}");
+    assert_eq!(item_v(&db, "a"), Value::Int64(7));
+}
+
+/// A vector `$param` written onto a plain (non-HNSW-indexed) property has no
+/// storage representation either — it must error, not become `0` and
+/// silently discard the vector data.
+#[test]
+fn set_vector_param_onto_plain_property_rejected() {
+    let (_dir, db) = make_db();
+    db.execute("CREATE (:Item {id: 'a', v: 7})").unwrap();
+
+    let err = db
+        .execute_with_params(
+            "MATCH (n:Item {id: 'a'}) SET n.v = $nv",
+            params(&[("nv", Value::Vector(vec![0.1, 0.2, 0.3]))]),
+        )
+        .expect_err("SET n.v = $nv (vector, non-indexed prop) must be rejected, not coerced to 0");
+    assert!(err.to_string().contains("vector"), "error: {err}");
+    assert_eq!(item_v(&db, "a"), Value::Int64(7));
+}
+
+// ── #473: CREATE with a null property ───────────────────────────────────────
+
+/// `execute_create_standalone` (used by plain `db.execute`) already rejected
+/// a literal null pre-fix (PR #492's `resolve_create_prop_value`) — this is
+/// the pre-existing, still-correct behavior, re-asserted here as a control
+/// so a future change to this file can tell "still works" from "newly
+/// fixed" apart. See `create_batch_null_literal_rejected` below for the
+/// arm that #473's fix actually touches.
+#[test]
+fn create_standalone_literal_null_rejected_no_node_created() {
+    let (_dir, db) = make_db();
+    let err = db
+        .execute("CREATE (:Item {id: 'a', v: null})")
+        .expect_err("CREATE with a literal null property must be rejected");
+    assert!(err.to_string().contains("null"), "error: {err}");
+
+    let rows = db.execute("MATCH (n:Item) RETURN n.id").unwrap().rows;
+    assert_eq!(rows.len(), 0, "no partial node may be left behind");
+}
+
+/// #473's exact named function (`value_to_store_value` /
+/// `crates/sparrowdb-execution/src/engine/mod.rs`) is reached via
+/// `execute_batch_mutation`'s `Statement::Create` arm — this used to
+/// hand-roll its own Null/Param rejection (already correct) but delegate to
+/// the then-unsafe `literal_to_value` catch-all for every other literal.
+/// This test exercises that arm directly via `execute_batch`, and doubles
+/// as confirmation that simplifying it to call `resolve_create_prop_value`
+/// (removing the duplicated hand-rolled check) didn't change behavior.
+#[test]
+fn create_batch_null_literal_rejected() {
+    let (_dir, db) = make_db();
+    let result = db.execute_batch(&["CREATE (:Item {id: 'a', v: null})"]);
+    let err = result.expect_err("batch CREATE with null property must be rejected");
+    assert!(err.to_string().contains("null"), "error: {err}");
+
+    let rows = db.execute("MATCH (n:Item) RETURN n.id").unwrap().rows;
+    assert_eq!(rows.len(), 0, "no partial node may be left behind");
+}
+
+#[test]
+fn create_batch_param_reference_rejected_batch_is_non_parameterized() {
+    let (_dir, db) = make_db();
+    let result = db.execute_batch(&["CREATE (:Item {id: 'a', v: $nv})"]);
+    let err = result.expect_err("batch CREATE cannot resolve $param — batch is non-parameterized");
+    assert!(
+        err.to_string().contains("execute_with_params") || err.to_string().contains("parameter"),
+        "error: {err}"
+    );
+}
+
+// ── MERGE: literal null in the merge-key props and in ON CREATE/MATCH SET ──
+
+#[test]
+fn merge_key_prop_null_rejected() {
+    let (_dir, db) = make_db();
+    let err = db
+        .execute("MERGE (n:Item {id: 'a', v: null})")
+        .expect_err("MERGE with a null key property must be rejected, not coerced to 0");
+    assert!(err.to_string().contains("null"), "error: {err}");
+
+    let rows = db.execute("MATCH (n:Item) RETURN n.id").unwrap().rows;
+    assert_eq!(rows.len(), 0, "no partial node may be left behind");
+}
+
+#[test]
+fn merge_on_create_set_null_rejected_no_node_left_behind() {
+    let (_dir, db) = make_db();
+    let err = db
+        .execute("MERGE (n:Item {id: 'a'}) ON CREATE SET n.v = null")
+        .expect_err("MERGE ... ON CREATE SET n.v = null must be rejected, not coerced to 0");
+    assert!(err.to_string().contains("null"), "error: {err}");
+}
+
+// ── UNWIND ... MATCH ... SET: a null element in the list literal ───────────
+
+/// `x` itself is never a valid `SET` right-hand side in this dialect (a bare
+/// variable reference isn't a literal or `$param`, and is rejected on that
+/// basis regardless of its value), so `DELETE` — which has no value
+/// expression at all — is used here to isolate the list-literal-build step
+/// (`db.rs`'s `expr_to_value(e)` over each `UNWIND [...]` item) from that
+/// unrelated, pre-existing restriction. The mutation never runs: list
+/// construction must fail before any row is scanned.
+#[test]
+fn unwind_list_literal_null_item_rejected_during_list_construction() {
+    let (_dir, db) = make_db();
+    db.execute("CREATE (:Item {id: 'a', v: 7})").unwrap();
+
+    let err = db
+        .execute("UNWIND [null] AS x MATCH (n:Item {id: 'a'}) DELETE n")
+        .expect_err("UNWIND list literal containing null must be rejected, not coerced to 0");
+    assert!(err.to_string().contains("null"), "error: {err}");
+
+    let rows = db.execute("MATCH (n:Item) RETURN n.id").unwrap().rows;
+    assert_eq!(
+        rows.len(),
+        1,
+        "the node must survive: list construction must fail before the DELETE ever scans a row"
+    );
+}
+
+// ── Durability: the rejection must not leave a partial write on disk ───────
+
+#[test]
+fn rejected_null_set_does_not_persist_across_checkpoint_and_reopen() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("test.sparrow");
+
+    {
+        let db = GraphDb::open(&db_path).expect("open session 1");
+        db.execute("CREATE (:Item {id: 'a', v: 7})").unwrap();
+
+        db.execute_with_params(
+            "MATCH (n:Item {id: 'a'}) SET n.v = $nv",
+            params(&[("nv", Value::Null)]),
+        )
+        .expect_err("null SET must be rejected");
+
+        db.checkpoint().expect("checkpoint");
+    }
+
+    {
+        let db = GraphDb::open(&db_path).expect("open session 2 (reopen)");
+        assert_eq!(
+            item_v(&db, "a"),
+            Value::Int64(7),
+            "a rejected null SET must not have persisted a 0 across checkpoint + reopen"
+        );
+    }
+}
+
+// ── Control: a genuine zero is unaffected by this fix ──────────────────────
+
+/// Proves the fix didn't overcorrect: an intentional `0` — via literal SET,
+/// via `$param` SET, and via CREATE — must still round-trip as `Int64(0)`,
+/// including after a checkpoint + reopen. Expected values derived by hand:
+/// this test creates the fixture and asserts on it, it does not assert
+/// whatever `db.execute` currently happens to return.
+#[test]
+fn genuine_zero_round_trips_across_all_paths_and_reopen() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("test.sparrow");
+
+    {
+        let db = GraphDb::open(&db_path).expect("open session 1");
+        // CREATE with a literal 0.
+        db.execute("CREATE (:Item {id: 'lit', v: 0})").unwrap();
+        // CREATE with a $param 0.
+        db.execute_with_params(
+            "CREATE (:Item {id: 'param', v: $v})",
+            params(&[("v", Value::Int64(0))]),
+        )
+        .unwrap();
+        // SET (literal) an existing nonzero value down to 0.
+        db.execute("CREATE (:Item {id: 'set-lit', v: 9})").unwrap();
+        db.execute("MATCH (n:Item {id: 'set-lit'}) SET n.v = 0")
+            .unwrap();
+        // SET ($param) an existing nonzero value down to 0.
+        db.execute("CREATE (:Item {id: 'set-param', v: 9})")
+            .unwrap();
+        db.execute_with_params(
+            "MATCH (n:Item {id: 'set-param'}) SET n.v = $v",
+            params(&[("v", Value::Int64(0))]),
+        )
+        .unwrap();
+
+        for id in ["lit", "param", "set-lit", "set-param"] {
+            assert_eq!(
+                item_v(&db, id),
+                Value::Int64(0),
+                "id='{id}' must be a genuine stored 0 before reopen"
+            );
+        }
+        db.checkpoint().expect("checkpoint");
+    }
+
+    {
+        let db = GraphDb::open(&db_path).expect("open session 2 (reopen)");
+        for id in ["lit", "param", "set-lit", "set-param"] {
+            assert_eq!(
+                item_v(&db, id),
+                Value::Int64(0),
+                "id='{id}' must still be a genuine stored 0 after reopen"
+            );
+        }
+    }
+}

--- a/npm/sparrowdb/test/integration.test.js
+++ b/npm/sparrowdb/test/integration.test.js
@@ -359,10 +359,27 @@ describe('executeWithParams — parameterized queries (KMSmcp #67)', () => {
     assert.ok(Array.isArray(r.rows), 'rows must be an array')
     assert.equal(r.rows.length, 0, 'SET returns no rows')
 
-    // The property must roundtrip on a follow-up read.
+    // `n.embedding` reads back as null via plain RETURN — this is correct,
+    // not a gap. The storage layer's property columns have no vector type
+    // (Int64 / Bytes / Float only), so a vector SET on an indexed property
+    // is written *exclusively* to the HNSW index below; the column is left
+    // absent rather than holding a value that isn't the real embedding.
+    //
+    // Before SPA-475/#473's fix, this assertion read `!= null` and passed —
+    // but only because the property WAS being written, as a silently
+    // coerced `Int64(0)` (the exact bug those issues fixed: a null/non-
+    // representable value written as the literal integer 0, indistinguishable
+    // from a real stored zero). `0 != null` in JS, so the assertion was
+    // satisfied by the coercion artifact, never by a real embedding value —
+    // it was enshrining the bug it looked like it was guarding against. See
+    // the discussion on PR #505.
     const got = db.execute("MATCH (n:Memory {id: 'k1'}) RETURN n.embedding")
     assert.equal(got.rows.length, 1, 'must find the node back')
-    assert.ok(got.rows[0]['n.embedding'] != null, 'embedding must be set')
+    assert.equal(
+      got.rows[0]['n.embedding'],
+      null,
+      'a vector property has no property-column representation; it must read back absent (null), not a coercion artifact — the real value lives only in the HNSW index, verified below'
+    )
 
     // CRITICAL: vectorSearch must return the node — the HNSW index must have
     // been updated by the SET.  Before the fix this returned an empty array.


### PR DESCRIPTION
## Summary

Closes #475 and #473 — a null (or list/map/vector/node-ref/edge-ref) property value was silently written as `Int64(0)`, a value indistinguishable on read from a genuine stored zero, destroying the original value with no error and no way to audit which rows were hit.

```rust
db.execute("CREATE (:Item {id: 'a', v: 7})")?;
let mut p = HashMap::new();
p.insert("nv".to_string(), Value::Null);
db.execute_with_params("MATCH (n:Item {id: 'a'}) SET n.v = $nv", p)?;
// pre-fix: MATCH (n:Item) RETURN n.id, n.v  ->  [["a", Int64(0)]]
// post-fix: the SET call above returns Err(InvalidArgument), v is still 7
```

## Root cause and blast radius

The catch-all-to-`Int64(0)` pattern existed in **six** functions across the write-value-resolution pipeline, not just the two named in the issues:

- `exec_value_to_storage` (#475's named function, `crates/sparrowdb/src/helpers.rs`)
- `value_to_store_value` (#473's named function, `crates/sparrowdb-execution/src/engine/mod.rs`)
- `literal_to_store_value` (same crate, dead code, same defect)
- `literal_to_value` / `expr_to_value` / `literal_to_value_with_params` (`helpers.rs`) — reachable via the **non-parameterized** `SET`/`MERGE` paths, a sibling of #475 that neither issue's repro exercised (`SET n.v = null` with no `$param` at all reaches a completely different function than the one #475 named).

All six are now exhaustive matches returning `Result`, rejecting `Null`/`List`/`Map`/`Vector`/`NodeRef`/`EdgeRef` with a message naming the offending kind — a future `Value` variant is now a compile error here, not a silent fallthrough.

## Chosen semantic: reject, don't silently remove the property

`SET n.prop = null` and `CREATE (n {prop: null})` both return `Err(InvalidArgument)`. Removing the property (matching how an absent property reads back) was considered and rejected for this fix: the storage layer has no primitive to clear a single property column back to absent for an *existing* node — `upsert_node_col`/`set_null_bit` only ever mark a column present, never clear it. Building that would mean a new WAL-able storage op, a `WriteTx` staging-enum change, and edits to every `Mutation::Set` call site — a real feature, not a bug fix, out of scope here.

Rejecting is also consistent with the precedent PR #492 already established for CREATE (`resolve_create_prop_value`): "one null convention for this call site, not two, rather than inventing 'null means omit the property'." That function's `$param` branch used to hand-duplicate `exec_value_to_storage`'s match specifically because that function's catch-all couldn't be trusted — now that it can be, `resolve_create_prop_value` delegates to it instead, and the duplication is gone.

## A real interaction this exposed: vector-index writes (Rust)

`SET n.emb = $vec` (and the MERGE/UNWIND equivalents) unconditionally ran the newly-fallible value resolver *before* the separate code block that detects a vector param and writes it to the HNSW index — so making the resolver reject `Vector` broke a legitimate, tested feature (`create_vector_index_is_a_noop_for_an_index_another_handle_owns` and the whole `vector_index.rs` suite caught this immediately).

Fixed by adding `set_value_is_indexed_vector_param`: when a SET/MERGE value is a `$param` bound to `Value::Vector` **and** a vector index is actually registered for that property, the column write is skipped entirely (the dedicated HNSW block still handles it, unchanged). A vector param on a property with no registered index still correctly errors — there's genuinely nowhere for it to go.

## A second interaction, found by CI: `n.embedding` reads back as `null` (Node binding test)

CI caught what the Rust suites couldn't: `npm/sparrowdb/test/integration.test.js`'s `SET n.embedding = $emb writes a vector via param AND populates HNSW` asserted `got.rows[0]['n.embedding'] != null` after the SET.

That assertion was **enshrining the bug**, the same failure mode as `spa_217_info_counts.rs` (#491): it passed on `main` only because the property WAS being written — as the `Int64(0)` coercion artifact this PR fixes. `0 != null` in JS, so the check was satisfied by the coercion, never by a real embedding value. It never actually verified anything about the embedding roundtripping.

With the coercion fixed, `n.embedding` correctly reads back **absent (`null`)**: the storage layer's property columns have no vector type (`Int64`/`Bytes`/`Float` only), so an indexed vector `$param` is written *exclusively* to the HNSW index, never the column — matching the doc comment already in `value_to_store_value` before this PR. This is the same design decision as the SET/CREATE semantic above, applied consistently: a value with no scalar representation does not get a placeholder.

Verified live (`cargo build --release -p sparrowdb-node`, matching `ci.yml`'s Node job, `.node` artifact copied into `npm/sparrowdb/`):
```
pre-fix:  MATCH (n:Memory {id:'k1'}) RETURN n.embedding  ->  [{"n.embedding": 0}]      (Int64(0) coercion)
post-fix: MATCH (n:Memory {id:'k1'}) RETURN n.embedding  ->  [{"n.embedding": null}]   (correctly absent)
          vectorSearch('Memory','embedding', realEmbedding, 5) -> still finds the node by its real vector (unchanged)
```
Fixed the test's assertion to check `=== null` with a comment explaining why, rather than quietly deleting or loosening it — the test's *real* regression guard (that `vectorSearch` finds the node via the HNSW index, the #410/KMSmcp-ch#202 guarantee) is later in the same test and is untouched. The sibling test two cases down (`Float32Array embedding via Array.from() roundtrips`) never had this assertion in the first place — only this one test carried the stale check. Full Node suite: 47/47 passing (was 46/47 before this correction).

## Testing

- `crates/sparrowdb/tests/regression_475_473_null_coercion.rs` — 13 e2e tests against a real `GraphDb`/`tempfile::TempDir`: SET (via `$param` and literal) null/list/map/vector, CREATE (standalone and batch) null, MERGE (key props and ON CREATE SET) null, UNWIND list-literal null, durability across checkpoint+reopen, and a genuine-zero control across every write path (literal/param × CREATE/SET), also checked across reopen.
- `crates/sparrowdb-execution/tests/regression_473_engine_execute_create_null.rs` — direct `Engine::execute_statement` test for #473's specific named function, since no path through the public `GraphDb` API reaches it today (confirmed by tracing every `Statement::Create` dispatch site — both `execute_create_standalone` and the batch-mode arm were already/now fixed separately and never call it).
- Ran the full CREATE/SET/MERGE/vector-index regression surface: `security_480_parameterized_create`, `regression_467`, `gap_10_parameterized_queries`, `match_after_create`, `merge_node`, `spa_168/182/183/211/215/233/235_234/243`, `regression_483_create_index_noop`, `vector_index*`, `spa_415_unwind_match_mutate` — all pass.
- **Confirmed against the pre-fix parent commit** (`3011dcb`, checked out in a scratch worktree): 9 of the 13 new `sparrowdb` tests fail there with the exact silent-zero symptom (e.g. `MERGE with a null key property must be rejected, not coerced to 0: QueryResult { columns: [], rows: [] }` — i.e. it silently succeeded); the `#473` engine-level test fails there too. The remaining 4 (already-fixed-by-#492 controls, and the genuine-zero control) correctly pass on both commits.
- Node integration suite (`npm/sparrowdb/test/integration.test.js`): 47/47 passing after correcting the one enshrined-bug assertion above.
- The only enshrined-bug test found in the whole repo was the Node one above (found via CI, fixed in the second commit on this branch). `spa_243_null_property_value_returns_descriptive_error` already expected rejection (pre-existing, from #492) and still passes unchanged; no other test asserted the old `Int64(0)` coercion.

## Checks

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p sparrowdb -p sparrowdb-execution --all-targets --keep-going` clean, zero warnings
- [x] No `Value` enum changes — no binding-crate (ruby/node/python) updates needed
- [x] Node integration suite passes (built and ran locally, matching CI's exact recipe)

## Could not verify

- Whether any external consumer of `sparrowdb` (including KMSmcp, the Node binding's primary consumer) depends on the old silent-zero behavior for null/list/map/vector property writes — by definition unrecoverable/undetectable from inside this repo (that's the whole premise of the bug). The CI failure this PR's second commit fixes is evidence this class of surprise is real, though in that case it was a stale test assertion, not production code.
- Ruby/Python bindings were not built and run locally (no `Value` enum change, so low risk, but unlike Node they weren't exercised end-to-end).
- A full `cargo test --workspace --exclude sparrowdb-ruby` run (beyond the explicitly-scoped suites above) was still in progress at last check, ~800+ test binaries in with zero failures; will report if the tail surfaces anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE
