### PR TITLE
chore: bump 0.1.24 → 0.1.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.24"
+version = "0.1.25"
 edition = "2021"
 license = "MIT"
 authors = ["Rich Yaker"]
@@ -28,13 +28,13 @@ documentation = "https://docs.rs/sparrowdb"
 readme = "README.md"
 
 [workspace.dependencies]
-sparrowdb-common = { path = "crates/sparrowdb-common", version = "0.1.24" }
-sparrowdb-storage = { path = "crates/sparrowdb-storage", version = "0.1.24" }
-sparrowdb-catalog = { path = "crates/sparrowdb-catalog", version = "0.1.24" }
-sparrowdb-cypher  = { path = "crates/sparrowdb-cypher", version = "0.1.24" }
-sparrowdb-execution = { path = "crates/sparrowdb-execution", version = "0.1.24" }
-sparrowdb = { path = "crates/sparrowdb", version = "0.1.24" }
-sparrowdb-metrics = { path = "crates/sparrowdb-metrics", version = "0.1.24" }
+sparrowdb-common = { path = "crates/sparrowdb-common", version = "0.1.25" }
+sparrowdb-storage = { path = "crates/sparrowdb-storage", version = "0.1.25" }
+sparrowdb-catalog = { path = "crates/sparrowdb-catalog", version = "0.1.25" }
+sparrowdb-cypher  = { path = "crates/sparrowdb-cypher", version = "0.1.25" }
+sparrowdb-execution = { path = "crates/sparrowdb-execution", version = "0.1.25" }
+sparrowdb = { path = "crates/sparrowdb", version = "0.1.25" }
+sparrowdb-metrics = { path = "crates/sparrowdb-metrics", version = "0.1.25" }
 tiny_http         = "0.12"
 tempfile          = "3"
 crc32fast         = "1"

--- a/npm/sparrowdb/package-lock.json
+++ b/npm/sparrowdb/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparrowdb",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparrowdb",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"
@@ -15,11 +15,11 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@sparrowdb/darwin-arm64": "0.1.24",
-        "@sparrowdb/darwin-x64": "0.1.24",
-        "@sparrowdb/linux-arm64-gnu": "0.1.24",
-        "@sparrowdb/linux-x64-gnu": "0.1.24",
-        "@sparrowdb/win32-x64-msvc": "0.1.24"
+        "@sparrowdb/darwin-arm64": "0.1.25",
+        "@sparrowdb/darwin-x64": "0.1.25",
+        "@sparrowdb/linux-arm64-gnu": "0.1.25",
+        "@sparrowdb/linux-x64-gnu": "0.1.25",
+        "@sparrowdb/win32-x64-msvc": "0.1.25"
       }
     },
     "node_modules/@napi-rs/cli": {

--- a/npm/sparrowdb/package.json
+++ b/npm/sparrowdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparrowdb",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Native Node.js/TypeScript bindings for SparrowDB — embedded graph database with Cypher query support",
   "main": "index.js",
   "types": "index.d.ts",
@@ -22,11 +22,11 @@
   },
   "keywords": ["graph", "database", "cypher", "native", "napi"],
   "optionalDependencies": {
-    "@sparrowdb/linux-x64-gnu": "0.1.24",
-    "@sparrowdb/linux-arm64-gnu": "0.1.24",
-    "@sparrowdb/darwin-x64": "0.1.24",
-    "@sparrowdb/darwin-arm64": "0.1.24",
-    "@sparrowdb/win32-x64-msvc": "0.1.24"
+    "@sparrowdb/linux-x64-gnu": "0.1.25",
+    "@sparrowdb/linux-arm64-gnu": "0.1.25",
+    "@sparrowdb/darwin-x64": "0.1.25",
+    "@sparrowdb/darwin-arm64": "0.1.25",
+    "@sparrowdb/win32-x64-msvc": "0.1.25"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4"


### PR DESCRIPTION
chore: bump 0.1.24 -> 0.1.25

0.1.24 ships two panics reachable from ordinary queries, which is the reason to cut this now rather
than batch further work into it.

  #506 / #502  TWO PANICS. `CALL { CREATE (:X) }` and — far worse — a plain
               `MATCH (a:A), (b:B) MERGE (a)-[r:KNOWS]->(b)` crashing the host process through
               execute_with_timeout while working fine through execute(). For an embedded database the
               caller IS the process. Root cause was five hand-copied dispatch matches that had drifted;
               the fix makes both the classifier and the dispatch exhaustive, so adding a Statement
               variant is now a compile error rather than a future panic.

  #505 / #475, #473  A null property value was silently written as Int64(0), destroying the previous
               value with no error. 0 is a legal value, so a coerced null is indistinguishable from a
               real zero on read. Six functions carried the coercion, three of them reachable via plain
               `SET n.v = null` with no parameter at all.

  #503 / #477  full_text_search() and bm25_score() returned nothing from a WHERE clause on a healthy
               index — silently. WHERE is the primary way to filter by relevance, so full-text search
               was unusable from its most natural form.

  #501 / #478  `CREATE (:A) RETURN 1 UNION CREATE (:B) RETURN 2` reported success and durably wrote
               nothing.

  #498         Release automation: a v* tag now publishes crates.io alongside npm. Both registries
               drifted in opposite directions within three days because crates.io was manual.

Every fix above ships with regression tests confirmed to fail against their parent commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workspace and package release version to 0.1.25.
  * Aligned platform-specific package dependencies with the new release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->