### PR TITLE
fix(execution): projection resolves RETURN columns by AST expr, not display name (closes #444, #430)

### DIFF
--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -2087,14 +2087,27 @@ fn prop_name_to_col_id(name: &str) -> u32 {
     col_id_of(name)
 }
 
-fn collect_col_ids_from_columns(column_names: &[String]) -> Vec<u32> {
+/// Collect column IDs referenced by property-access RETURN items.
+///
+/// Dispatches on the AST expression (`item.expr`), not on the (possibly
+/// aliased) output column name. `collect_col_ids_from_columns` — the function
+/// this replaces — parsed the *display* name (`RETURN n.name AS personName`
+/// produced `"personName"`) as if it encoded `var.prop`, so the property to
+/// fetch from storage was hashed from the alias instead of `name`. That
+/// silently omitted the real column from the read, which is the root cause of
+/// #444 (aliased projection returns Null) and part of #430's phantom rows.
+///
+/// See `project_row` for the corresponding projection-time fix, and
+/// `collect_col_ids_for_var_from_items` (#369) for the same item-based
+/// pattern already established on the hop/traversal paths.
+fn collect_col_ids_from_return_items(items: &[ReturnItem]) -> Vec<u32> {
     let mut ids = Vec::new();
-    for name in column_names {
-        // name could be "var.col_N" or "col_N"
-        let prop = name.split('.').next_back().unwrap_or(name.as_str());
-        let col_id = prop_name_to_col_id(prop);
-        if !ids.contains(&col_id) {
-            ids.push(col_id);
+    for item in items {
+        if let Expr::PropAccess { prop, .. } = &item.expr {
+            let col_id = prop_name_to_col_id(prop);
+            if !ids.contains(&col_id) {
+                ids.push(col_id);
+            }
         }
     }
     ids
@@ -2639,50 +2652,41 @@ fn eval_expr(expr: &Expr, vals: &HashMap<String, Value>) -> Value {
     }
 }
 
+/// Project a scanned node's properties into RETURN columns.
+///
+/// Dispatches on the AST expression (`items[i].expr`), not on the (possibly
+/// aliased) output column name — this fixes #444: `RETURN n.name AS
+/// personName` must resolve `n.name`, not `"personName"`. The old
+/// implementation split the *output* column string on `.` and hashed
+/// whatever followed, which only happened to work when the alias equalled
+/// the property name.
+///
+/// Every call site only reaches `project_row` once `id(var)`, `labels(var)`,
+/// bare `var`, and every other non-aggregate `FnCall` have already been
+/// routed to the eval path (`needs_node_ref_in_return` /
+/// `expr_needs_eval_path`, checked by every caller before choosing between
+/// this fast path and the eval path). So every item here is guaranteed to be
+/// a `PropAccess`; the `_ => Value::Null` arm is a defensive fallback, not a
+/// reachable case.
 fn project_row(
     props: &[(u32, u64)],
-    column_names: &[String],
-    _col_ids: &[u32],
-    // Variable name for the scanned node (e.g. "n"), used for labels(n) columns.
+    items: &[ReturnItem],
+    // Variable name for the scanned node, used to disambiguate PropAccess.
     var_name: &str,
-    // Primary label for the scanned node, used for labels(n) columns.
-    node_label: &str,
     store: &NodeStore,
-    // NodeId of the scanned node, used for id(var) columns.
-    node_id: Option<NodeId>,
 ) -> Vec<Value> {
-    column_names
+    items
         .iter()
-        .map(|col_name| {
-            // Handle id(var) column — returns the node's integer id.
-            if let Some(inner) = col_name
-                .strip_prefix("id(")
-                .and_then(|s| s.strip_suffix(')'))
-            {
-                if inner == var_name {
-                    if let Some(nid) = node_id {
-                        return Value::Int64(nid.0 as i64);
-                    }
-                }
-                return Value::Null;
+        .map(|item| match &item.expr {
+            Expr::PropAccess { var, prop } if var.as_str() == var_name => {
+                let col_id = prop_name_to_col_id(prop);
+                props
+                    .iter()
+                    .find(|(c, _)| *c == col_id)
+                    .map(|(_, v)| decode_raw_val(*v, store))
+                    .unwrap_or(Value::Null)
             }
-            // Handle labels(var) column.
-            if let Some(inner) = col_name
-                .strip_prefix("labels(")
-                .and_then(|s| s.strip_suffix(')'))
-            {
-                if inner == var_name && !node_label.is_empty() {
-                    return Value::List(vec![Value::String(node_label.to_string())]);
-                }
-                return Value::Null;
-            }
-            let prop = col_name.split('.').next_back().unwrap_or(col_name.as_str());
-            let col_id = prop_name_to_col_id(prop);
-            props
-                .iter()
-                .find(|(c, _)| *c == col_id)
-                .map(|(_, v)| decode_raw_val(*v, store))
-                .unwrap_or(Value::Null)
+            _ => Value::Null,
         })
         .collect()
 }

--- a/crates/sparrowdb-execution/src/engine/pipeline_exec.rs
+++ b/crates/sparrowdb-execution/src/engine/pipeline_exec.rs
@@ -1095,12 +1095,9 @@ impl Engine {
             // Project output row.
             let row = project_row(
                 &x_props,
-                column_names,
-                &col_ids_x,
+                &m.return_clause.items,
                 x_var,
-                &label,
                 &self.snapshot.store,
-                Some(x_node_id),
             );
             rows.push(row);
 
@@ -1842,7 +1839,7 @@ impl Engine {
         tracing::debug!(label = %label, hwm = hwm, "chunked pipeline: label scan");
 
         // Collect all col_ids needed (RETURN + WHERE + inline prop filters).
-        let mut all_col_ids: Vec<u32> = collect_col_ids_from_columns(column_names);
+        let mut all_col_ids: Vec<u32> = collect_col_ids_from_return_items(&m.return_clause.items);
         if let Some(ref wexpr) = m.where_clause {
             collect_col_ids_from_expr(wexpr, &mut all_col_ids);
         }
@@ -1912,12 +1909,9 @@ impl Engine {
                 // Project RETURN columns.
                 let row = project_row(
                     &props,
-                    column_names,
-                    &all_col_ids,
+                    &m.return_clause.items,
                     var_name,
-                    &label,
                     &self.snapshot.store,
-                    Some(node_id),
                 );
                 rows.push(row);
             }

--- a/crates/sparrowdb-execution/src/engine/scan.rs
+++ b/crates/sparrowdb-execution/src/engine/scan.rs
@@ -350,8 +350,8 @@ impl Engine {
 
         // Check if this is a relationship hop pattern.
         if !pat.rels.is_empty() {
-            // Relationship traversal in a pipeline MATCH stage.
-            // Currently supports single-hop: (src)-[:REL]->(dst)
+            // Relationship traversal in a pipeline MATCH stage. Handles any
+            // number of fixed hops, e.g. (src)-[:REL]->(mid)-[:REL]->(dst) (#430).
             return self.execute_pipeline_match_hop(pat, where_clause, binding);
         }
 
@@ -405,30 +405,33 @@ impl Engine {
         Ok(result)
     }
 
-    /// Execute a single-hop relationship traversal in a pipeline MATCH stage.
+    /// Execute a relationship-chain traversal in a pipeline MATCH stage.
     ///
-    /// Handles `(src:Label {props})-[:REL]->(dst:Label {props})` where `src` or `dst`
-    /// variable names may already be bound in `binding`.
+    /// Handles `(src:Label {props})-[:REL]->(mid:Label {props})-[:REL]->(dst:Label {props})…`
+    /// — any number of fixed hops — where the leading variable may already be
+    /// bound in `binding` from a preceding `WITH`.
+    ///
+    /// #430: this used to read only `pat.rels[0]` / `pat.nodes[0..2]` and
+    /// silently drop every hop after the first, so `WITH a MATCH
+    /// (a)-[:R]->(b)-[:S]->(c)` answered the one-hop pattern `(a)-[:R]->(b)`
+    /// instead: `c` was never bound (it projected as NULL), and a pattern
+    /// whose second hop didn't exist at all still returned a row. This walks
+    /// every hop in `pat.rels` in turn, threading the accumulated binding map
+    /// forward the same way `execute_n_hop` does for the leading MATCH.
     pub(crate) fn execute_pipeline_match_hop(
         &self,
         pat: &sparrowdb_cypher::ast::PathPattern,
         where_clause: Option<&Expr>,
         binding: &HashMap<String, Value>,
     ) -> Result<Vec<HashMap<String, Value>>> {
-        if pat.nodes.len() < 2 || pat.rels.is_empty() {
+        if pat.nodes.len() < 2 || pat.rels.is_empty() || pat.nodes.len() != pat.rels.len() + 1 {
             return Ok(vec![]);
         }
 
-        // #421: this executor takes a single step along `rels[0]` and ignores
-        // any quantifier on it.  A variable-length relationship inside a
-        // pipeline MATCH stage (`WITH … MATCH (a)-[:R*1..2]->(b) …`) would
-        // therefore be answered with depth-1 matches only — the same silent
-        // truncation #421 fixed in the top-level MATCH path.  Reject instead:
-        // an error the caller can see beats data they cannot check.
-        //
-        // It also drops `rels[1..]` of any multi-hop pattern, which is the same
-        // failure without a quantifier; that is tracked separately as #430 and
-        // deliberately left alone here.
+        // #421: reject variable-length quantifiers anywhere in the chain — a
+        // pipeline MATCH stage takes one fixed step per hop and would
+        // otherwise silently truncate `*min..max` to depth 1, the same
+        // failure #421 fixed in the top-level MATCH path.
         if pat
             .rels
             .iter()
@@ -442,30 +445,16 @@ impl Engine {
             ));
         }
 
-        let src_pat = &pat.nodes[0];
-        let dst_pat = &pat.nodes[1];
-        let rel_pat = &pat.rels[0];
-
-        let dst_label = dst_pat.labels.first().cloned().unwrap_or_default();
-
-        let dst_label_id = match self.snapshot.catalog.get_label(&dst_label)? {
-            Some(id) => id as u32,
-            None => return Ok(vec![]),
-        };
-
-        let dst_col_ids: Vec<u32> = self
-            .snapshot
-            .store
-            .col_ids_for_label(dst_label_id)
-            .unwrap_or_default();
         let params = self.dollar_params();
 
-        // Find candidate src nodes.
+        // ── Hop 0: resolve the source node(s) ───────────────────────────────
+        //
         // Check binding BEFORE resolving the src label: when the src variable is
         // already bound as a NodeRef (from a preceding WITH stage), we derive the
         // src_label_id directly from the NodeId encoding and skip the label scan
         // entirely.  This is the critical fix for issue #355: `WITH a MATCH (a)-…`
         // where `a` has no label annotation on the second MATCH pattern.
+        let src_pat = &pat.nodes[0];
         let bound_src_nid: Option<NodeId> = binding
             .get(&src_pat.var)
             .or_else(|| binding.get(&format!("{}.__node_id__", src_pat.var)))
@@ -508,7 +497,6 @@ impl Engine {
             .col_ids_for_label(src_label_id)
             .unwrap_or_default();
 
-        // Find candidate src nodes.
         let src_candidates: Vec<NodeId> = if let Some(nid) = bound_src_nid {
             vec![nid]
         } else {
@@ -533,48 +521,88 @@ impl Engine {
             cands
         };
 
-        let rel_table_id = self.resolve_rel_table_id(src_label_id, dst_label_id, &rel_pat.rel_type);
-
-        let mut result: Vec<HashMap<String, Value>> = Vec::new();
+        // Frontier: one entry per partial match so far — the current node's
+        // label (needed to resolve the next hop's rel table), its NodeId, and
+        // the row_vals accumulated for every variable bound up to this point.
+        let mut frontier: Vec<(u32, NodeId, HashMap<String, Value>)> =
+            Vec::with_capacity(src_candidates.len());
         for src_id in src_candidates {
-            let src_slot = src_id.0 & 0xFFFF_FFFF;
-            let dst_slots: Vec<u64> = match &rel_table_id {
-                RelTableLookup::Found(rtid) => self.csr_neighbors(*rtid, src_slot),
-                RelTableLookup::NotFound => continue,
-                // Untyped edge: restrict to tables that run from this node's
-                // label to `dst_label_id`, which is the label the destination
-                // NodeId is built from a few lines below.
-                RelTableLookup::All => self.csr_neighbor_slots_to_label(
-                    src_slot,
-                    src_label_id,
-                    Some(dst_label_id),
-                    &[],
-                ),
-            };
-            // Also check the delta.  Slots are label-relative, so an edge that
-            // lands on a different label must not be read as `dst_label_id`.
-            let delta_slots: Vec<u64> = self
-                .read_delta_all()
-                .into_iter()
-                .filter(|r| {
-                    let r_src_label = (r.src.0 >> 32) as u32;
-                    let r_src_slot = r.src.0 & 0xFFFF_FFFF;
-                    let r_dst_label = (r.dst.0 >> 32) as u32;
-                    r_src_label == src_label_id
-                        && r_src_slot == src_slot
-                        && r_dst_label == dst_label_id
-                })
-                .map(|r| r.dst.0 & 0xFFFF_FFFF)
-                .collect();
-            let all_slots: std::collections::HashSet<u64> =
-                dst_slots.into_iter().chain(delta_slots).collect();
+            let src_props = self
+                .snapshot
+                .store
+                .get_node_raw(src_id, &src_col_ids)
+                .unwrap_or_default();
+            let mut row_vals =
+                build_row_vals(&src_props, &src_pat.var, &src_col_ids, &self.snapshot.store);
+            row_vals.insert(src_pat.var.clone(), Value::NodeRef(src_id));
+            row_vals.insert(
+                format!("{}.__node_id__", src_pat.var),
+                Value::NodeRef(src_id),
+            );
+            frontier.push((src_label_id, src_id, row_vals));
+        }
 
-            for dst_slot in all_slots {
-                let dst_id = NodeId(((dst_label_id as u64) << 32) | dst_slot);
-                if self.is_node_tombstoned(dst_id) {
-                    continue;
-                }
-                if let Ok(dst_props) = self.snapshot.store.get_node_raw(dst_id, &dst_col_ids) {
+        // ── Walk every hop, threading the accumulated binding map forward ───
+        for (hop_idx, rel_pat) in pat.rels.iter().enumerate() {
+            let dst_pat = &pat.nodes[hop_idx + 1];
+            let dst_label = dst_pat.labels.first().cloned().unwrap_or_default();
+            let dst_label_id = match self.snapshot.catalog.get_label(&dst_label)? {
+                Some(id) => id as u32,
+                None => return Ok(vec![]),
+            };
+            let dst_col_ids: Vec<u32> = self
+                .snapshot
+                .store
+                .col_ids_for_label(dst_label_id)
+                .unwrap_or_default();
+
+            let mut next_frontier: Vec<(u32, NodeId, HashMap<String, Value>)> = Vec::new();
+
+            for (cur_label_id, cur_id, row_vals) in frontier {
+                let rel_table_id =
+                    self.resolve_rel_table_id(cur_label_id, dst_label_id, &rel_pat.rel_type);
+                let cur_slot = cur_id.0 & 0xFFFF_FFFF;
+                let dst_slots: Vec<u64> = match &rel_table_id {
+                    RelTableLookup::Found(rtid) => self.csr_neighbors(*rtid, cur_slot),
+                    RelTableLookup::NotFound => continue,
+                    // Untyped edge: restrict to tables that run from this
+                    // node's label to `dst_label_id`, the label the
+                    // destination NodeId is built from a few lines below.
+                    RelTableLookup::All => self.csr_neighbor_slots_to_label(
+                        cur_slot,
+                        cur_label_id,
+                        Some(dst_label_id),
+                        &[],
+                    ),
+                };
+                // Also check the delta.  Slots are label-relative, so an edge
+                // that lands on a different label must not be read as
+                // `dst_label_id`.
+                let delta_slots: Vec<u64> = self
+                    .read_delta_all()
+                    .into_iter()
+                    .filter(|r| {
+                        let r_src_label = (r.src.0 >> 32) as u32;
+                        let r_src_slot = r.src.0 & 0xFFFF_FFFF;
+                        let r_dst_label = (r.dst.0 >> 32) as u32;
+                        r_src_label == cur_label_id
+                            && r_src_slot == cur_slot
+                            && r_dst_label == dst_label_id
+                    })
+                    .map(|r| r.dst.0 & 0xFFFF_FFFF)
+                    .collect();
+                let all_slots: std::collections::HashSet<u64> =
+                    dst_slots.into_iter().chain(delta_slots).collect();
+
+                for dst_slot in all_slots {
+                    let dst_id = NodeId(((dst_label_id as u64) << 32) | dst_slot);
+                    if self.is_node_tombstoned(dst_id) {
+                        continue;
+                    }
+                    let dst_props = match self.snapshot.store.get_node_raw(dst_id, &dst_col_ids) {
+                        Ok(p) => p,
+                        Err(_) => continue,
+                    };
                     if !self.matches_prop_filter_with_binding(
                         &dst_props,
                         &dst_pat.props,
@@ -583,46 +611,42 @@ impl Engine {
                     ) {
                         continue;
                     }
-                    let src_props = self
-                        .snapshot
-                        .store
-                        .get_node_raw(src_id, &src_col_ids)
-                        .unwrap_or_default();
-                    let mut row_vals = build_row_vals(
-                        &src_props,
-                        &src_pat.var,
-                        &src_col_ids,
-                        &self.snapshot.store,
-                    );
-                    row_vals.extend(build_row_vals(
+                    let mut new_row_vals = row_vals.clone();
+                    new_row_vals.extend(build_row_vals(
                         &dst_props,
                         &dst_pat.var,
                         &dst_col_ids,
                         &self.snapshot.store,
                     ));
-                    // Merge upstream bindings.
-                    row_vals.extend(binding.clone());
-                    row_vals.insert(src_pat.var.clone(), Value::NodeRef(src_id));
-                    row_vals.insert(
-                        format!("{}.__node_id__", src_pat.var),
-                        Value::NodeRef(src_id),
-                    );
-                    row_vals.insert(dst_pat.var.clone(), Value::NodeRef(dst_id));
-                    row_vals.insert(
+                    new_row_vals.insert(dst_pat.var.clone(), Value::NodeRef(dst_id));
+                    new_row_vals.insert(
                         format!("{}.__node_id__", dst_pat.var),
                         Value::NodeRef(dst_id),
                     );
-
-                    if let Some(wexpr) = where_clause {
-                        let mut row_vals_p = row_vals.clone();
-                        row_vals_p.extend(params.clone());
-                        if !self.eval_where_graph(wexpr, &row_vals_p) {
-                            continue;
-                        }
-                    }
-                    result.push(row_vals);
+                    next_frontier.push((dst_label_id, dst_id, new_row_vals));
                 }
             }
+
+            frontier = next_frontier;
+            if frontier.is_empty() {
+                break;
+            }
+        }
+
+        // ── Merge upstream binding and apply the trailing WHERE clause ──────
+        let mut result: Vec<HashMap<String, Value>> = Vec::new();
+        for (_label_id, _id, row_vals) in frontier {
+            let mut final_row = binding.clone();
+            final_row.extend(row_vals);
+
+            if let Some(wexpr) = where_clause {
+                let mut row_vals_p = final_row.clone();
+                row_vals_p.extend(params.clone());
+                if !self.eval_where_graph(wexpr, &row_vals_p) {
+                    continue;
+                }
+            }
+            result.push(final_row);
         }
         Ok(result)
     }
@@ -1055,7 +1079,7 @@ impl Engine {
             }
 
             // Fetch all properties we might need for RETURN projection.
-            let all_col_ids: Vec<u32> = collect_col_ids_from_columns(column_names);
+            let all_col_ids: Vec<u32> = collect_col_ids_from_return_items(&m.return_clause.items);
             let nullable_props = self
                 .snapshot
                 .store
@@ -1065,31 +1089,33 @@ impl Engine {
                 .filter_map(|&(col_id, opt)| opt.map(|v| (col_id, v)))
                 .collect();
 
-            // Project the RETURN columns.
-            let row: Vec<Value> = column_names
+            // Project the RETURN columns. Dispatch on the AST expression, not
+            // on the (possibly aliased) output column name — see #444.
+            let row: Vec<Value> = m
+                .return_clause
+                .items
                 .iter()
-                .map(|col_name| {
+                .map(|item| match &item.expr {
                     // Resolve out_degree(var) / degree(var) → degree value.
-                    let degree_col_name_out = format!("out_degree({node_var})");
-                    let degree_col_name_deg = format!("degree({node_var})");
-                    if col_name == &degree_col_name_out
-                        || col_name == &degree_col_name_deg
-                        || col_name == "degree"
-                        || col_name == "out_degree"
-                    {
-                        return Value::Int64(degree as i64);
+                    Expr::FnCall { name, args } => {
+                        let name_lc = name.to_lowercase();
+                        let arg_matches =
+                            matches!(args.first(), Some(Expr::Var(v)) if v == node_var);
+                        if (name_lc == "out_degree" || name_lc == "degree") && arg_matches {
+                            Value::Int64(degree as i64)
+                        } else {
+                            Value::Null
+                        }
                     }
-                    // Resolve property accesses: "var.prop" or "prop".
-                    let prop = col_name
-                        .split_once('.')
-                        .map(|(_, p)| p)
-                        .unwrap_or(col_name.as_str());
-                    let col_id = prop_name_to_col_id(prop);
-                    props
-                        .iter()
-                        .find(|(c, _)| *c == col_id)
-                        .map(|(_, v)| decode_raw_val(*v, &self.snapshot.store))
-                        .unwrap_or(Value::Null)
+                    Expr::PropAccess { prop, .. } => {
+                        let col_id = prop_name_to_col_id(prop);
+                        props
+                            .iter()
+                            .find(|(c, _)| *c == col_id)
+                            .map(|(_, v)| decode_raw_val(*v, &self.snapshot.store))
+                            .unwrap_or(Value::Null)
+                    }
+                    _ => Value::Null,
                 })
                 .collect();
 
@@ -1379,10 +1405,6 @@ impl Engine {
             .cloned()
             .collect();
 
-        // We need all column names from leading MATCH variables for the scan.
-        // Collect all column names referenced by lead-side return items.
-        let lead_col_names = extract_return_column_names(&lead_return_items);
-
         // Check that the leading MATCH label exists.
         if mom.match_patterns.is_empty() || mom.match_patterns[0].nodes.is_empty() {
             let null_row = vec![Value::Null; column_names.len()];
@@ -1406,7 +1428,7 @@ impl Engine {
 
         // Collect all col_ids needed for lead scan.
         let lead_all_col_ids: Vec<u32> = {
-            let mut ids = collect_col_ids_from_columns(&lead_col_names);
+            let mut ids = collect_col_ids_from_return_items(&lead_return_items);
             if let Some(ref wexpr) = mom.match_where {
                 collect_col_ids_from_expr(wexpr, &mut ids);
             }
@@ -1809,7 +1831,7 @@ impl Engine {
 
         // Collect all col_ids we need: RETURN columns + WHERE clause columns +
         // inline prop filter columns.
-        let col_ids = collect_col_ids_from_columns(column_names);
+        let col_ids = collect_col_ids_from_return_items(&m.return_clause.items);
         let mut all_col_ids: Vec<u32> = col_ids.clone();
         // Add col_ids referenced by the WHERE clause.
         if let Some(ref where_expr) = m.where_clause {
@@ -2161,12 +2183,9 @@ impl Engine {
                 // Project RETURN columns directly (fast path).
                 let row = project_row(
                     &props,
-                    column_names,
-                    &all_col_ids,
+                    &m.return_clause.items,
                     var_name,
-                    &label,
                     &self.snapshot.store,
-                    Some(node_id),
                 );
                 rows.push(row);
                 // SPA-198: early exit when we have enough rows for SKIP+LIMIT.
@@ -2286,25 +2305,11 @@ impl Engine {
                     }
                     raw_rows.push(row_vals);
                 } else {
-                    // Fast path: find the primary label name for project_row.
-                    let sec_primary_lid = (sec_node_id.0 >> 32) as u32;
-                    let sec_primary_label = self
-                        .snapshot
-                        .catalog
-                        .list_labels()
-                        .unwrap_or_default()
-                        .into_iter()
-                        .find(|(id, _)| *id as u32 == sec_primary_lid)
-                        .map(|(_, name)| name)
-                        .unwrap_or_default();
                     let row = project_row(
                         &props,
-                        column_names,
-                        &all_col_ids,
+                        &m.return_clause.items,
                         sec_var_name,
-                        &sec_primary_label,
                         &self.snapshot.store,
-                        Some(sec_node_id),
                     );
                     rows.push(row);
                 }
@@ -2369,7 +2374,7 @@ impl Engine {
         }
 
         // Collect col_ids.
-        let mut all_col_ids: Vec<u32> = collect_col_ids_from_columns(column_names);
+        let mut all_col_ids: Vec<u32> = collect_col_ids_from_return_items(&m.return_clause.items);
         if let Some(ref where_expr) = m.where_clause {
             collect_col_ids_from_expr(where_expr, &mut all_col_ids);
         }
@@ -2462,24 +2467,11 @@ impl Engine {
                 }
                 raw_rows.push(row_vals);
             } else {
-                let prim_lid = (node_id.0 >> 32) as u32;
-                let prim_label_name = self
-                    .snapshot
-                    .catalog
-                    .list_labels()
-                    .unwrap_or_default()
-                    .into_iter()
-                    .find(|(id, _)| *id as u32 == prim_lid)
-                    .map(|(_, name)| name)
-                    .unwrap_or_default();
                 let row = project_row(
                     &props,
-                    column_names,
-                    &all_col_ids,
+                    &m.return_clause.items,
                     var_name,
-                    &prim_label_name,
                     &self.snapshot.store,
-                    Some(node_id),
                 );
                 rows.push(row);
             }
@@ -2524,7 +2516,7 @@ impl Engine {
         let var_name = node.var.as_str();
 
         // Collect col_ids needed across all labels (same set for every label).
-        let mut all_col_ids: Vec<u32> = collect_col_ids_from_columns(column_names);
+        let mut all_col_ids: Vec<u32> = collect_col_ids_from_return_items(&m.return_clause.items);
         if let Some(ref where_expr) = m.where_clause {
             collect_col_ids_from_expr(where_expr, &mut all_col_ids);
         }
@@ -2642,12 +2634,9 @@ impl Engine {
                 } else {
                     let row = project_row(
                         &props,
-                        column_names,
-                        &all_col_ids,
+                        &m.return_clause.items,
                         var_name,
-                        label_name,
                         &self.snapshot.store,
-                        Some(node_id),
                     );
                     rows.push(row);
                 }

--- a/crates/sparrowdb/tests/regression_444_430_null_projection.rs
+++ b/crates/sparrowdb/tests/regression_444_430_null_projection.rs
@@ -1,0 +1,265 @@
+//! Regression tests for #444 and #430 — projection silently fabricating Null.
+//!
+//! Both issues share one root cause: the fast (non-eval) projection paths
+//! resolved a RETURN column's *stored property* by re-parsing the (possibly
+//! aliased) **output** column name instead of dispatching on the underlying
+//! AST expression (`ReturnItem.expr`). Two independent symptoms fell out of
+//! that:
+//!
+//! - **#444**: `RETURN n.name AS personName` hashed `"personName"` as if it
+//!   were the property name, so the wrong (nonexistent) column was fetched
+//!   from storage and the value came back `Null` — silently wrong, not an
+//!   error.
+//! - **#430**: `execute_pipeline_match_hop` (the executor for a MATCH stage
+//!   following `WITH`) only ever read `pat.rels[0]` / `pat.nodes[0..2]` and
+//!   dropped every hop after the first. A 2+-hop pattern after `WITH` bound
+//!   only the first destination node; every later variable in the RETURN
+//!   clause silently projected `Null` — or, worse, produced a row at all for
+//!   a path that does not exist in the graph.
+//!
+//! All expected values below are derived by hand from the fixtures, never
+//! captured from program output (see repo `feedback_derive_expected_from_source`).
+
+use sparrowdb::GraphDb;
+use sparrowdb_execution::Value;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// #444 — aliased property projection
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// One `Person` node: name="Alice", age=30. A second node, `Eve`, has a
+/// `name` but no `age` at all — the control for "genuinely null" below.
+fn setup_alias_graph() -> (GraphDb, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    db.execute("CREATE (n:Person {name: 'Alice', age: 30})")
+        .expect("CREATE Alice");
+    db.execute("CREATE (n:Person {name: 'Eve'})")
+        .expect("CREATE Eve (no age)");
+    (db, dir)
+}
+
+/// alias == prop name: was already correct pre-fix; locks in no regression.
+#[test]
+fn alias_equal_to_property_name_is_correct() {
+    let (db, _dir) = setup_alias_graph();
+    let r = db
+        .execute("MATCH (n:Person {name: 'Alice'}) RETURN n.name AS name")
+        .unwrap();
+    assert_eq!(r.columns, vec!["name"]);
+    assert_eq!(r.rows, vec![vec![Value::String("Alice".into())]]);
+}
+
+/// alias != prop name: the exact #444 reproduction.
+#[test]
+fn alias_different_from_property_name_resolves_correctly() {
+    let (db, _dir) = setup_alias_graph();
+    let r = db
+        .execute("MATCH (n:Person {name: 'Alice'}) RETURN n.name AS personName")
+        .unwrap();
+    assert_eq!(r.columns, vec!["personName"]);
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::String("Alice".into())]],
+        "personName must resolve n.name, not Null (#444)"
+    );
+}
+
+/// Multiple aliased columns in one RETURN, both different from their props.
+#[test]
+fn multiple_aliased_columns_all_resolve() {
+    let (db, _dir) = setup_alias_graph();
+    let r = db
+        .execute("MATCH (n:Person {name: 'Alice'}) RETURN n.name AS a, n.age AS b")
+        .unwrap();
+    assert_eq!(r.columns, vec!["a", "b"]);
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::String("Alice".into()), Value::Int64(30)]],
+        "both aliased columns must resolve to their source properties"
+    );
+}
+
+/// Alias on an expression (not a bare property) — this already routes
+/// through the eval path (`expr_needs_eval_path`), so it must already work;
+/// this test locks that in rather than assuming it from the code read.
+#[test]
+fn alias_on_function_expression_resolves_correctly() {
+    let (db, _dir) = setup_alias_graph();
+    let r = db
+        .execute("MATCH (n:Person {name: 'Alice'}) RETURN toUpper(n.name) AS upperName")
+        .unwrap();
+    assert_eq!(r.columns, vec!["upperName"]);
+    assert_eq!(r.rows, vec![vec![Value::String("ALICE".into())]]);
+}
+
+/// Control: a genuinely absent property must still project Null — the fix
+/// must not turn a real null into an error or a fabricated value.
+#[test]
+fn genuinely_missing_property_still_projects_null() {
+    let (db, _dir) = setup_alias_graph();
+    let r = db
+        .execute("MATCH (n:Person {name: 'Eve'}) RETURN n.age AS personAge")
+        .unwrap();
+    assert_eq!(r.columns, vec!["personAge"]);
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::Null]],
+        "Eve has no age property; this Null is real, not a resolution failure"
+    );
+}
+
+/// The degree-cache ORDER BY fast-path (`try_degree_sort_fastpath`,
+/// SPA-272) has its own inline projection that had the identical bug: it
+/// parsed the (possibly aliased) output column string instead of the AST
+/// expression. `cypher_order_by_degree_alias_returns_top_k` in
+/// spa_272_q7_cypher_wiring.rs only covers aliasing the *function name*
+/// (`degree` vs `out_degree`), not an `AS` alias on the RETURN item.
+#[test]
+fn degree_fastpath_with_aliased_property_column() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    db.execute("CREATE (n:Widget {id: 1})").unwrap();
+    db.execute("CREATE (n:Widget {id: 2})").unwrap();
+    db.execute("CREATE (n:Widget {id: 3})").unwrap();
+    // id=1 has out-degree 2 (the top-1 by degree).
+    db.execute("MATCH (a:Widget {id:1}),(b:Widget {id:2}) CREATE (a)-[:E]->(b)")
+        .unwrap();
+    db.execute("MATCH (a:Widget {id:1}),(b:Widget {id:3}) CREATE (a)-[:E]->(b)")
+        .unwrap();
+
+    let r = db
+        .execute(
+            "MATCH (n:Widget) RETURN n.id AS widgetId \
+             ORDER BY out_degree(n) DESC LIMIT 1",
+        )
+        .unwrap();
+    assert_eq!(r.columns, vec!["widgetId"]);
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::Int64(1)]],
+        "widgetId must resolve n.id (the top-degree node is id=1), not Null"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// #430 — MATCH after WITH drops hops past the first
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Chain A -[:KNOWS]-> B -[:KNOWS]-> C -[:KNOWS]-> D.
+/// A separate, isolated node E has no outgoing KNOWS edges at all.
+fn setup_chain_graph() -> (GraphDb, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    for name in ["A", "B", "C", "D", "E"] {
+        db.execute(&format!("CREATE (n:Person {{name: '{name}'}})"))
+            .unwrap_or_else(|e| panic!("CREATE {name}: {e}"));
+    }
+    db.execute("MATCH (a:Person {name:'A'}),(b:Person {name:'B'}) CREATE (a)-[:KNOWS]->(b)")
+        .expect("A KNOWS B");
+    db.execute("MATCH (b:Person {name:'B'}),(c:Person {name:'C'}) CREATE (b)-[:KNOWS]->(c)")
+        .expect("B KNOWS C");
+    db.execute("MATCH (c:Person {name:'C'}),(d:Person {name:'D'}) CREATE (c)-[:KNOWS]->(d)")
+        .expect("C KNOWS D");
+    (db, dir)
+}
+
+/// Single hop after WITH already worked pre-fix; locks in no regression.
+#[test]
+fn one_hop_after_with_still_works() {
+    let (db, _dir) = setup_chain_graph();
+    let r = db
+        .execute(
+            "MATCH (a:Person {name:'A'}) WITH a \
+             MATCH (a)-[:KNOWS]->(b:Person) RETURN b.name",
+        )
+        .unwrap();
+    assert_eq!(r.rows, vec![vec![Value::String("B".into())]]);
+}
+
+/// The exact #430 reproduction: two hops after WITH must bind the third node.
+#[test]
+fn two_hop_after_with_binds_third_node() {
+    let (db, _dir) = setup_chain_graph();
+    let r = db
+        .execute(
+            "MATCH (a:Person {name:'A'}) WITH a \
+             MATCH (a)-[:KNOWS]->(b:Person)-[:KNOWS]->(c:Person) \
+             RETURN b.name, c.name",
+        )
+        .unwrap();
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::String("B".into()), Value::String("C".into())]],
+        "c must bind to C, not project Null (#430)"
+    );
+}
+
+/// Three hops after WITH must bind the fourth node.
+#[test]
+fn three_hop_after_with_binds_fourth_node() {
+    let (db, _dir) = setup_chain_graph();
+    let r = db
+        .execute(
+            "MATCH (a:Person {name:'A'}) WITH a \
+             MATCH (a)-[:KNOWS]->(b:Person)-[:KNOWS]->(c:Person)-[:KNOWS]->(d:Person) \
+             RETURN d.name",
+        )
+        .unwrap();
+    assert_eq!(r.rows, vec![vec![Value::String("D".into())]]);
+}
+
+/// WHERE on the final node of a 2-hop post-WITH pattern must still filter.
+#[test]
+fn two_hop_after_with_respects_where_on_final_node() {
+    let (db, _dir) = setup_chain_graph();
+    let r = db
+        .execute(
+            "MATCH (a:Person {name:'A'}) WITH a \
+             MATCH (a)-[:KNOWS]->(b:Person)-[:KNOWS]->(c:Person) \
+             WHERE c.name = 'Z' RETURN b.name, c.name",
+        )
+        .unwrap();
+    assert_eq!(
+        r.rows.len(),
+        0,
+        "no node named Z exists two hops out; WHERE must filter it to zero rows"
+    );
+}
+
+/// A post-WITH path that genuinely does not exist must yield zero rows, not
+/// a fabricated `[[Null]]` row. D has no outgoing KNOWS edge, so the 4-hop
+/// chain A->B->C->D->? does not exist.
+#[test]
+fn post_with_nonexistent_path_yields_empty_not_null_row() {
+    let (db, _dir) = setup_chain_graph();
+    let r = db
+        .execute(
+            "MATCH (a:Person {name:'A'}) WITH a \
+             MATCH (a)-[:KNOWS]->(b:Person)-[:KNOWS]->(c:Person)-[:KNOWS]->(d:Person)-[:KNOWS]->(e:Person) \
+             RETURN e.name",
+        )
+        .unwrap();
+    assert_eq!(
+        r.rows.len(),
+        0,
+        "the 4-hop pattern does not exist in the graph; expected [] but got {:?} \
+         (a fabricated [[Null]] row would be worse than dropping the hop)",
+        r.rows
+    );
+}
+
+/// A node with zero outgoing edges at hop 1 must not produce any rows for a
+/// downstream multi-hop pattern.
+#[test]
+fn multi_hop_after_with_from_isolated_node_yields_empty() {
+    let (db, _dir) = setup_chain_graph();
+    let r = db
+        .execute(
+            "MATCH (a:Person {name:'E'}) WITH a \
+             MATCH (a)-[:KNOWS]->(b:Person)-[:KNOWS]->(c:Person) \
+             RETURN c.name",
+        )
+        .unwrap();
+    assert_eq!(r.rows.len(), 0, "E has no outgoing KNOWS edges at all");
+}


### PR DESCRIPTION
## Summary

Both #444 and #430 shared one root cause: the fast (non-eval) projection paths resolved a RETURN column's stored property by re-parsing the *output* column name — the alias, when one is present — instead of dispatching on the underlying `ReturnItem.expr`. Confirmed as one shared mechanism, not two independent bugs.

- **#444** — `collect_col_ids_from_columns` / `project_row` hashed the alias string as if it were the property name, so `RETURN n.name AS personName` hashed `col_id_of("personName")` — a column that never existed — instead of `name`'s real column, and silently projected `Null`. Replaced with `collect_col_ids_from_return_items` / a rewritten `project_row`, both dispatching on `item.expr` — the same pattern `project_hop_row` already established for the hop path when #369 was fixed. The identical anti-pattern also existed inline in `try_degree_sort_fastpath` (SPA-272 degree-cache fast path) and is fixed there too.
- **#430** — `execute_pipeline_match_hop` (the executor for a MATCH stage following `WITH`) only ever read `pat.rels[0]` / `pat.nodes[0..2]` and silently dropped every hop after the first. A 2+-hop pattern after `WITH` therefore bound only the first destination node — later RETURN variables projected `Null`, or worse, the query fabricated a row for a path that does not exist in the graph at all. Rewritten to walk every hop in `pat.rels` in turn, threading the accumulated binding map forward the same way `execute_n_hop` already does for the leading MATCH.

## Testing

New file: `crates/sparrowdb/tests/regression_444_430_null_projection.rs` — e2e against a real `GraphDb` on a `tempfile::TempDir`. Covers: alias == prop, alias != prop, multiple aliased columns in one RETURN, alias on an expression (`toUpper(...)`) rather than a bare property, the degree-fastpath aliasing gap, 1/2/3-hop after `WITH`, a post-WITH path that genuinely does not exist (must be `[]`, not a fabricated `[[Null]]` row), and a control where the property is genuinely absent (must stay `Null`, not become an error).

All expected values derived by hand from the fixtures. All 6 alias/hop-dependent tests confirmed to **fail against the pre-fix parent commit** with the predicted symptom before the source fix was applied — verified by stashing the source changes and re-running:

```
alias_different_from_property_name_resolves_correctly: left: [[Null]]  right: [[String("Alice")]]
multiple_aliased_columns_all_resolve:                  left: [[Null, Null]]  right: [[String("Alice"), Int64(30)]]
degree_fastpath_with_aliased_property_column:          left: [[Null]]  right: [[Int64(1)]]
three_hop_after_with_binds_fourth_node:                left: [[Null]]  right: [[String("D")]]
two_hop_after_with_binds_third_node:                   left: [[String("B"), Null]]  right: [[String("B"), String("C")]]
post_with_nonexistent_path_yields_empty_not_null_row:   left: 1 row [[Null]]  right: 0 rows  (the fabricated-row symptom)
```

`$CARGO fmt -- --check` and `$CARGO clippy -p sparrowdb -p sparrowdb-execution --all-targets --keep-going` both clean. `cargo check --workspace --exclude sparrowdb-ruby` clean.

Ran and passed (all green, no regressions): `regression_444_430_null_projection` (12), `regression_421_varlen_plus_hop` (15), `regression_369` (3), `regression_355` (3), `regression_467` (11), `regression_477_fts_where` (10), `spa_130_with_clause` (6), `spa_131_optional_match` (10), `spa_134_multi_clause` (13), `spa_138_case_when`, `spa_140_143_functions` (27), `spa_151_kms_query_validation`, `spa_155_unwind_param`, `spa_192_match_no_label` (5), `spa_194_count_node_var` (3), `spa_196_id_function` (4), `spa_197_count_label_fastpath`, `spa_207_labels_function` (4), `spa_213_return_node_var` (3), `spa_237_unwind_match`, `spa_242_count_rel_var`, `spa_251_text_search_index`, `spa_261_edge_props_perf`, `spa_263_two_hop_agg`, `spa_263_two_hop_null`, `spa_264_boolean_props`, `spa_265_backtick_escaping`, `spa_272_q7_count_fastpath`, `spa_272_q7_cypher_wiring` (5), `spa_289_multi_label` (10 + 2 pre-existing ignores), `spa_299_chunked_pipeline` (23), `spa_299_phase4_parity`, `spa_415_unwind_match_mutate`, `spa_98_wal_encryption`, `spa_aggregation`, `spa_collect_agg`, `spa_list_predicates`, `uc7_unwind`, `vector_index`, `acceptance`, `call_subquery`, `cypher_range_function_test`, `fts_index`, `gap_10_parameterized_queries`, `hybrid_search`, `mcp_cypher_templates`, `regression_363`, `regression_372`, `regression_406`, `regression_456_load_is_not_destructive`, `regression_462_fts_open_swallow`, `regression_475_473_null_coercion`, `regression_485_stale_count`.

Rebased onto current `origin/main` (`1a3b506`) before pushing — fast-forward only, no conflicts (the only new commit since my base was a CI-only change; sibling #459/#436 work had not landed on `origin/main` at push time).

## Could not verify

- **`regression_real_world.rs`: `knowledge_graph_facts_count` and `social_graph_company_count` hang** (60s+ timeouts hit, single-threaded, `--nocapture`). **Confirmed pre-existing and unrelated to this change** — reproduced identically by stashing this PR's source changes and re-running against unmodified `origin/main`. Not caused by this fix; left as-is and flagged for separate triage rather than fixed here (out of scope for #444/#430, and I didn't want to guess at a root cause for an unrelated hang under time pressure).
- Did not add coverage for `SET`/`MERGE`/mutation-path projection using the same `project_row`/`collect_col_ids_from_columns` machinery beyond what the existing suite already exercises — the fix is general (dispatches on `item.expr` for every caller), and the full targeted suite above passed, but I did not write new mutation-specific alias tests.
- Did not chase whether `execute_pipeline_match_hop`'s inline prop filters on hop 2+ can reference chain-local variables bound at hop 1 (e.g. `{x: b.y}` where `b` is itself mid-chain) — I deliberately kept `matches_prop_filter_with_binding` scoped to the upstream `binding` map only, matching pre-existing single-hop semantics exactly, rather than introducing new cross-hop filter semantics untested by any existing case.

## Test plan

- [x] `regression_444_430_null_projection` — 12/12, and 6/12 confirmed to fail pre-fix
- [x] Full targeted projection/pipeline/WITH/alias suite — all green
- [x] `cargo fmt --check`, `cargo clippy --keep-going` clean
- [x] `cargo check --workspace --exclude sparrowdb-ruby` clean
- [x] Rebased onto current `origin/main`, no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE