### PR TITLE
ci: weekly credential health check

### DIFF
--- a/.github/workflows/credential-healthcheck.yml
+++ b/.github/workflows/credential-healthcheck.yml
@@ -1,0 +1,118 @@
+name: Credential health check
+
+# Every credential in the release path expires on its own schedule, and the only
+# symptom of expiry has so far been a release failing — TAP_GITHUB_TOKEN silently
+# died and was discovered when v0.1.24 and v0.1.25 both failed to update the
+# Homebrew formula (#508); NPM_TOKEN went the same way two days earlier. This
+# checks them BEFORE a release needs them.
+#
+# Every check is READ-ONLY. Nothing here publishes, pushes, or mutates anything —
+# each call is the registry's own "who am I" endpoint, or a metadata read.
+#
+# Tokens are passed via env and never echoed. Do not add `set -x`.
+
+on:
+  schedule:
+    - cron: '17 9 * * 1'   # Mondays 09:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Validate release credentials
+    runs-on: ubuntu-latest
+    steps:
+      - name: npm (NPM_TOKEN)
+        id: npm
+        continue-on-error: true
+        env:
+          TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${TOKEN:-}" ]; then echo "::error::NPM_TOKEN is not set"; exit 1; fi
+          who=$(curl -sS -m 30 -H "Authorization: Bearer $TOKEN" https://registry.npmjs.org/-/whoami)
+          if printf '%s' "$who" | grep -q '"username"'; then
+            echo "ok — npm accepts the token (user: $(printf '%s' "$who" | sed -n 's/.*"username":"\([^"]*\)".*/\1/p'))"
+          else
+            echo "::error::NPM_TOKEN rejected by registry.npmjs.org. Mint an Automation or Bypass-2FA granular token and: printf '%s' '<tok>' | gh secret set NPM_TOKEN --repo ryaker/SparrowDB"
+            exit 1
+          fi
+
+      - name: crates.io (CARGO_REGISTRY_TOKEN)
+        id: cargo
+        continue-on-error: true
+        env:
+          TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          if [ -z "${TOKEN:-}" ]; then echo "::error::CARGO_REGISTRY_TOKEN is not set"; exit 1; fi
+          code=$(curl -sS -m 30 -o /tmp/me.json -w '%{http_code}' \
+            -H "Authorization: $TOKEN" -H "User-Agent: sparrowdb-credential-check" \
+            https://crates.io/api/v1/me)
+          if [ "$code" = "200" ]; then
+            echo "ok — crates.io accepts the token"
+          else
+            echo "::error::CARGO_REGISTRY_TOKEN rejected by crates.io (HTTP $code). Mint a publish-update token at crates.io/settings/tokens and: printf '%s' '<tok>' | gh secret set CARGO_REGISTRY_TOKEN --repo ryaker/SparrowDB"
+            exit 1
+          fi
+
+      - name: Homebrew tap (TAP_GITHUB_TOKEN)
+        id: tap
+        continue-on-error: true
+        env:
+          TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+        run: |
+          if [ -z "${TOKEN:-}" ]; then echo "::error::TAP_GITHUB_TOKEN is not set"; exit 1; fi
+          # Checks auth AND write access to the ONE repo the release job pushes to.
+          # /user alone would pass for a token that cannot reach the tap.
+          code=$(curl -sS -m 30 -o /tmp/tap.json -w '%{http_code}' \
+            -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/ryaker/homebrew-sparrowdb)
+          if [ "$code" != "200" ]; then
+            echo "::error::TAP_GITHUB_TOKEN cannot read ryaker/homebrew-sparrowdb (HTTP $code) — this is what fails the release's Update Homebrew tap job (#508). Mint a fine-grained PAT with Contents: read+write on that repo and: printf '%s' '<tok>' | gh secret set TAP_GITHUB_TOKEN --repo ryaker/SparrowDB"
+            exit 1
+          fi
+          # Read access is not enough: the job commits and pushes.
+          if grep -q '"push": *true' /tmp/tap.json; then
+            echo "ok — token can read AND push to ryaker/homebrew-sparrowdb"
+          else
+            echo "::error::TAP_GITHUB_TOKEN can read ryaker/homebrew-sparrowdb but has no push permission — the release job commits a formula update and will fail."
+            exit 1
+          fi
+
+      - name: rubygems (GEM_HOST_API_KEY)
+        id: gem
+        continue-on-error: true
+        env:
+          TOKEN: ${{ secrets.GEM_HOST_API_KEY }}
+        run: |
+          if [ -z "${TOKEN:-}" ]; then
+            echo "notice — GEM_HOST_API_KEY is not set; the publish-rubygems job is commented out, so this is not currently a release blocker."
+            exit 0
+          fi
+          code=$(curl -sS -m 30 -o /dev/null -w '%{http_code}' \
+            -H "Authorization: $TOKEN" https://rubygems.org/api/v1/profile/me.json)
+          if [ "$code" = "200" ]; then
+            echo "ok — rubygems accepts the token"
+          else
+            echo "::error::GEM_HOST_API_KEY rejected by rubygems.org (HTTP $code). Not a release blocker today (publish-rubygems is disabled), but it will be when that job is re-enabled."
+            exit 1
+          fi
+
+      - name: Summary — fail if any credential is bad
+        run: |
+          fail=0
+          report() {
+            if [ "$2" = "success" ]; then echo "  PASS  $1"; else echo "  FAIL  $1"; fail=1; fi
+          }
+          echo "Credential health:"
+          report "NPM_TOKEN            (npm publish)"        "${{ steps.npm.outcome }}"
+          report "CARGO_REGISTRY_TOKEN (crates.io publish)"  "${{ steps.cargo.outcome }}"
+          report "TAP_GITHUB_TOKEN     (homebrew formula)"   "${{ steps.tap.outcome }}"
+          report "GEM_HOST_API_KEY     (rubygems, disabled)" "${{ steps.gem.outcome }}"
+          echo
+          if [ "$fail" = "1" ]; then
+            echo "::error::One or more release credentials are invalid. The next tag push will fail on those steps — fix them before releasing, not during."
+            exit 1
+          fi
+          echo "All release credentials valid."


### PR DESCRIPTION
ci: weekly credential health check

Every credential in the release path expires on its own schedule, and so far the
only symptom of expiry has been a release failing:

  2026-08-13  NPM_TOKEN silently expired; found when v0.1.23's publish returned E403.
  2026-08-15  TAP_GITHUB_TOKEN silently expired; found when v0.1.24 AND v0.1.25 both
              failed to update the Homebrew formula (#508). brew install sparrowdb
              still serves 0.1.23.

Two credentials in three days, both discovered by a broken release rather than by
anything watching. A calendar reminder does not fix this — it relies on someone
reading it, and the tokens expire at different times.

This checks all four before a release needs them:

  NPM_TOKEN             registry.npmjs.org/-/whoami
  CARGO_REGISTRY_TOKEN  crates.io/api/v1/me
  TAP_GITHUB_TOKEN      api.github.com/repos/ryaker/homebrew-sparrowdb
  GEM_HOST_API_KEY      rubygems.org/api/v1/profile/me.json (advisory — that job is
                        commented out, so a failure is reported but not a blocker)

Three design points:

1. EVERY CHECK IS READ-ONLY. Each call is the registry's own "who am I" endpoint or
   a metadata read. Nothing publishes, pushes, or mutates. A health check that can
   damage the thing it monitors is worse than no health check.

2. THE TAP CHECK VERIFIES PUSH, NOT JUST AUTH. Hitting /user would pass for a token
   that cannot reach the tap repo at all. It reads the repo and asserts
   permissions.push is true, because the release job commits and pushes a formula
   update — read access would still fail at the step that matters.

3. STEPS ARE continue-on-error WITH A FINAL GATE. One dead credential must not mask
   the state of the others; the summary reports all four and then fails.

Each failure message names the exact command to fix it, so the log is actionable
without looking anything up.

Tokens are passed via env and never echoed. Do not add `set -x` to this file.

Runs Mondays 09:17 UTC, plus workflow_dispatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated credential health checks for release services.
  * Checks can run on a schedule or be triggered manually.
  * Reports all credential issues in a single run and marks the check as failed when any credential is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->