### PR TITLE
fix(npm): index.d.ts fails to parse as TypeScript

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,12 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Type-check npm/sparrowdb/index.d.ts
+        working-directory: npm/sparrowdb
+        run: |
+          npm install
+          npm run typecheck
+
       - name: Build sparrowdb-node (.node binary)
         run: |
           cargo build --release -p sparrowdb-node

--- a/crates/sparrowdb-node/src/lib.rs
+++ b/crates/sparrowdb-node/src/lib.rs
@@ -241,9 +241,9 @@ pub struct QueryResult {
 ///
 /// ```typescript
 /// interface NodeResult {
-///   /** Node ID as a decimal string (full u64 range, JS-safe). */
+///   // Node ID as a decimal string (full u64 range, JS-safe).
 ///   id: string;
-///   /** Relevance score: cosine similarity / BM25 score / distance. */
+///   // Relevance score: cosine similarity / BM25 score / distance.
 ///   score: number;
 /// }
 /// ```
@@ -267,9 +267,12 @@ pub struct NodeResult {
 /// }
 /// ```
 ///
-/// Note the `//` comments above rather than nested doc comments: a `*/` inside
-/// a generated JSDoc block closes it early, which is why the checked-in
-/// `npm/sparrowdb/index.d.ts` does not currently parse as TypeScript.
+/// Note the `//` comments above rather than nested doc comments. A JSDoc
+/// close-marker inside a generated JSDoc block terminates it early, and every
+/// declaration after that point is then parsed as code — which is exactly how
+/// the checked-in `npm/sparrowdb/index.d.ts` stopped parsing as TypeScript
+/// (#449). `npm run typecheck` in CI now guards against a recurrence; keep
+/// examples in these doc comments to `//` so it never fires.
 #[napi(object)]
 pub struct VectorIndexHealth {
     /// Vectors stored in the index.

--- a/npm/sparrowdb/index.d.ts
+++ b/npm/sparrowdb/index.d.ts
@@ -28,8 +28,10 @@ export interface QueryResult {
  *
  * ```typescript
  * interface NodeResult {
- *   id: string;   // Node ID as a decimal string (full u64 range, JS-safe).
- *   score: number; // Relevance score: cosine similarity / BM25 score / distance.
+ *   // Node ID as a decimal string (full u64 range, JS-safe).
+ *   id: string;
+ *   // Relevance score: cosine similarity / BM25 score / distance.
+ *   score: number;
  * }
  * ```
  */
@@ -50,9 +52,12 @@ export interface NodeResult {
  * }
  * ```
  *
- * Note the `//` comments above rather than nested doc comments: a `*\/` inside
- * a generated JSDoc block closes it early, which is why the checked-in
- * `npm/sparrowdb/index.d.ts` does not currently parse as TypeScript.
+ * Note the `//` comments above rather than nested doc comments. A JSDoc
+ * close-marker inside a generated JSDoc block terminates it early, and every
+ * declaration after that point is then parsed as code — which is exactly how
+ * the checked-in `npm/sparrowdb/index.d.ts` stopped parsing as TypeScript
+ * (#449). `npm run typecheck` in CI now guards against a recurrence; keep
+ * examples in these doc comments to `//` so it never fires.
  */
 export interface VectorIndexHealth {
   /** Vectors stored in the index. */

--- a/npm/sparrowdb/index.d.ts
+++ b/npm/sparrowdb/index.d.ts
@@ -28,10 +28,8 @@ export interface QueryResult {
  *
  * ```typescript
  * interface NodeResult {
- *   /** Node ID as a decimal string (full u64 range, JS-safe). */
- *   id: string;
- *   /** Relevance score: cosine similarity / BM25 score / distance. */
- *   score: number;
+ *   id: string;   // Node ID as a decimal string (full u64 range, JS-safe).
+ *   score: number; // Relevance score: cosine similarity / BM25 score / distance.
  * }
  * ```
  */

--- a/npm/sparrowdb/index.js
+++ b/npm/sparrowdb/index.js
@@ -58,4 +58,17 @@ function loadNative() {
   )
 }
 
-module.exports = loadNative()
+const native = loadNative()
+
+module.exports = native
+
+// Named exports must be assigned explicitly (not just spread onto
+// `module.exports`) so that Node's ESM/CJS interop — which relies on static
+// analysis via cjs-module-lexer, not evaluation — can see them. A dynamic
+// `module.exports = loadNative()` alone is invisible to that analysis, so an
+// ESM consumer's `import { SparrowDB } from 'sparrowdb'` fails with "Named
+// export 'SparrowDB' not found" even though `require('sparrowdb').SparrowDB`
+// works fine under CommonJS. See issue #449.
+module.exports.SparrowDB = native.SparrowDB
+module.exports.ReadTx = native.ReadTx
+module.exports.WriteTx = native.WriteTx

--- a/npm/sparrowdb/package-lock.json
+++ b/npm/sparrowdb/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.25",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
-        "@napi-rs/cli": "^2.18.4"
+        "@napi-rs/cli": "^2.18.4",
+        "typescript": "^5.6.0"
       },
       "engines": {
         "node": ">= 18"
@@ -37,6 +38,20 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     }
   }

--- a/npm/sparrowdb/package.json
+++ b/npm/sparrowdb/package.json
@@ -4,13 +4,21 @@
   "description": "Native Node.js/TypeScript bindings for SparrowDB — embedded graph database with Cypher query support",
   "main": "index.js",
   "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "index.js",
     "index.d.ts",
     "*.node"
   ],
   "scripts": {
-    "test": "node --test test/integration.test.js"
+    "test": "node --test test/integration.test.js",
+    "typecheck": "tsc -p tsconfig.json"
   },
   "engines": {
     "node": ">= 18"
@@ -29,6 +37,7 @@
     "@sparrowdb/win32-x64-msvc": "0.1.25"
   },
   "devDependencies": {
-    "@napi-rs/cli": "^2.18.4"
+    "@napi-rs/cli": "^2.18.4",
+    "typescript": "^5.6.0"
   }
 }

--- a/npm/sparrowdb/test/consumer.ts
+++ b/npm/sparrowdb/test/consumer.ts
@@ -1,0 +1,43 @@
+// Type-check smoke test for the published `.d.ts` — not executed, only
+// compiled. Exercises the shapes real TypeScript consumers rely on: named
+// import of the class exports, `execute`, `executeWithParams`, and iterating
+// `QueryResult.rows`. CI type-checks this file against `index.d.ts` so a
+// change to the declarations that breaks a realistic consumer fails the
+// build instead of shipping silently (see issue #449).
+import { SparrowDB, ReadTx, WriteTx } from 'sparrowdb'
+
+// Stand-in for a real sink (console.log) so this file type-checks without
+// pulling in @types/node just to know the shape of `console`.
+declare function use(value: unknown): void
+
+const db: SparrowDB = SparrowDB.open('/tmp/example.db')
+
+const result = db.execute('MATCH (n:Person) RETURN n.name LIMIT 5')
+for (const row of result.rows) {
+  use(row['n.name'])
+}
+
+const paramResult = db.executeWithParams(
+  'MERGE (k:Memory {id: $id}) SET k.embedding = $emb',
+  { id: 'abc-123', emb: [0.1, 0.2, 0.3] },
+)
+use(paramResult.columns)
+
+const health = db.vectorIndexHealth('Memory', 'embedding')
+use([health.stored, health.reachable, health.unreachable])
+
+const hits = db.hybridSearch('Memory', 'content', 'embedding', new Float32Array(768), 'query', 10, 0.7)
+for (const hit of hits) {
+  use([hit.id, hit.score])
+}
+
+const readTx: ReadTx = db.beginRead()
+use(readTx.snapshotTxnId)
+
+const writeTx: WriteTx = db.beginWrite()
+writeTx.execute("CREATE (:Person {name: 'Ada'})")
+const newTxnId: string = writeTx.commit()
+use(newTxnId)
+
+db.checkpoint()
+db.optimize()

--- a/npm/sparrowdb/tsconfig.json
+++ b/npm/sparrowdb/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "types": [],
+    "noEmit": true,
+    "skipLibCheck": false,
+    "baseUrl": ".",
+    "paths": {
+      "sparrowdb": ["./index.d.ts"]
+    }
+  },
+  "include": ["index.d.ts", "test/consumer.ts"]
+}


### PR DESCRIPTION
## Summary
- `npm/sparrowdb/index.d.ts` had one remaining occurrence of the nested-doc-comment bug from #449: the `NodeResult` JSDoc example used inner `/** ... */` blocks whose `*/` closed the outer comment early, cascading into TS syntax errors from line 32 on. Fixed with `//` line comments, matching the pattern #447 already applied to `VectorIndexHealth`, `VectorIndexLoadFailure`, and `VectorIndexDamageReport` in the same file.
- Fixed an adjacent, confirmed bug found while verifying a realistic consumer: `import { SparrowDB } from 'sparrowdb'` throws under ESM (`Named export 'SparrowDB' not found`) even though `require('sparrowdb').SparrowDB` works under CommonJS. Cause: `module.exports = loadNative()` in `index.js` is a dynamic assignment, invisible to Node's static cjs-module-lexer analysis used for CJS→ESM named-export detection. Fixed by assigning the named exports explicitly. Also added an `exports` map to `package.json`.
- Added a CI type-check step (`npm install && npm run typecheck`) so a broken `.d.ts` fails the build — there was no TypeScript step in `ci.yml` before this. New `npm/sparrowdb/tsconfig.json` + `npm/sparrowdb/test/consumer.ts` type-check the declarations plus a realistic consumer shape (`execute`, `executeWithParams`, vector/hybrid search, transactions) via a path alias, without requiring the native binary.

## Not changed — reported, not fixed
Two documentation/behavior mismatches from issue #480, confirmed against the built native module but left alone (out of scope for this PR — see discussion below):
- The doc comments (`QueryResult`, `execute`, `executeWithParams`) describe node/edge values as `{ $type: "node", id: string }` / `{ $type: "edge", id: string }`. Actual runtime for `RETURN n` (a bare node) returns a plain property map with hashed column names (e.g. `{ "col_2369371622": "Ada" }`) — no `$type`, no `id`. There is no `NodeRef` type declared anywhere in the file.
- The doc comments list `boolean` as a supported Cypher value type. Actual runtime returns booleans as `1`/`0` (JS `number`), confirmed via `RETURN f.active`.

Both are prose-only inaccuracies inside `rows: Array<any>` — the TS type itself isn't wrong (already maximally loose), so there's no "correct type" to fix here without also fixing the runtime, which is out of scope. These doc comments also originate from Rust doc comments in `crates/sparrowdb-node/src/lib.rs` (this file is auto-generated by NAPI-RS), so a durable fix belongs there, not in the checked-in `.d.ts`.

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck npm/sparrowdb/index.d.ts` exits 0
- [x] `npm run typecheck` (new script) exits 0, checking `index.d.ts` + a realistic consumer file
- [x] `node -e "require('./index.js')"` still exposes `SparrowDB`/`ReadTx`/`WriteTx` under CommonJS
- [x] ESM `import { SparrowDB } from 'sparrowdb'` verified working against the built native module
- [x] `cargo build --release -p sparrowdb-node` + `node --test npm/sparrowdb/test/integration.test.js` — 47/47 pass

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved CommonJS and ES module interoperability with named exports for core database classes.
  * Added package export mappings for the main entry point, type declarations, and package metadata.

* **Bug Fixes**
  * Improved TypeScript compatibility and validation for published package declarations.

* **Documentation**
  * Clarified result documentation for returned IDs and scores.

* **Tests**
  * Added comprehensive TypeScript checks covering queries, vectors, results, transactions, and database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->