### PR TITLE
ci: fix false positive and false blocker in the credential health check

### DIFF
--- a/.github/workflows/credential-healthcheck.yml
+++ b/.github/workflows/credential-healthcheck.yml
@@ -46,15 +46,32 @@ jobs:
           TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           if [ -z "${TOKEN:-}" ]; then echo "::error::CARGO_REGISTRY_TOKEN is not set"; exit 1; fi
-          code=$(curl -sS -m 30 -o /tmp/me.json -w '%{http_code}' \
-            -H "Authorization: $TOKEN" -H "User-Agent: sparrowdb-credential-check" \
-            https://crates.io/api/v1/me)
-          if [ "$code" = "200" ]; then
-            echo "ok — crates.io accepts the token"
-          else
-            echo "::error::CARGO_REGISTRY_TOKEN rejected by crates.io (HTTP $code). Mint a publish-update token at crates.io/settings/tokens and: printf '%s' '<tok>' | gh secret set CARGO_REGISTRY_TOKEN --repo ryaker/SparrowDB"
-            exit 1
-          fi
+          # crates.io has no read-only endpoint a PUBLISH-scoped token may call:
+          #   /api/v1/me                     -> 403 even for a valid publish token
+          #   /api/v1/crates/<c>/owners      -> 200 with NO token at all (public)
+          # Using the owners endpoint would be a vacuous check that passes for a
+          # garbage token, which is worse than no check. So this discriminates on
+          # the /me error BODY, which differs by state even though all three
+          # return HTTP 403:
+          #   no token sent    "this action requires authentication"
+          #   invalid token    "authentication failed"
+          #   VALID publish    "this action can only be performed on the crates.io website"
+          # The third proves crates.io authenticated the token and refused on scope.
+          body=$(curl -sS -m 30 -H "Authorization: $TOKEN" \
+            -H "User-Agent: sparrowdb-credential-check" https://crates.io/api/v1/me)
+          case "$body" in
+            *"can only be performed on the crates.io website"*)
+              echo "ok — crates.io authenticated the token (publish scope; /me is website-only)" ;;
+            *"authentication failed"*)
+              echo "::error::CARGO_REGISTRY_TOKEN rejected by crates.io — the token is invalid or revoked. Mint a publish-update token at https://crates.io/settings/tokens and: printf '%s' '<tok>' | gh secret set CARGO_REGISTRY_TOKEN --repo ryaker/SparrowDB"
+              exit 1 ;;
+            *"requires authentication"*)
+              echo "::error::CARGO_REGISTRY_TOKEN was not accepted as an Authorization header — the secret may be empty or malformed."
+              exit 1 ;;
+            *)
+              echo "::error::Unexpected response from crates.io /api/v1/me; cannot determine token validity. Body: $body"
+              exit 1 ;;
+          esac
 
       - name: Homebrew tap (TAP_GITHUB_TOKEN)
         id: tap
@@ -95,8 +112,7 @@ jobs:
           if [ "$code" = "200" ]; then
             echo "ok — rubygems accepts the token"
           else
-            echo "::error::GEM_HOST_API_KEY rejected by rubygems.org (HTTP $code). Not a release blocker today (publish-rubygems is disabled), but it will be when that job is re-enabled."
-            exit 1
+            echo "::warning::GEM_HOST_API_KEY rejected by rubygems.org (HTTP $code). NOT a release blocker today — publish-rubygems is commented out — but it must be replaced before that job is re-enabled."
           fi
 
       - name: Summary — fail if any credential is bad
@@ -109,7 +125,9 @@ jobs:
           report "NPM_TOKEN            (npm publish)"        "${{ steps.npm.outcome }}"
           report "CARGO_REGISTRY_TOKEN (crates.io publish)"  "${{ steps.cargo.outcome }}"
           report "TAP_GITHUB_TOKEN     (homebrew formula)"   "${{ steps.tap.outcome }}"
-          report "GEM_HOST_API_KEY     (rubygems, disabled)" "${{ steps.gem.outcome }}"
+          # rubygems is advisory only: the publish job is disabled, so a stale key
+          # must not fail this run. Its status is reported, never gated on.
+          echo "  INFO  GEM_HOST_API_KEY     (rubygems job disabled — advisory)"
           echo
           if [ "$fail" = "1" ]; then
             echo "::error::One or more release credentials are invalid. The next tag push will fail on those steps — fix them before releasing, not during."


### PR DESCRIPTION
ci: fix a false positive and a false blocker in the credential health check

Running #509 for real immediately exposed two defects in it — which is the point of
running a check against reality rather than trusting it.

FALSE POSITIVE: CARGO_REGISTRY_TOKEN was reported FAIL by a token that had
successfully published 0.1.25 an hour earlier. crates.io has no read-only endpoint a
PUBLISH-scoped token may call:

  /api/v1/me                  403 even for a valid publish token
  /api/v1/crates/<c>/owners   200 with NO token at all — it is public

The obvious "fix" of switching to the owners endpoint would have been far worse: a
vacuous check that passes for a garbage token, verified by calling it with
"cio_notarealtoken" and getting 200. A check that cannot fail is the exact pattern
this repo keeps finding in its tests.

The three states ARE distinguishable, by response body, despite all returning 403:

  no token sent   "this action requires authentication"
  invalid token   "authentication failed"
  VALID publish   "this action can only be performed on the crates.io website"

The third proves crates.io authenticated the token and refused on scope. Each case is
now handled explicitly, with an unexpected body treated as "cannot determine" rather
than as success — blind must not look like green.

FALSE BLOCKER: a rejected GEM_HOST_API_KEY failed the whole run, though
publish-rubygems is commented out in release.yml, so it cannot break a release today.
It is now a warning and is excluded from the gate. A weekly job that goes red for
something that cannot break anything is a job people learn to ignore, which would
defeat the purpose.

After this, the run reports exactly one real failure — TAP_GITHUB_TOKEN (#508) — which
is the true state.
