### PR TITLE
fix(execution): hybrid_search()/UNWIND RETURN no longer silently return Null (closes #459)

### DIFF
--- a/crates/sparrowdb-execution/src/engine/expr.rs
+++ b/crates/sparrowdb-execution/src/engine/expr.rs
@@ -1,6 +1,55 @@
 //! Auto-generated submodule — see engine/mod.rs for context.
 use super::*;
 
+/// Signature shared by every scalar function that can only be evaluated with
+/// engine (graph) context — `eval_full_text_search`, `eval_bm25_score`, and
+/// `eval_hybrid_search` all have this exact shape.
+type GraphOnlyFn = fn(&Engine, &[Expr], &HashMap<String, Value>) -> Value;
+
+/// The single source of truth for which scalar functions require
+/// `Engine::eval_expr_graph` rather than the free, non-engine `eval_expr`,
+/// and how to dispatch each one.
+///
+/// # #459: one table instead of two name lists
+///
+/// Before this table existed, `eval_expr_graph`'s `FnCall` arm and
+/// `expr_needs_graph` (`engine/mod.rs`) each kept their own copy of the same
+/// three names, with nothing keeping them in sync. When they agreed the
+/// system worked; the day someone added a fourth graph-only function to one
+/// list and not the other, `expr_needs_graph` would keep saying "no" for it,
+/// `aggregate_rows_graph` would keep delegating to the non-engine
+/// `aggregate_rows` → `eval_expr`, and the new function would silently
+/// return `Value::Null` against a perfectly healthy index — this issue,
+/// verbatim, for the next function. This project has hit the same shape
+/// twice already for a match/dispatch pair that can drift (`is_mutation` vs
+/// its dispatch match: #478 missing-from-classifier, #502
+/// missing-from-dispatch).
+///
+/// A table is used instead of a plain name list so the dispatch itself reads
+/// from the same data `is_graph_only_fn` checks against — adding a function
+/// here is the only step; both the "does this need graph context" check and
+/// the actual call site update together. See `eval_expr_graph`'s `FnCall`
+/// arm below and `regression_459_hybrid_search_return.rs` /
+/// `graph_only_fn_table_covers_every_dispatched_name` (this file's tests).
+///
+/// To add a new graph-only function: add its `eval_*` method to this `impl
+/// Engine` block, then add one row here. Nothing else needs to change.
+const GRAPH_ONLY_FNS: &[(&str, GraphOnlyFn)] = &[
+    ("full_text_search", Engine::eval_full_text_search),
+    ("bm25_score", Engine::eval_bm25_score),
+    ("hybrid_search", Engine::eval_hybrid_search),
+];
+
+/// Returns `true` when `name` (case-insensitive) names one of
+/// [`GRAPH_ONLY_FNS`] — a scalar function that can only be evaluated via
+/// `Engine::eval_expr_graph`. Used by `expr_needs_graph` (`engine/mod.rs`)
+/// to route `aggregate_rows_graph` correctly; see the module doc on
+/// `GRAPH_ONLY_FNS` for why this must not be a second, independent list.
+pub(crate) fn is_graph_only_fn(name: &str) -> bool {
+    let name_lc = name.to_ascii_lowercase();
+    GRAPH_ONLY_FNS.iter().any(|(n, _)| *n == name_lc)
+}
+
 /// Key of the process-global `hybrid_search` index cache: which database
 /// directory, which `(label, prop)` pair.
 type HybridCacheKey = (std::path::PathBuf, String, String);
@@ -665,12 +714,17 @@ impl Engine {
                 }
                 Value::Null
             }
-            Expr::FnCall { name, args } => match name.to_ascii_lowercase().as_str() {
-                "full_text_search" => self.eval_full_text_search(args, vals),
-                "bm25_score" => self.eval_bm25_score(args, vals),
-                "hybrid_search" => self.eval_hybrid_search(args, vals),
-                _ => eval_expr(expr, vals),
-            },
+            // Dispatch through the shared GRAPH_ONLY_FNS table (#459) rather
+            // than a hand-written match, so this call site and
+            // `is_graph_only_fn` can never disagree about which names route
+            // here.
+            Expr::FnCall { name, args } => {
+                let name_lc = name.to_ascii_lowercase();
+                match GRAPH_ONLY_FNS.iter().find(|(n, _)| *n == name_lc) {
+                    Some((_, f)) => f(self, args, vals),
+                    None => eval_expr(expr, vals),
+                }
+            }
             // #477: a bare `full_text_search(...)`/`bm25_score(...)` call is
             // routed above, but a threshold comparison like
             // `bm25_score(n.text, 'q') > 0.5` wraps the call in a `BinOp` —
@@ -1121,5 +1175,64 @@ impl Engine {
                     .collect()
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #459 pin: `expr_needs_graph` (`engine/mod.rs`) must return `true` for
+    /// every name `eval_expr_graph` actually dispatches through
+    /// `GRAPH_ONLY_FNS` — read directly off that table, not a fourth copy of
+    /// the name list, so this test cannot silently drift the same way the
+    /// two independent name lists it replaces did before this fix. If a
+    /// future graph-only function is added to `GRAPH_ONLY_FNS` without a
+    /// matching change anywhere, this test still passes (there is nothing
+    /// left to keep in sync) — that is the point.
+    #[test]
+    fn expr_needs_graph_covers_every_name_in_the_dispatch_table() {
+        for (name, _) in GRAPH_ONLY_FNS {
+            let expr = Expr::FnCall {
+                name: (*name).to_string(),
+                args: vec![],
+            };
+            assert!(
+                expr_needs_graph(&expr),
+                "expr_needs_graph() must return true for {name:?} — it is in \
+                 GRAPH_ONLY_FNS (eval_expr_graph's real dispatch table), so \
+                 aggregate_rows_graph must route it through eval_expr_graph \
+                 rather than the non-engine eval_expr fallback that produced \
+                 issue #459's Null-on-a-healthy-index bug"
+            );
+            assert!(
+                is_graph_only_fn(name),
+                "is_graph_only_fn({name:?}) must agree with its own table"
+            );
+        }
+    }
+
+    /// Sanity companion: an ordinary function name outside the table must
+    /// NOT be flagged as graph-only — otherwise the pin above would pass
+    /// trivially by treating every function as graph-only.
+    #[test]
+    fn expr_needs_graph_does_not_flag_an_ordinary_function() {
+        let expr = Expr::FnCall {
+            name: "toUpper".to_string(),
+            args: vec![],
+        };
+        assert!(!expr_needs_graph(&expr));
+        assert!(!is_graph_only_fn("toUpper"));
+    }
+
+    /// Case-insensitivity parity: `eval_expr_graph`'s dispatch lowercases the
+    /// name before matching, so the routing check must too.
+    #[test]
+    fn expr_needs_graph_is_case_insensitive() {
+        let expr = Expr::FnCall {
+            name: "HYBRID_SEARCH".to_string(),
+            args: vec![],
+        };
+        assert!(expr_needs_graph(&expr));
     }
 }

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -3221,11 +3221,31 @@ fn agg_kind(expr: &Expr) -> AggKind {
 /// Non-aggregate RETURN items become the group key.  Returns one output
 /// `Vec<Value>` per unique key in the same column order as `return_items`.
 /// Returns `true` if the expression contains a `CASE WHEN`, `shortestPath`,
-/// or `EXISTS` sub-expression that requires the graph-aware eval path
-/// (rather than the fast `project_row` column lookup).
+/// `EXISTS`, or `hybrid_search`/`full_text_search`/`bm25_score` sub-expression
+/// that requires the graph-aware eval path (rather than the fast
+/// `project_row` column lookup or the non-engine-aware `eval_expr` fallback).
+///
+/// # #459: the three engine-only scalar functions
+///
+/// `Engine::eval_expr_graph` (`engine/expr.rs`) special-cases exactly three
+/// function names — `hybrid_search`, `full_text_search`, `bm25_score` — and
+/// falls through to the free, non-engine `eval_expr` for everything else.
+/// That free `eval_expr`'s `FnCall` arm dispatches to
+/// `functions::dispatch_function`, which has never heard of these three, so
+/// it silently returns `Value::Null` for an unrelated reason (unknown
+/// function name). Before this fix, a bare `hybrid_search(...)` (or the
+/// other two) in a non-aggregate RETURN item did not trip `expr_needs_graph`,
+/// so `aggregate_rows_graph` delegated to the plain `aggregate_rows` helper's
+/// `eval_expr`-based projection instead of `eval_expr_graph` — producing
+/// `Null` against a perfectly healthy index. See
+/// `regression_459_hybrid_search_return.rs`.
 fn expr_needs_graph(expr: &Expr) -> bool {
     match expr {
         Expr::ShortestPath(_) | Expr::ExistsSubquery(_) | Expr::CaseWhen { .. } => true,
+        Expr::FnCall { name, .. } => matches!(
+            name.to_ascii_lowercase().as_str(),
+            "hybrid_search" | "full_text_search" | "bm25_score"
+        ),
         Expr::And(l, r) | Expr::Or(l, r) => expr_needs_graph(l) || expr_needs_graph(r),
         Expr::Not(inner) | Expr::IsNull(inner) | Expr::IsNotNull(inner) => expr_needs_graph(inner),
         Expr::BinOp { left, right, .. } => expr_needs_graph(left) || expr_needs_graph(right),

--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -3221,31 +3221,28 @@ fn agg_kind(expr: &Expr) -> AggKind {
 /// Non-aggregate RETURN items become the group key.  Returns one output
 /// `Vec<Value>` per unique key in the same column order as `return_items`.
 /// Returns `true` if the expression contains a `CASE WHEN`, `shortestPath`,
-/// `EXISTS`, or `hybrid_search`/`full_text_search`/`bm25_score` sub-expression
-/// that requires the graph-aware eval path (rather than the fast
-/// `project_row` column lookup or the non-engine-aware `eval_expr` fallback).
+/// `EXISTS`, or graph-only scalar function (`hybrid_search`,
+/// `full_text_search`, `bm25_score`, ...) sub-expression that requires the
+/// graph-aware eval path (rather than the fast `project_row` column lookup
+/// or the non-engine-aware `eval_expr` fallback).
 ///
-/// # #459: the three engine-only scalar functions
+/// # #459: ask the real dispatcher, never a duplicated name list
 ///
-/// `Engine::eval_expr_graph` (`engine/expr.rs`) special-cases exactly three
-/// function names — `hybrid_search`, `full_text_search`, `bm25_score` — and
-/// falls through to the free, non-engine `eval_expr` for everything else.
-/// That free `eval_expr`'s `FnCall` arm dispatches to
-/// `functions::dispatch_function`, which has never heard of these three, so
-/// it silently returns `Value::Null` for an unrelated reason (unknown
-/// function name). Before this fix, a bare `hybrid_search(...)` (or the
-/// other two) in a non-aggregate RETURN item did not trip `expr_needs_graph`,
-/// so `aggregate_rows_graph` delegated to the plain `aggregate_rows` helper's
-/// `eval_expr`-based projection instead of `eval_expr_graph` — producing
-/// `Null` against a perfectly healthy index. See
-/// `regression_459_hybrid_search_return.rs`.
+/// The graph-only function names are *not* repeated here. `expr::GRAPH_ONLY_FNS`
+/// (`engine/expr.rs`) is the single table both `Engine::eval_expr_graph`'s
+/// `FnCall` arm and this function read from, via `expr::is_graph_only_fn`.
+/// Before that table existed, this match and `eval_expr_graph`'s dispatch
+/// each kept an independent copy of the same three names. When they agreed
+/// the system worked; the day they drifted, a graph-only function would
+/// dispatch fine from `eval_expr_graph` directly but never trip this check,
+/// so `aggregate_rows_graph` would keep delegating to the non-engine
+/// `aggregate_rows` → `eval_expr`, which has never heard of it — silently
+/// `Value::Null` against a perfectly healthy index. That was this issue,
+/// caused by exactly this shape. See `regression_459_hybrid_search_return.rs`.
 fn expr_needs_graph(expr: &Expr) -> bool {
     match expr {
         Expr::ShortestPath(_) | Expr::ExistsSubquery(_) | Expr::CaseWhen { .. } => true,
-        Expr::FnCall { name, .. } => matches!(
-            name.to_ascii_lowercase().as_str(),
-            "hybrid_search" | "full_text_search" | "bm25_score"
-        ),
+        Expr::FnCall { name, .. } => expr::is_graph_only_fn(name),
         Expr::And(l, r) | Expr::Or(l, r) => expr_needs_graph(l) || expr_needs_graph(r),
         Expr::Not(inner) | Expr::IsNull(inner) | Expr::IsNotNull(inner) => expr_needs_graph(inner),
         Expr::BinOp { left, right, .. } => expr_needs_graph(left) || expr_needs_graph(right),

--- a/crates/sparrowdb-execution/src/engine/mutation.rs
+++ b/crates/sparrowdb-execution/src/engine/mutation.rs
@@ -773,36 +773,39 @@ impl Engine {
         let mut op = UnwindOperator::new(u.alias.clone(), values);
         let chunks = op.collect_all()?;
 
-        // Materialize: for each chunk/group/row, project the RETURN columns.
+        // Materialize: for each chunk/group/row, project the RETURN columns
+        // through `eval_expr_graph` against a row-value map containing only
+        // the UNWIND alias binding.
         //
-        // Only fall back to the UNWIND alias value when the output column
-        // actually corresponds to the alias variable.  Returning a value for
-        // an unrelated variable (e.g. `RETURN y` when alias is `x`) would
-        // silently produce wrong results instead of NULL.
+        // #459: this used to hand-roll a single case — `RETURN <alias>`
+        // returned the unwound value, and *every other expression shape*
+        // (a bare `hybrid_search(...)` call, arithmetic on the alias, an
+        // unrelated variable, ...) hardcoded `Value::Null`. That correctly
+        // NULLs an out-of-scope variable (e.g. `RETURN y` when the alias is
+        // `x`) purely by accident of it not being `Expr::Var(alias)` either —
+        // but it also NULLs every legitimate expression that isn't a bare
+        // alias reference. Evaluating through `eval_expr_graph` against a row
+        // map that only contains the alias preserves the "unrelated variable
+        // → NULL" behavior (an absent key evaluates to `Value::Null`, same as
+        // before) while making `hybrid_search`/`full_text_search`/
+        // `bm25_score` and any other expression resolve correctly. See
+        // `regression_459_hybrid_search_return.rs`.
         let mut rows: Vec<Vec<Value>> = Vec::new();
         for chunk in &chunks {
             for group in &chunk.groups {
                 let n = group.len();
                 for row_idx in 0..n {
-                    let row = u
+                    let mut row_vals: HashMap<String, Value> = HashMap::new();
+                    row_vals.insert(
+                        u.alias.clone(),
+                        group.get_value(&u.alias, row_idx).unwrap_or(Value::Null),
+                    );
+                    row_vals.extend(self.dollar_params());
+                    let row: Vec<Value> = u
                         .return_clause
                         .items
                         .iter()
-                        .map(|item| {
-                            // Determine whether this RETURN item refers to the
-                            // alias variable produced by UNWIND.
-                            let is_alias = match &item.expr {
-                                Expr::Var(name) => name == &u.alias,
-                                _ => false,
-                            };
-                            if is_alias {
-                                group.get_value(&u.alias, row_idx).unwrap_or(Value::Null)
-                            } else {
-                                // Variable is not in scope for this UNWIND —
-                                // return NULL rather than leaking the alias value.
-                                Value::Null
-                            }
-                        })
+                        .map(|item| self.eval_expr_graph(&item.expr, &row_vals))
                         .collect();
                     rows.push(row);
                 }

--- a/crates/sparrowdb/tests/regression_459_hybrid_search_return.rs
+++ b/crates/sparrowdb/tests/regression_459_hybrid_search_return.rs
@@ -1,0 +1,334 @@
+//! Regression guard for #459: `MATCH ... RETURN hybrid_search(...)` (and the
+//! `WHERE`/`UNWIND` shapes) returned `Value::Null` against a genuinely
+//! **healthy** index.
+//!
+//! # Root cause (established by reading, not by running the code first)
+//!
+//! Two independent bugs, not the one the issue title guessed at:
+//!
+//! 1. `Engine::execute_scan`'s eval path funnels non-aggregate RETURN items
+//!    through `aggregate_rows_graph` (`engine/expr.rs`), which only recurses
+//!    into `eval_expr_graph` when `expr_needs_graph()` (`engine/mod.rs`)
+//!    returns `true` for a RETURN item. That function checked for
+//!    `ShortestPath`/`ExistsSubquery`/`CaseWhen` but never `Expr::FnCall`, so
+//!    a bare `hybrid_search(...)` fell through to the non-aggregate
+//!    "plain projection" branch of the free `aggregate_rows()` helper, which
+//!    evaluates every item with the **non-engine-aware** free function
+//!    `eval_expr()`. That function's `FnCall` arm dispatches to
+//!    `functions::dispatch_function`, which has never heard of
+//!    `hybrid_search`/`full_text_search`/`bm25_score` (those three are
+//!    special-cased only inside `Engine::eval_expr_graph`), so it silently
+//!    returns `Value::Null` for an unrelated reason: unknown function name.
+//!    This explains the `MATCH ... RETURN` and `MATCH ... WHERE ... RETURN`
+//!    rows in the issue table.
+//!
+//!    This is *not* the chunked pipeline: `can_use_chunked_pipeline` already
+//!    routes any non-aggregate `FnCall` in RETURN to the row engine via
+//!    `expr_needs_eval_path` (`engine/mod.rs`), which predates this fix and
+//!    already covers `hybrid_search`. The chunked scan path is never reached
+//!    for this query shape.
+//!
+//! 2. `Engine::execute_unwind` (`engine/mutation.rs`) is a *separate* code
+//!    path (bare `UNWIND ... RETURN` parses to `Statement::Unwind`, not
+//!    `Statement::Pipeline`). It projected RETURN items with a hand-rolled
+//!    check: if the item was exactly `Expr::Var(alias)` it returned the
+//!    unwound value, and for literally every other expression shape —
+//!    including `hybrid_search(...)`, arithmetic, or any other function
+//!    call — it hardcoded `Value::Null`. This explains the `UNWIND ...
+//!    RETURN` row independently of bug 1.
+//!
+//! # What must NOT change
+//!
+//! The `expr_needs_graph` fix only adds the three functions
+//! `Engine::eval_expr_graph` already special-cases
+//! (`hybrid_search`/`full_text_search`/`bm25_score`); it does not weaken the
+//! `#456`/`#458`/`#462` absent-vs-damaged guarantee. A genuinely corrupt
+//! index must still surface as `Value::Null` through this same
+//! `MATCH ... RETURN` shape — asserted below by reusing the truncation
+//! technique from `regression_456_load_is_not_destructive.rs`.
+//!
+//! Every expected value below is derived by hand from the fixture, per this
+//! repo's testing rule (see `regression_406.rs`/[[feedback_derive_expected_from_source]]).
+
+use sparrowdb::GraphDb;
+use sparrowdb_execution::Value;
+
+fn open_db(dir: &std::path::Path) -> GraphDb {
+    GraphDb::open(dir).expect("open db")
+}
+
+fn exec(db: &GraphDb, cypher: &str) {
+    db.execute(cypher)
+        .unwrap_or_else(|e| panic!("exec failed for `{cypher}`: {e}"));
+}
+
+fn get_node_id(db: &GraphDb, label: &str, key_prop: &str, key_val: &str) -> u64 {
+    let q = format!("MATCH (n:{label}) WHERE n.{key_prop} = '{key_val}' RETURN id(n) AS nid");
+    let res = db.execute(&q).expect("get_node_id query");
+    match &res.rows[0][0] {
+        Value::Int64(n) => *n as u64,
+        other => panic!("expected Int64 node_id, got {other:?}"),
+    }
+}
+
+/// Flatten a `Value::List<Value::Map{node_id, ...}>` hybrid_search result
+/// into the ordered list of node ids it contains. Panics on any other shape
+/// so a Null (or otherwise malformed) result cannot silently read as "empty".
+fn hit_ids(v: &Value) -> Vec<u64> {
+    match v {
+        Value::List(items) => items
+            .iter()
+            .map(|item| match item {
+                Value::Map(kvs) => match kvs.iter().find(|(k, _)| k == "node_id") {
+                    Some((_, Value::Int64(n))) => *n as u64,
+                    other => panic!("expected node_id: Int64 entry, got {other:?}"),
+                },
+                other => panic!("expected Map hit, got {other:?}"),
+            })
+            .collect(),
+        other => panic!("expected List, got {other:?}"),
+    }
+}
+
+/// Build the fixture two-node `Doc` index this whole file shares:
+/// - n0: content "rust graph database", embedding [1,0,0,0] — the perfect
+///   match on both the vector query [1,0,0,0] and the text query "rust
+///   graph" (contains both terms; n1 contains neither).
+/// - n1: content "unrelated content", embedding [0,1,0,0] — orthogonal
+///   vector, zero text-term overlap.
+///
+/// Hand-derived expectation for `hybrid_search('Doc','embedding','content',
+/// [1,0,0,0],'rust graph',1)`: vector search ranks n0 first (cosine
+/// similarity 1.0 vs 0.0), BM25 ranks n0 first (2 matching terms vs 0), so
+/// n0 is first under RRF fusion by both signals regardless of tie-break
+/// details for n1 — and `k=1` truncates to exactly that one entry.
+fn build_two_node_fixture(dir: &std::path::Path) -> (GraphDb, u64, u64) {
+    let db = open_db(dir);
+    db.create_vector_index("Doc", "embedding", 4, "cosine")
+        .expect("create vector index");
+    exec(&db, "CREATE FULLTEXT INDEX FOR (n:Doc) ON (n.content)");
+
+    exec(
+        &db,
+        "CREATE (d:Doc {dockey: 'n0', content: 'rust graph database'})",
+    );
+    exec(
+        &db,
+        "CREATE (d:Doc {dockey: 'n1', content: 'unrelated content'})",
+    );
+    let n0 = get_node_id(&db, "Doc", "dockey", "n0");
+    let n1 = get_node_id(&db, "Doc", "dockey", "n1");
+
+    let arc = db.get_vector_index("Doc", "embedding").expect("vec index");
+    arc.write()
+        .expect("w")
+        .insert(n0, &[1.0_f32, 0.0, 0.0, 0.0]);
+    arc.write()
+        .expect("w")
+        .insert(n1, &[0.0_f32, 1.0, 0.0, 0.0]);
+    let vec_dir = dir.join("vector_indexes");
+    arc.read()
+        .expect("r")
+        .save(&vec_dir, "Doc", "embedding")
+        .expect("save vector index");
+
+    (db, n0, n1)
+}
+
+const QUERY_EXPR: &str = "hybrid_search('Doc', 'embedding', 'content', \
+    [1.0, 0.0, 0.0, 0.0], 'rust graph', 1)";
+
+// ── 1. MATCH ... RETURN hybrid_search(...) ─────────────────────────────────
+
+#[test]
+fn match_return_hybrid_search_healthy_index_returns_hits() {
+    let dir = tempfile::tempdir().unwrap();
+    let (db, n0, _n1) = build_two_node_fixture(dir.path());
+
+    let result = db
+        .execute(&format!("MATCH (d:Doc) RETURN {QUERY_EXPR} AS hits"))
+        .expect("MATCH ... RETURN hybrid_search must execute");
+
+    assert_eq!(result.rows.len(), 2, "one row per Doc node (n0 and n1)");
+    for (i, row) in result.rows.iter().enumerate() {
+        let ids = hit_ids(&row[0]);
+        assert_eq!(
+            ids,
+            vec![n0],
+            "row {i}: hybrid_search does not depend on the matched node, so \
+             every row must carry the same single top hit (n0); got {ids:?} \
+             (raw value {:?})",
+            row[0]
+        );
+    }
+}
+
+// ── 2. MATCH ... WHERE ... RETURN hybrid_search(...) ───────────────────────
+
+#[test]
+fn match_where_return_hybrid_search_healthy_index_returns_hits() {
+    let dir = tempfile::tempdir().unwrap();
+    let (db, n0, _n1) = build_two_node_fixture(dir.path());
+
+    let result = db
+        .execute(&format!(
+            "MATCH (d:Doc) WHERE d.dockey = 'n0' RETURN {QUERY_EXPR} AS hits"
+        ))
+        .expect("MATCH ... WHERE ... RETURN hybrid_search must execute");
+
+    assert_eq!(result.rows.len(), 1, "WHERE narrows the scan to one row");
+    let ids = hit_ids(&result.rows[0][0]);
+    assert_eq!(ids, vec![n0], "got {:?}", result.rows[0][0]);
+}
+
+// ── 3. UNWIND ... RETURN hybrid_search(...) ────────────────────────────────
+
+#[test]
+fn unwind_return_hybrid_search_healthy_index_returns_hits() {
+    let dir = tempfile::tempdir().unwrap();
+    let (db, n0, _n1) = build_two_node_fixture(dir.path());
+
+    let result = db
+        .execute(&format!(
+            "UNWIND [1, 2, 3] AS i RETURN {QUERY_EXPR} AS hits"
+        ))
+        .expect("UNWIND ... RETURN hybrid_search must execute");
+
+    assert_eq!(result.rows.len(), 3, "one row per unwound element");
+    for (i, row) in result.rows.iter().enumerate() {
+        let ids = hit_ids(&row[0]);
+        assert_eq!(
+            ids,
+            vec![n0],
+            "row {i}: hybrid_search does not reference the UNWIND alias, so \
+             every row must carry the same single top hit (n0); got {ids:?} \
+             (raw value {:?})",
+            row[0]
+        );
+    }
+}
+
+// ── 4. UNWIND ... RETURN i (baseline: the alias itself must still work) ───
+
+/// The pre-fix `execute_unwind` distinguished the bare alias variable by a
+/// hand-rolled `Expr::Var` check. Routing everything through
+/// `eval_expr_graph` must not regress that ordinary case.
+#[test]
+fn unwind_return_bare_alias_still_works() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    let result = db
+        .execute("UNWIND [10, 20, 30] AS i RETURN i AS val")
+        .expect("UNWIND ... RETURN i must execute");
+
+    let vals: Vec<i64> = result
+        .rows
+        .iter()
+        .map(|r| match &r[0] {
+            Value::Int64(n) => *n,
+            other => panic!("expected Int64, got {other:?}"),
+        })
+        .collect();
+    assert_eq!(vals, vec![10, 20, 30]);
+}
+
+// ── 5. Healthy-but-empty index: genuine non-match must be an empty List,
+//        never Null (Null is reserved for damage — #445/#456/#458). ────────
+
+#[test]
+fn match_return_hybrid_search_no_match_returns_empty_list_not_null() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = open_db(dir.path());
+
+    // A second, valid, healthy index registered on a label with zero nodes
+    // and zero inserted vectors — persisted to disk so the query path loads
+    // a real (empty) index rather than treating it as "not configured".
+    db.create_vector_index("EmptyDoc", "emb", 4, "cosine")
+        .expect("create empty vector index");
+    exec(&db, "CREATE FULLTEXT INDEX FOR (n:EmptyDoc) ON (n.text)");
+    let arc = db
+        .get_vector_index("EmptyDoc", "emb")
+        .expect("empty vec index handle");
+    let vec_dir = dir.path().join("vector_indexes");
+    arc.read()
+        .expect("r")
+        .save(&vec_dir, "EmptyDoc", "emb")
+        .expect("save empty vector index");
+
+    // Need at least one row to project from; use an unrelated populated label.
+    exec(&db, "CREATE (d:Doc {dockey: 'only'})");
+
+    let result = db
+        .execute(
+            "MATCH (d:Doc) RETURN hybrid_search('EmptyDoc', 'emb', 'text', \
+             [1.0, 0.0, 0.0, 0.0], 'anything', 5) AS hits",
+        )
+        .expect("hybrid_search against a healthy empty index must not error");
+
+    assert_eq!(result.rows.len(), 1);
+    let ids = hit_ids(&result.rows[0][0]);
+    assert!(
+        ids.is_empty(),
+        "an index with zero vectors and zero indexed text is healthy and has \
+         no matches — the result must be an empty List, not Null (which is \
+         reserved for damage); got {:?}",
+        result.rows[0][0]
+    );
+}
+
+// ── 6. Corrupt index: the #456/#458 guard must survive through this shape ──
+
+/// Truncate the on-disk HNSW file to 4 bytes — the same undecodable-by-hand
+/// derivation as `regression_456_load_is_not_destructive.rs::truncate_to_4_bytes`.
+fn truncate_to_4_bytes(file: &std::path::Path) {
+    let original = std::fs::metadata(file).expect("stat index file").len();
+    assert!(
+        original > 4,
+        "fixture precondition: a serialised VectorIndex must exceed the 4-byte \
+         truncation point, got {original} bytes"
+    );
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(file)
+        .expect("open index file for truncation")
+        .set_len(4)
+        .expect("truncate index file to 4 bytes");
+}
+
+#[test]
+fn match_return_hybrid_search_corrupt_index_still_returns_null() {
+    let dir = tempfile::tempdir().unwrap();
+    let (db, _n0, _n1) = build_two_node_fixture(dir.path());
+
+    // Sanity: the healthy baseline must actually produce hits through this
+    // exact query shape before we corrupt anything underneath it.
+    let baseline = db
+        .execute(&format!("MATCH (d:Doc) RETURN {QUERY_EXPR} AS hits"))
+        .expect("baseline must execute");
+    assert!(
+        !hit_ids(&baseline.rows[0][0]).is_empty(),
+        "fixture precondition: the healthy index must return hits"
+    );
+
+    let file = dir
+        .path()
+        .join("vector_indexes")
+        .join("hnsw_Doc_embedding.bin");
+    truncate_to_4_bytes(&file);
+
+    let result = db
+        .execute(&format!("MATCH (d:Doc) RETURN {QUERY_EXPR} AS hits"))
+        .expect("the query itself must not error even though the index is damaged");
+
+    assert_eq!(result.rows.len(), 2);
+    for (i, row) in result.rows.iter().enumerate() {
+        assert!(
+            matches!(row[0], Value::Null),
+            "row {i}: a damaged index must still surface as Null through \
+             MATCH ... RETURN — the #459 routing fix must not weaken the \
+             #456/#458 absent-vs-damaged guard; got {:?}",
+            row[0]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`MATCH ... RETURN hybrid_search(...)` (and the `WHERE`/`UNWIND` variants) returned `Value::Null` against a genuinely **healthy** index — issue #459. **Not the chunked pipeline**, contrary to the issue title's working theory: `can_use_chunked_pipeline` already excludes any non-aggregate `FnCall` in RETURN via `expr_needs_eval_path`, so the chunked scan path is never reached for this query shape. Two independent routing bugs instead:

1. **`aggregate_rows_graph` (`engine/expr.rs`)** only recurses into the engine-aware `eval_expr_graph` when `expr_needs_graph()` (`engine/mod.rs`) returns `true` for a RETURN item. That function checked for `ShortestPath`/`ExistsSubquery`/`CaseWhen` but never `Expr::FnCall`, so a bare `hybrid_search(...)` fell through to the free `aggregate_rows()` helper's non-aggregate "plain projection" branch, which evaluates every item with the **non-engine-aware** `eval_expr()`. That function's `FnCall` arm dispatches to `functions::dispatch_function`, which has never heard of `hybrid_search`/`full_text_search`/`bm25_score` (those three are special-cased only inside `Engine::eval_expr_graph`) — so it silently returns `Null` for an unrelated reason: unknown function name. Explains the `MATCH ... RETURN` and `MATCH ... WHERE ... RETURN` rows.

2. **`Engine::execute_unwind` (`engine/mutation.rs`)** is a separate code path — bare `UNWIND ... RETURN` parses to `Statement::Unwind`, not `Statement::Pipeline`. It hand-rolled RETURN projection: a bare `Expr::Var(alias)` resolved to the unwound value, and *every other expression shape* — `hybrid_search(...)`, arithmetic, anything — was hardcoded to `Value::Null`. Independent bug, same symptom, explains the `UNWIND ... RETURN` row.

## Fix

- `expr_needs_graph()`: added an `Expr::FnCall` arm matching the same three names `eval_expr_graph` already special-cases. This single change fixes the RETURN projection across every scan variant that shares `aggregate_rows_graph` (single-label scan, multi-label scan, secondary-label scan, one-hop, ...).
- `execute_unwind()`: replaced the hand-rolled `Var`-only check with a proper row-value map (alias binding + `$params`) evaluated via `self.eval_expr_graph(...)` for every RETURN item. Preserves "unrelated variable → `Null`" (an absent map key still evaluates to `Null`) while making `hybrid_search` and any other expression resolve correctly.

## What did NOT change

`Engine::eval_hybrid_search` itself — the #456/#458/#465 absent-vs-damaged guard — is untouched. Verified with a corrupt-index e2e test through the exact `MATCH ... RETURN` shape this fix changes: still returns `Null`, not a fabricated result.

## Testing

New: `crates/sparrowdb/tests/regression_459_hybrid_search_return.rs` — 6 e2e tests against a real `GraphDb`/`tempfile::TempDir`, every expected value hand-derived from the fixture (never captured from a run):

- `match_return_hybrid_search_healthy_index_returns_hits`
- `match_where_return_hybrid_search_healthy_index_returns_hits`
- `unwind_return_hybrid_search_healthy_index_returns_hits`
- `unwind_return_bare_alias_still_works` (no-regression baseline — passed pre-fix too)
- `match_return_hybrid_search_no_match_returns_empty_list_not_null` (healthy-but-empty index → empty `List`, never `Null`)
- `match_return_hybrid_search_corrupt_index_still_returns_null` (guard preserved — reuses the `truncate_to_4_bytes` technique from `regression_456_load_is_not_destructive.rs`)

All 5 hit-producing tests confirmed to fail against the pre-fix commit with `expected List, got Null` (quoted in the commit message / session log).

Also re-ran clean: `hybrid_search.rs`, `fts_index.rs`, `regression_462_fts_open_swallow.rs`, `regression_456_load_is_not_destructive.rs`, `regression_477_fts_where.rs`, `vector_index.rs`, `vector_index_durability.rs`, `vector_index_load_errors.rs`, `uc7_unwind.rs`, `acceptance.rs`, `regression_475_473_null_coercion.rs`, `spa_134_multi_clause.rs`, plus the full `cargo test --workspace --exclude sparrowdb-ruby --no-fail-fast` (237 test binaries, 0 failures).

`cargo fmt --check` clean. `cargo clippy -p sparrowdb -p sparrowdb-execution --tests --keep-going -- -D warnings` clean.

Rebased onto current `origin/main` (through #512) before opening.

## Could not verify

- Whether some test file outside the ones I grepped for (`execute_unwind`/`"UNWIND ["`) exercises bare `UNWIND ... RETURN` with a non-alias `FnCall` in a way I didn't anticipate — the full workspace run (237 binaries, 0 failures) is the backstop here, but I did not enumerate every UNWIND-touching test by hand.
- Whether #514 (in flight per the team lead, touches `engine/mod.rs` in the same `expr_needs_graph`/`needs_node_ref_in_return` neighborhood) will conflict with this PR once merged — it had not landed on `origin/main` as of this rebase, so I could not test against it.

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE