### PR TITLE
fix(storage): DELETE dangling edges + DETACH DELETE cross-table pollution (#436)

### DIFF
--- a/crates/sparrowdb/src/write_tx.rs
+++ b/crates/sparrowdb/src/write_tx.rs
@@ -456,45 +456,72 @@ impl WriteTx {
     ///
     /// [`commit`]: WriteTx::commit
     pub fn delete_node(&mut self, node_id: NodeId) -> crate::Result<()> {
-        // SPA-185: check ALL per-type delta logs for attached edges, not just
-        // the hardcoded RelTableId(0).  Always include table-0 so that any
-        // edges written before the catalog had entries are still detected.
-        let rel_entries = self.catalog.list_rel_table_ids();
-        let mut rel_ids_to_check: Vec<u32> =
-            rel_entries.iter().map(|(id, _, _, _)| *id as u32).collect();
-        // Always include the legacy table-0 slot.  If it is already in the
-        // catalog list this dedup prevents a double-read.
-        if !rel_ids_to_check.contains(&0u32) {
-            rel_ids_to_check.push(0u32);
-        }
-        for rel_id in rel_ids_to_check {
-            let store = EdgeStore::open(&self.inner.path, RelTableId(rel_id));
+        // SPA-185 / #436: check ALL per-type delta logs and CSR files for
+        // attached edges, not just the hardcoded RelTableId(0).
+        //
+        // CSR files are indexed by label-relative *slot*, not by the packed
+        // `NodeId` (which has the label folded into the upper 32 bits, see
+        // `NodeId` encoding). Indexing with the full `node_id.0` overflows
+        // `CsrForward::n_nodes`/`CsrBackward::n_nodes` for almost any label
+        // other than label 0, so `neighbors`/`predecessors` silently returned
+        // `&[]` and this check never fired for checkpointed edges — a node
+        // with a checkpointed edge could be deleted, leaving that edge
+        // dangling (#436). Strip the label bits before indexing.
+        //
+        // Each rel table's CSR is only meaningful for node_id when its label
+        // actually matches that table's declared src label (forward) or dst
+        // label (backward); a table for an unrelated label pair may have a
+        // numerically coincidental slot that is not actually node_id at all.
+        let node_slot = node_id.0 & 0xFFFF_FFFF;
+        let node_label_id = (node_id.0 >> 32) as u16;
 
-            // Check delta log (un-checkpointed edges).
-            if let Ok(ref s) = store {
+        let rel_entries = self.catalog.list_rel_table_ids();
+        for (rel_table_id, src_label_id, dst_label_id, _rel_type) in &rel_entries {
+            let store = EdgeStore::open(&self.inner.path, RelTableId(*rel_table_id as u32));
+            let Ok(ref s) = store else { continue };
+
+            // Check delta log (un-checkpointed edges). Delta records store
+            // full NodeIds, so a direct `==` comparison is unambiguous
+            // regardless of which table it came from.
+            let delta = s.read_delta().unwrap_or_default();
+            if delta.iter().any(|r| r.src == node_id || r.dst == node_id) {
+                return Err(sparrowdb_common::Error::NodeHasEdges { node_id: node_id.0 });
+            }
+
+            // SPA-304: Check CSR forward file — node_id can only be a
+            // *source* in this table if its label matches the table's src
+            // label.
+            if node_label_id == *src_label_id {
+                if let Ok(csr) = s.open_fwd() {
+                    if !csr.neighbors(node_slot).is_empty() {
+                        return Err(sparrowdb_common::Error::NodeHasEdges { node_id: node_id.0 });
+                    }
+                }
+            }
+
+            // SPA-304: Check CSR backward file — node_id can only be a
+            // *destination* in this table if its label matches the table's
+            // dst label.
+            if node_label_id == *dst_label_id {
+                if let Ok(csr) = s.open_bwd() {
+                    if !csr.predecessors(node_slot).is_empty() {
+                        return Err(sparrowdb_common::Error::NodeHasEdges { node_id: node_id.0 });
+                    }
+                }
+            }
+        }
+
+        // Legacy fallback: always also check RelTableId(0)'s delta log, in
+        // case it holds edges written before the catalog had any rel-table
+        // entries (and so is absent from `rel_entries` above). There is no
+        // label information for this ad-hoc table, so only the (unambiguous,
+        // full-NodeId) delta check applies here; skip it if 0 was already
+        // covered above to avoid a redundant read.
+        if !rel_entries.iter().any(|(id, ..)| *id == 0) {
+            if let Ok(s) = EdgeStore::open(&self.inner.path, RelTableId(0)) {
                 let delta = s.read_delta().unwrap_or_default();
                 if delta.iter().any(|r| r.src == node_id || r.dst == node_id) {
                     return Err(sparrowdb_common::Error::NodeHasEdges { node_id: node_id.0 });
-                }
-            }
-
-            // SPA-304: Check CSR forward file — the node may be a *source* of
-            // checkpointed edges that are no longer in the delta log.
-            if let Ok(ref s) = store {
-                if let Ok(csr) = s.open_fwd() {
-                    if !csr.neighbors(node_id.0).is_empty() {
-                        return Err(sparrowdb_common::Error::NodeHasEdges { node_id: node_id.0 });
-                    }
-                }
-            }
-
-            // SPA-304: Check CSR backward file — the node may be a *destination*
-            // of checkpointed edges.
-            if let Ok(ref s) = store {
-                if let Ok(csr) = s.open_bwd() {
-                    if !csr.predecessors(node_id.0).is_empty() {
-                        return Err(sparrowdb_common::Error::NodeHasEdges { node_id: node_id.0 });
-                    }
                 }
             }
         }
@@ -544,6 +571,7 @@ impl WriteTx {
         // Strip the label bits before calling neighbors/predecessors, and
         // reconstruct full NodeIds with the correct label bits on return.
         let node_slot = node_id.0 & 0xFFFF_FFFF;
+        let node_label_id = (node_id.0 >> 32) as u16;
 
         for (rel_table_id, src_label_id, dst_label_id, rel_type) in &rel_entries {
             let rel_id = *rel_table_id as u32;
@@ -551,7 +579,8 @@ impl WriteTx {
             let Ok(ref s) = store else { continue };
 
             // Collect incident edges from the delta log (un-checkpointed).
-            // Delta records store full NodeIds, so compare directly.
+            // Delta records store full NodeIds, so compare directly — this is
+            // unambiguous regardless of which table it came from.
             if let Ok(delta) = s.read_delta() {
                 for rec in &delta {
                     if rec.src == node_id || rec.dst == node_id {
@@ -561,22 +590,34 @@ impl WriteTx {
             }
 
             // Collect outgoing edges from the checkpointed CSR forward file.
-            // CSR is indexed by slot and returns destination slots.
-            // Reconstruct full NodeIds by combining the dst_label_id with the slot.
-            if let Ok(csr) = s.open_fwd() {
-                for &dst_slot in csr.neighbors(node_slot) {
-                    let dst_id = NodeId((*dst_label_id as u64) << 32 | dst_slot);
-                    edges_to_delete.push((node_id, dst_id, rel_type.clone()));
+            // CSR is indexed by slot and returns destination slots. This
+            // table's forward CSR is only meaningful for node_id if node_id's
+            // own label matches the table's declared src label — otherwise
+            // `node_slot` is being used to index a completely unrelated
+            // node's adjacency list, which can spuriously "find" a neighbor
+            // that has nothing to do with node_id (#436: this produced
+            // phantom edges — including a self-loop on node_id when the
+            // node's slot coincided with an unrelated table's dst slot — and
+            // then failed to resolve in the catalog when deleted).
+            if node_label_id == *src_label_id {
+                if let Ok(csr) = s.open_fwd() {
+                    for &dst_slot in csr.neighbors(node_slot) {
+                        let dst_id = NodeId((*dst_label_id as u64) << 32 | dst_slot);
+                        edges_to_delete.push((node_id, dst_id, rel_type.clone()));
+                    }
                 }
             }
 
             // Collect incoming edges from the checkpointed CSR backward file.
-            // CSR is indexed by slot and returns source slots.
-            // Reconstruct full NodeIds by combining the src_label_id with the slot.
-            if let Ok(csr) = s.open_bwd() {
-                for &src_slot in csr.predecessors(node_slot) {
-                    let src_id = NodeId((*src_label_id as u64) << 32 | src_slot);
-                    edges_to_delete.push((src_id, node_id, rel_type.clone()));
+            // CSR is indexed by slot and returns source slots. Symmetric to
+            // the forward case: only meaningful if node_id's label matches
+            // this table's declared dst label.
+            if node_label_id == *dst_label_id {
+                if let Ok(csr) = s.open_bwd() {
+                    for &src_slot in csr.predecessors(node_slot) {
+                        let src_id = NodeId((*src_label_id as u64) << 32 | src_slot);
+                        edges_to_delete.push((src_id, node_id, rel_type.clone()));
+                    }
                 }
             }
         }

--- a/crates/sparrowdb/tests/regression_436_dangling_edges.rs
+++ b/crates/sparrowdb/tests/regression_436_dangling_edges.rs
@@ -1,0 +1,431 @@
+//! Regression tests for GitHub issue #436:
+//! `MATCH (n:Label) DELETE n` leaves dangling edges; `DETACH DELETE` fails
+//! with `relationship type '...' not found in catalog for labels (...)`.
+//!
+//! ## Root cause
+//!
+//! CSR forward/backward files (`crates/sparrowdb-storage/src/csr.rs`) are
+//! indexed by **label-relative slot** — the lower 32 bits of a packed
+//! `NodeId` — not by the packed `NodeId` itself.
+//!
+//! `WriteTx::delete_node` (crates/sparrowdb/src/write_tx.rs) called
+//! `csr.neighbors(node_id.0)` / `csr.predecessors(node_id.0)` with the full
+//! packed id (label bits included). For any label other than label 0 this
+//! value is far larger than `CsrForward::n_nodes`/`CsrBackward::n_nodes`, so
+//! `neighbors`/`predecessors` returned `&[]` unconditionally and the
+//! `NodeHasEdges` safety check never fired for *checkpointed* edges. A node
+//! with a checkpointed edge could therefore be `DELETE`d, leaving that edge's
+//! endpoint pointing at a tombstoned node — the dangling edge from the issue.
+//!
+//! `WriteTx::detach_delete_node` correctly stripped the label bits
+//! (`node_slot`) before indexing, but checked *every* registered
+//! relationship table's CSR regardless of whether `node_id`'s own label
+//! matched that table's declared src/dst label. When `node_id`'s slot number
+//! coincidentally aligned with a valid slot in an unrelated table (a
+//! different label pair entirely — e.g. an ontology-internal `__SO_*` rel
+//! type, or here a second application rel type), the code treated a
+//! completely unrelated adjacency-list entry as if it were `node_id`'s own
+//! edge, including manufacturing a nonexistent self-loop. The bogus edge
+//! tuple then failed `catalog.get_rel_table(src_label, dst_label, rel_type)`
+//! and `DETACH DELETE` returned an `InvalidArgument` "not found in catalog"
+//! error instead of ever deleting the node — exactly the error text from the
+//! issue.
+//!
+//! The fix (crates/sparrowdb/src/write_tx.rs):
+//!   - `delete_node`: index CSR files with `node_id.0 & 0xFFFF_FFFF` (slot,
+//!     not full id), and only consult a table's forward CSR when node_id's
+//!     label matches that table's src label / backward CSR when it matches
+//!     the dst label.
+//!   - `detach_delete_node`: apply the same src/dst label filter before
+//!     consulting a table's CSR, so an unrelated table's coincidental slot
+//!     can never be attributed to node_id.
+//!
+//! All expected values below are derived by hand from each fixture's create
+//! calls, never captured from program output. Every `Result` is asserted on
+//! explicitly — nothing is discarded with `.ok()`.
+
+use sparrowdb::open;
+use sparrowdb_common::Error;
+use sparrowdb_execution::types::Value;
+
+fn make_db() -> (tempfile::TempDir, sparrowdb::GraphDb) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = open(dir.path()).expect("open");
+    (dir, db)
+}
+
+/// Build the same "bump the label counter" prelude every fixture below needs:
+/// without it, the first two labels created (Person, Company) would land on
+/// label_id 0 and 1, and label_id 0 is exactly the case where packed
+/// `NodeId == slot`, masking the original `delete_node` bug entirely. A
+/// throwaway label ensures Person/Company get non-zero label ids, matching
+/// the realistic case (any DB with more than one label already in use).
+fn seed_dummy_label(db: &sparrowdb::GraphDb) {
+    db.execute("CREATE (:Dummy {x: 1})").expect("dummy label");
+}
+
+// ── 1. Plain DELETE on a node with a checkpointed edge must error ──────────
+
+/// Before checkpoint (delta-only edge): `DELETE` on a node with an edge must
+/// return `NodeHasEdges`, not silently succeed. This path was not broken by
+/// #436 (the delta-log check compares full NodeIds, which is unambiguous),
+/// but is included as a baseline so the checkpointed case below has a known-
+/// good control.
+#[test]
+fn delete_without_detach_errors_pre_checkpoint() {
+    let (_dir, db) = make_db();
+    seed_dummy_label(&db);
+
+    db.execute("CREATE (:Person {name: 'Alice'})")
+        .expect("alice");
+    db.execute("CREATE (:Company {name: 'Acme'})")
+        .expect("acme");
+    db.execute(
+        "MATCH (a:Person {name:'Alice'}), (c:Company {name:'Acme'}) CREATE (a)-[:WORKS_FOR]->(c)",
+    )
+    .expect("edge");
+
+    let result = db.execute("MATCH (n:Person {name: 'Alice'}) DELETE n");
+    match result {
+        Err(Error::NodeHasEdges { .. }) => {}
+        other => panic!(
+            "expected NodeHasEdges for DELETE on a node with a (delta-only) edge, got {other:?}"
+        ),
+    }
+
+    // Alice must still exist — the delete must not have partially applied.
+    let alice = db
+        .execute("MATCH (n:Person {name:'Alice'}) RETURN n.name")
+        .expect("match alice");
+    assert_eq!(
+        alice.rows.len(),
+        1,
+        "Alice must still be present after the errored DELETE"
+    );
+}
+
+/// The actual #436 bug: after `checkpoint()`, `DELETE` on a node with an edge
+/// must *still* return `NodeHasEdges`. Pre-fix, `csr.neighbors(node_id.0)`
+/// indexed with the full packed id (Person's label_id is 1 here, since
+/// Dummy took label 0, so `node_id.0 == 1 << 32`, far beyond
+/// `CsrForward::n_nodes`), so the check silently no-opped and the DELETE
+/// succeeded — leaving Acme's incoming edge pointing at a tombstoned Alice.
+#[test]
+fn delete_without_detach_errors_post_checkpoint() {
+    let (dir, db) = make_db();
+    seed_dummy_label(&db);
+
+    db.execute("CREATE (:Person {name: 'Alice'})")
+        .expect("alice");
+    db.execute("CREATE (:Company {name: 'Acme'})")
+        .expect("acme");
+    db.execute(
+        "MATCH (a:Person {name:'Alice'}), (c:Company {name:'Acme'}) CREATE (a)-[:WORKS_FOR]->(c)",
+    )
+    .expect("edge");
+
+    db.checkpoint().expect("checkpoint");
+
+    let result = db.execute("MATCH (n:Person {name: 'Alice'}) DELETE n");
+    match result {
+        Err(Error::NodeHasEdges { .. }) => {}
+        other => panic!(
+            "#436: expected NodeHasEdges for DELETE on a node with a checkpointed edge, got {other:?}"
+        ),
+    }
+
+    // Alice must still exist and the edge must still resolve correctly —
+    // this is the "traverse from the other end" check: if the delete had
+    // silently gone through, this MATCH would still return Alice as a
+    // dangling endpoint even though `n:Person` no longer would.
+    let alice = db
+        .execute("MATCH (n:Person {name:'Alice'}) RETURN n.name")
+        .expect("match alice");
+    assert_eq!(
+        alice.rows.len(),
+        1,
+        "Alice must still be present after the errored DELETE"
+    );
+
+    let traversal = db
+        .execute("MATCH (a:Person)-[:WORKS_FOR]->(c:Company) RETURN a.name, c.name")
+        .expect("traverse");
+    assert_eq!(
+        traversal.rows,
+        vec![vec![
+            Value::String("Alice".into()),
+            Value::String("Acme".into())
+        ]],
+        "the real edge must be unchanged"
+    );
+
+    // Reopen and re-verify: the rejection (and thus the still-live node and
+    // edge) must be durable, not an artifact of in-memory delta-log state.
+    drop(db);
+    let db2 = open(dir.path()).expect("reopen");
+    let alice2 = db2
+        .execute("MATCH (n:Person {name:'Alice'}) RETURN n.name")
+        .expect("match alice after reopen");
+    assert_eq!(alice2.rows.len(), 1, "Alice must survive reopen");
+    let traversal2 = db2
+        .execute("MATCH (a:Person)-[:WORKS_FOR]->(c:Company) RETURN a.name, c.name")
+        .expect("traverse after reopen");
+    assert_eq!(
+        traversal2.rows,
+        vec![vec![
+            Value::String("Alice".into()),
+            Value::String("Acme".into())
+        ]],
+        "the real edge must survive reopen unchanged"
+    );
+}
+
+// ── 2. DETACH DELETE must actually remove the node AND its edges ───────────
+
+/// DETACH DELETE before checkpoint (delta-only edge): node and edge both
+/// gone, verified from both traversal directions, and durable across reopen.
+#[test]
+fn detach_delete_removes_node_and_edge_pre_checkpoint() {
+    let (dir, db) = make_db();
+    seed_dummy_label(&db);
+
+    db.execute("CREATE (:Person {name: 'Alice'})")
+        .expect("alice");
+    db.execute("CREATE (:Company {name: 'Acme'})")
+        .expect("acme");
+    db.execute(
+        "MATCH (a:Person {name:'Alice'}), (c:Company {name:'Acme'}) CREATE (a)-[:WORKS_FOR]->(c)",
+    )
+    .expect("edge");
+
+    db.execute("MATCH (n:Person {name: 'Alice'}) DETACH DELETE n")
+        .expect("DETACH DELETE must succeed");
+
+    let alice = db
+        .execute("MATCH (n:Person {name:'Alice'}) RETURN n.name")
+        .expect("match alice");
+    assert!(
+        alice.rows.is_empty(),
+        "Alice must be gone after DETACH DELETE"
+    );
+
+    let fwd = db
+        .execute("MATCH (a:Person)-[:WORKS_FOR]->(c:Company) RETURN a.name, c.name")
+        .expect("forward traversal");
+    assert!(
+        fwd.rows.is_empty(),
+        "no edge must remain (forward direction)"
+    );
+
+    // Traverse from the other end: a stale edge would show up as Acme
+    // returning a predecessor that no longer exists.
+    let bwd = db
+        .execute("MATCH (c:Company)<-[:WORKS_FOR]-(a:Person) RETURN c.name, a.name")
+        .expect("backward traversal");
+    assert!(
+        bwd.rows.is_empty(),
+        "no edge must remain (backward direction)"
+    );
+
+    drop(db);
+    let db2 = open(dir.path()).expect("reopen");
+    let alice2 = db2
+        .execute("MATCH (n:Person {name:'Alice'}) RETURN n.name")
+        .expect("match alice after reopen");
+    assert!(
+        alice2.rows.is_empty(),
+        "Alice must remain gone after reopen"
+    );
+    let fwd2 = db2
+        .execute("MATCH (a:Person)-[:WORKS_FOR]->(c:Company) RETURN a.name, c.name")
+        .expect("forward traversal after reopen");
+    assert!(fwd2.rows.is_empty(), "no edge must remain after reopen");
+}
+
+/// DETACH DELETE after checkpoint: the CSR-backed path. This is the case
+/// that previously either raised the wrong "not found in catalog" error
+/// (multi-table pollution below) or, in the single-table case, worked by
+/// accident because the collected edge tuple's labels happened to be
+/// self-consistent — verifying it explicitly here as the durability case.
+#[test]
+fn detach_delete_removes_node_and_edge_post_checkpoint() {
+    let (dir, db) = make_db();
+    seed_dummy_label(&db);
+
+    db.execute("CREATE (:Person {name: 'Alice'})")
+        .expect("alice");
+    db.execute("CREATE (:Company {name: 'Acme'})")
+        .expect("acme");
+    db.execute(
+        "MATCH (a:Person {name:'Alice'}), (c:Company {name:'Acme'}) CREATE (a)-[:WORKS_FOR]->(c)",
+    )
+    .expect("edge");
+
+    db.checkpoint().expect("checkpoint");
+
+    db.execute("MATCH (n:Person {name: 'Alice'}) DETACH DELETE n")
+        .expect("DETACH DELETE must succeed post-checkpoint");
+
+    let alice = db
+        .execute("MATCH (n:Person {name:'Alice'}) RETURN n.name")
+        .expect("match alice");
+    assert!(
+        alice.rows.is_empty(),
+        "Alice must be gone after DETACH DELETE"
+    );
+
+    let fwd = db
+        .execute("MATCH (a:Person)-[:WORKS_FOR]->(c:Company) RETURN a.name, c.name")
+        .expect("forward traversal");
+    assert!(
+        fwd.rows.is_empty(),
+        "no checkpointed edge must remain (forward)"
+    );
+    let bwd = db
+        .execute("MATCH (c:Company)<-[:WORKS_FOR]-(a:Person) RETURN c.name, a.name")
+        .expect("backward traversal");
+    assert!(
+        bwd.rows.is_empty(),
+        "no checkpointed edge must remain (backward)"
+    );
+
+    drop(db);
+    let db2 = open(dir.path()).expect("reopen");
+    let alice2 = db2
+        .execute("MATCH (n:Person {name:'Alice'}) RETURN n.name")
+        .expect("match alice after reopen");
+    assert!(
+        alice2.rows.is_empty(),
+        "Alice must remain gone after reopen"
+    );
+    let fwd2 = db2
+        .execute("MATCH (a:Person)-[:WORKS_FOR]->(c:Company) RETURN a.name, c.name")
+        .expect("forward traversal after reopen");
+    assert!(
+        fwd2.rows.is_empty(),
+        "no checkpointed edge must remain after reopen"
+    );
+
+    // Company node itself (never targeted for deletion) must be untouched.
+    let acme = db2
+        .execute("MATCH (n:Company {name:'Acme'}) RETURN n.name")
+        .expect("match acme after reopen");
+    assert_eq!(
+        acme.rows.len(),
+        1,
+        "Acme must survive — only Alice was deleted"
+    );
+}
+
+// ── 3. Cross-table pollution: the exact "not found in catalog" repro ───────
+
+/// Two independent relationship tables (WORKS_FOR: Person→Company, PART_OF:
+/// Widget→Assembly) are checkpointed. Alice (Person, slot 0) is the target
+/// of DETACH DELETE. Because Widget's first node (slot 0) also has an
+/// outgoing PART_OF edge, and Alice's own slot is 0, the pre-fix code
+/// misattributed PART_OF's CSR entries to Alice — producing edge tuples
+/// whose (src_label, dst_label, rel_type) combination did not exist in the
+/// catalog, which is exactly the `relationship type '...' not found in
+/// catalog for labels (...)` error from the issue.
+///
+/// The fix must both (a) let DETACH DELETE succeed, and (b) leave the
+/// unrelated Widget→Assembly edge completely untouched — a naive fix that
+/// merely suppressed the error without fixing the label filter could still
+/// silently delete the wrong edge.
+#[test]
+fn detach_delete_does_not_cross_pollute_unrelated_rel_table() {
+    let (dir, db) = make_db();
+
+    // Person = label 0, Company = label 1 (first two labels created).
+    db.execute("CREATE (:Person {name: 'Alice'})")
+        .expect("alice");
+    db.execute("CREATE (:Company {name: 'Acme'})")
+        .expect("acme");
+    db.execute(
+        "MATCH (a:Person {name:'Alice'}), (c:Company {name:'Acme'}) CREATE (a)-[:WORKS_FOR]->(c)",
+    )
+    .expect("works_for edge");
+
+    // Widget = label 2, Assembly = label 3. W0 is Widget's slot 0, same as
+    // Alice's slot 0 in Person — the coincidence the pre-fix code mishandled.
+    db.execute("CREATE (:Widget {name: 'W0'})").expect("w0");
+    db.execute("CREATE (:Assembly {name: 'AsmX'})")
+        .expect("asmx");
+    db.execute(
+        "MATCH (w:Widget {name:'W0'}), (asm:Assembly {name:'AsmX'}) CREATE (w)-[:PART_OF]->(asm)",
+    )
+    .expect("part_of edge");
+
+    db.checkpoint().expect("checkpoint");
+
+    let result = db.execute("MATCH (n:Person {name: 'Alice'}) DETACH DELETE n");
+    match result {
+        Ok(_) => {}
+        Err(e) => panic!(
+            "#436: DETACH DELETE must succeed, not fail resolving an unrelated \
+             rel table's catalog entry; got {e:?}"
+        ),
+    }
+
+    // Alice and her WORKS_FOR edge are gone.
+    let alice = db
+        .execute("MATCH (n:Person {name:'Alice'}) RETURN n.name")
+        .expect("match alice");
+    assert!(alice.rows.is_empty(), "Alice must be gone");
+    let works_for = db
+        .execute("MATCH (a:Person)-[:WORKS_FOR]->(c:Company) RETURN a.name, c.name")
+        .expect("works_for traversal");
+    assert!(works_for.rows.is_empty(), "WORKS_FOR edge must be gone");
+
+    // The completely unrelated Widget -[:PART_OF]-> Assembly edge, and both
+    // of its endpoints, must be untouched.
+    let w0 = db
+        .execute("MATCH (n:Widget {name:'W0'}) RETURN n.name")
+        .expect("match w0");
+    assert_eq!(
+        w0.rows.len(),
+        1,
+        "W0 must be untouched by Alice's DETACH DELETE"
+    );
+    let asmx = db
+        .execute("MATCH (n:Assembly {name:'AsmX'}) RETURN n.name")
+        .expect("match asmx");
+    assert_eq!(
+        asmx.rows.len(),
+        1,
+        "AsmX must be untouched by Alice's DETACH DELETE"
+    );
+    let part_of = db
+        .execute("MATCH (w:Widget)-[:PART_OF]->(a:Assembly) RETURN w.name, a.name")
+        .expect("part_of traversal");
+    assert_eq!(
+        part_of.rows,
+        vec![vec![
+            Value::String("W0".to_string()),
+            Value::String("AsmX".to_string())
+        ]],
+        "PART_OF edge must survive Alice's unrelated DETACH DELETE"
+    );
+
+    // Durable across reopen.
+    drop(db);
+    let db2 = open(dir.path()).expect("reopen");
+    let part_of2 = db2
+        .execute("MATCH (w:Widget)-[:PART_OF]->(a:Assembly) RETURN w.name, a.name")
+        .expect("part_of traversal after reopen");
+    assert_eq!(
+        part_of2.rows,
+        vec![vec![
+            Value::String("W0".to_string()),
+            Value::String("AsmX".to_string())
+        ]],
+        "PART_OF edge must survive reopen"
+    );
+    let alice2 = db2
+        .execute("MATCH (n:Person {name:'Alice'}) RETURN n.name")
+        .expect("match alice after reopen");
+    assert!(
+        alice2.rows.is_empty(),
+        "Alice must remain gone after reopen"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #436 — two related node-deletion bugs, both rooted in `WriteTx` treating a CSR slot number as unambiguous node identity (the same root-cause class already fixed on the *read* path for #415/#427/#429/#431 — see `regression_slot_identity_root_cause.rs` — now fixed on the *write* path).

**1. `DELETE` (no `DETACH`) left checkpointed edges dangling.**
`WriteTx::delete_node`'s `NodeHasEdges` safety check indexed CSR forward/backward files with the *full packed* `NodeId` (label bits included) instead of the label-relative slot. For any label other than label 0 this value overflows `CsrForward`/`CsrBackward::n_nodes`, so `neighbors()`/`predecessors()` silently returned `&[]` — the check never fired for checkpointed edges. A node with a checkpointed edge could be `DELETE`d, leaving the edge pointing at a tombstoned node.

**2. `DETACH DELETE` failed with `relationship type '...' not found in catalog for labels (...)`.**
`WriteTx::detach_delete_node` correctly stripped the label bits before indexing, but consulted *every* registered relationship table's CSR regardless of whether the deleted node's own label matched that table's declared src/dst label. When the node's slot number coincidentally aligned with a valid slot in an unrelated table, the code attributed that table's adjacency data to the node — including manufacturing a nonexistent self-loop — and the bogus edge tuple then failed to resolve in the catalog, surfacing exactly the reported error.

## Fix

Both methods now only consult a relationship table's forward CSR when the node's label matches that table's declared src label, and its backward CSR when it matches the dst label — mirroring the label-filtered lookup pattern already established on the read path.

## Verification

`crates/sparrowdb/tests/regression_436_dangling_edges.rs` adds 5 e2e tests against a real `GraphDb` on `tempfile::TempDir`, asserting on every `Result` (no `.ok()`), covering both `DELETE` and `DETACH DELETE`, both directions of traversal, pre- and post-`checkpoint()`, and full reopen. All expected values were derived by hand from each fixture's `CREATE` calls.

Confirmed against the pre-fix commit (712ace4): the 3 bug-catching tests fail with the exact reported symptoms —
- `delete_without_detach_errors_post_checkpoint`: DELETE silently succeeds instead of returning `NodeHasEdges`
- `detach_delete_removes_node_and_edge_post_checkpoint` / `detach_delete_does_not_cross_pollute_unrelated_rel_table`: `InvalidArgument("relationship type '...' not found in catalog for labels (...)")`

All pass with the fix applied.

## Test plan
- [x] `regression_436_dangling_edges.rs` (5 new tests) — pass with fix, fail (3/5) against pre-fix commit with the exact reported symptoms
- [x] `delete_edge.rs`, `spa_216_delete_node.rs`, `spa_186_csr_nodeid.rs`, `spa_201_csr_backward.rs` — pass
- [x] `regression_486_edge_direction.rs`, `regression_487_488_edge_direction.rs` — pass
- [x] `spa_222_csr_lazy_load.rs` (slow suite) — pass
- [x] `cargo fmt`, `cargo clippy -p sparrowdb -p sparrowdb-execution --all-targets` — clean
- [x] `cargo check -p sparrowdb` — clean
- [ ] Full `cargo test -p sparrowdb` — running in background as extra diligence; will report if it surfaces anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE