### PR TITLE
fix(npm): drop dishonest optionalDependencies, fix darwin-arm64 load bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
           echo "Copied $ARTIFACT → npm/sparrowdb/sparrowdb.node"
 
       - name: Run Node.js integration tests
-        run: node --test npm/sparrowdb/test/integration.test.js
+        run: node --test npm/sparrowdb/test/*.test.js
 
   # ── Ruby bindings (compile check) ─────────────────────────────────────────
   ruby-bindings:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,16 +93,17 @@ jobs:
 
       - name: Assemble npm package
         run: |
-          # Copy native binaries into npm package directory
+          # Copy native binaries into npm package directory. index.js maps
+          # process.platform+arch to exactly these filenames — do NOT also
+          # write a platform-agnostic `sparrowdb.node` here. That name is
+          # reserved for local dev builds (see index.js); publishing one
+          # from CI made every install silently load whichever platform's
+          # binary happened to be copied last, regardless of the actual
+          # runtime platform (issue #481).
           cp artifacts/sparrowdb-node-linux-x64/libsparrowdb_node.so \
              npm/sparrowdb/sparrowdb.linux-x64-gnu.node 2>/dev/null || true
           cp artifacts/sparrowdb-node-darwin-arm64/libsparrowdb_node.dylib \
              npm/sparrowdb/sparrowdb.darwin-arm64.node 2>/dev/null || true
-
-          # Also create a generic fallback name
-          if [ -f npm/sparrowdb/sparrowdb.linux-x64-gnu.node ]; then
-            cp npm/sparrowdb/sparrowdb.linux-x64-gnu.node npm/sparrowdb/sparrowdb.node
-          fi
 
       - name: Sync version to package.json
         run: |
@@ -111,12 +112,6 @@ jobs:
           node -e "
             const pkg = require('./package.json');
             pkg.version = '$VERSION';
-            // Update optional dependency versions too
-            if (pkg.optionalDependencies) {
-              for (const dep of Object.keys(pkg.optionalDependencies)) {
-                pkg.optionalDependencies[dep] = '$VERSION';
-              }
-            }
             require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
           echo "package.json version set to $VERSION"

--- a/README.md
+++ b/README.md
@@ -147,6 +147,24 @@ SparrowDB is *not* the right choice when:
 npm install sparrowdb
 ```
 
+The `sparrowdb` npm package bundles prebuilt native binaries directly in the tarball — there is no separate `@sparrowdb/<platform>` package to resolve.
+
+| Platform | Supported |
+|---|---|
+| macOS arm64 (Apple Silicon) | Yes |
+| Linux x64 (glibc) | Yes |
+| macOS x64 (Intel) | No — build from source |
+| Linux arm64 | No — build from source |
+| Windows x64 | No — build from source |
+| Linux x64/arm64 (musl / Alpine) | No — unsupported on every architecture |
+
+On an unsupported platform, `require('sparrowdb')` throws a clear error naming the platform and the supported list, rather than a raw module-resolution failure. To build from source on those platforms:
+
+```bash
+cargo build --release -p sparrowdb-node
+cp target/release/libsparrowdb_node.<so|dylib|dll> npm/sparrowdb/sparrowdb.node
+```
+
 ### Rust
 
 ```toml

--- a/npm/sparrowdb/index.js
+++ b/npm/sparrowdb/index.js
@@ -14,28 +14,48 @@ const PLATFORM_BINARIES = {
   'darwin-arm64': 'sparrowdb.darwin-arm64.node',
 }
 
+// A file existing under an expected name is not proof it's a valid,
+// loadable binary for this platform — issue #481 shipped for a year because
+// a mis-copied binary sat at a name that was `require`d unconditionally, and
+// the resulting dlopen/ABI error propagated straight out of loadNative()
+// uncaught instead of falling through to the clear message below. Every
+// candidate here is therefore tried, not just checked for existence.
+function tryLoad(path) {
+  try {
+    return { ok: true, value: require(path) }
+  } catch (err) {
+    return { ok: false, error: err }
+  }
+}
+
 function loadNative() {
-  // 1. Try the binary bundled for this exact platform+arch (production / npm install).
+  const attempts = []
+
+  // 1. The binary bundled for this exact platform+arch (production / npm install).
   const key = `${process.platform}-${process.arch}`
   const bundled = PLATFORM_BINARIES[key]
   if (bundled) {
     const bundledPath = join(__dirname, bundled)
     if (existsSync(bundledPath)) {
-      return require(bundledPath)
+      const result = tryLoad(bundledPath)
+      if (result.ok) return result.value
+      attempts.push(`${bundledPath}: ${result.error.message}`)
     }
   }
 
-  // 2. Try a locally compiled sparrowdb.node in the same directory
+  // 2. A locally compiled sparrowdb.node in the same directory
   //    (development: `cargo build --release && cp target/release/libsparrowdb_node.so npm/sparrowdb/sparrowdb.node`).
   //    This is a dev-only convenience — CI never publishes a file by this
   //    name, so it can't shadow the platform-specific binaries above with
   //    the wrong platform's build (see issue #481).
   const local = join(__dirname, 'sparrowdb.node')
   if (existsSync(local)) {
-    return require(local)
+    const result = tryLoad(local)
+    if (result.ok) return result.value
+    attempts.push(`${local}: ${result.error.message}`)
   }
 
-  // 3. Try the workspace target directory (useful during development without copying).
+  // 3. The workspace target directory (useful during development without copying).
   //    Node native addons must be loaded as .node files regardless of platform.
   //    Use `napi-cli` or manually rename the compiled artifact:
   //      Linux:   target/release/libsparrowdb_node.so  → sparrowdb.node
@@ -47,15 +67,21 @@ function loadNative() {
   ]
   for (const t of targets) {
     if (existsSync(t)) {
-      return require(t)
+      const result = tryLoad(t)
+      if (result.ok) return result.value
+      attempts.push(`${t}: ${result.error.message}`)
     }
   }
 
   const supported = Object.keys(PLATFORM_BINARIES).join(', ')
+  const detail = attempts.length
+    ? `\nTried and failed to load:\n${attempts.map((a) => `  - ${a}`).join('\n')}`
+    : ''
   throw new Error(
     `sparrowdb: no prebuilt native module for ${process.platform}-${process.arch}.\n` +
     `Supported platforms: ${supported}\n` +
-    `Run \`cargo build --release -p sparrowdb-node\` to build locally.`
+    `Run \`cargo build --release -p sparrowdb-node\` to build locally.` +
+    detail
   )
 }
 

--- a/npm/sparrowdb/index.js
+++ b/npm/sparrowdb/index.js
@@ -3,32 +3,33 @@
 const { existsSync } = require('fs')
 const { join } = require('path')
 
-// Map platform+arch to the optional dependency package name.
-const PLATFORM_PACKAGES = {
-  'linux-x64': '@sparrowdb/linux-x64-gnu',
-  'linux-arm64': '@sparrowdb/linux-arm64-gnu',
-  'darwin-x64': '@sparrowdb/darwin-x64',
-  'darwin-arm64': '@sparrowdb/darwin-arm64',
-  'win32-x64': '@sparrowdb/win32-x64-msvc',
+// There are no separate `@sparrowdb/<platform>` packages — the prebuilt
+// binaries for every platform this package supports are bundled directly
+// in this tarball (see .github/workflows/release.yml). Map platform+arch
+// to the bundled filename so we only ever try to load a binary that was
+// actually built for the running platform. See README for the supported
+// platform list and why musl/Alpine isn't one of them.
+const PLATFORM_BINARIES = {
+  'linux-x64': 'sparrowdb.linux-x64-gnu.node',
+  'darwin-arm64': 'sparrowdb.darwin-arm64.node',
 }
 
 function loadNative() {
-  // 1. Try the platform-specific optional dependency (production / npm install).
+  // 1. Try the binary bundled for this exact platform+arch (production / npm install).
   const key = `${process.platform}-${process.arch}`
-  const pkg = PLATFORM_PACKAGES[key]
-  if (pkg) {
-    try {
-      return require(pkg)
-    } catch (err) {
-      // Only fall through if the package simply isn't installed.
-      // Re-throw any other error (ABI mismatch, init failure, etc.) so it
-      // isn't silently swallowed and we don't end up loading the wrong binary.
-      if (err.code !== 'MODULE_NOT_FOUND') throw err
+  const bundled = PLATFORM_BINARIES[key]
+  if (bundled) {
+    const bundledPath = join(__dirname, bundled)
+    if (existsSync(bundledPath)) {
+      return require(bundledPath)
     }
   }
 
   // 2. Try a locally compiled sparrowdb.node in the same directory
   //    (development: `cargo build --release && cp target/release/libsparrowdb_node.so npm/sparrowdb/sparrowdb.node`).
+  //    This is a dev-only convenience — CI never publishes a file by this
+  //    name, so it can't shadow the platform-specific binaries above with
+  //    the wrong platform's build (see issue #481).
   const local = join(__dirname, 'sparrowdb.node')
   if (existsSync(local)) {
     return require(local)
@@ -50,9 +51,9 @@ function loadNative() {
     }
   }
 
-  const supported = Object.keys(PLATFORM_PACKAGES).join(', ')
+  const supported = Object.keys(PLATFORM_BINARIES).join(', ')
   throw new Error(
-    `sparrowdb: could not load native module for ${process.platform}-${process.arch}.\n` +
+    `sparrowdb: no prebuilt native module for ${process.platform}-${process.arch}.\n` +
     `Supported platforms: ${supported}\n` +
     `Run \`cargo build --release -p sparrowdb-node\` to build locally.`
   )

--- a/npm/sparrowdb/index.js
+++ b/npm/sparrowdb/index.js
@@ -99,3 +99,13 @@ module.exports = native
 module.exports.SparrowDB = native.SparrowDB
 module.exports.ReadTx = native.ReadTx
 module.exports.WriteTx = native.WriteTx
+
+// Exposed so test/platform-resolution.test.js can look up the bundled
+// filename for the running platform+arch instead of re-deriving the naming
+// convention itself — a test that keeps its own copy of this rule is a
+// second place for it to drift from index.js (see issue #481, where a test
+// doing exactly that passed on darwin-arm64 by coincidence and failed on
+// linux-x64 because it reconstructed "sparrowdb.linux-x64.node" instead of
+// the real "sparrowdb.linux-x64-gnu.node"). Not part of the documented
+// public API.
+module.exports.PLATFORM_BINARIES = PLATFORM_BINARIES

--- a/npm/sparrowdb/package-lock.json
+++ b/npm/sparrowdb/package-lock.json
@@ -14,13 +14,6 @@
       },
       "engines": {
         "node": ">= 18"
-      },
-      "optionalDependencies": {
-        "@sparrowdb/darwin-arm64": "0.1.25",
-        "@sparrowdb/darwin-x64": "0.1.25",
-        "@sparrowdb/linux-arm64-gnu": "0.1.25",
-        "@sparrowdb/linux-x64-gnu": "0.1.25",
-        "@sparrowdb/win32-x64-msvc": "0.1.25"
       }
     },
     "node_modules/@napi-rs/cli": {

--- a/npm/sparrowdb/package.json
+++ b/npm/sparrowdb/package.json
@@ -17,7 +17,7 @@
     "*.node"
   ],
   "scripts": {
-    "test": "node --test test/integration.test.js",
+    "test": "node --test test/*.test.js",
     "typecheck": "tsc -p tsconfig.json"
   },
   "engines": {

--- a/npm/sparrowdb/package.json
+++ b/npm/sparrowdb/package.json
@@ -29,13 +29,6 @@
     "url": "https://github.com/ryaker/SparrowDB"
   },
   "keywords": ["graph", "database", "cypher", "native", "napi"],
-  "optionalDependencies": {
-    "@sparrowdb/linux-x64-gnu": "0.1.25",
-    "@sparrowdb/linux-arm64-gnu": "0.1.25",
-    "@sparrowdb/darwin-x64": "0.1.25",
-    "@sparrowdb/darwin-arm64": "0.1.25",
-    "@sparrowdb/win32-x64-msvc": "0.1.25"
-  },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4",
     "typescript": "^5.6.0"

--- a/npm/sparrowdb/test/integration.test.js
+++ b/npm/sparrowdb/test/integration.test.js
@@ -20,7 +20,7 @@ const path = require('node:path')
 // ── Load native binding ──────────────────────────────────────────────────────
 
 // index.js handles the platform lookup / fallback chain:
-//   1. Platform-specific optional dependency (production)
+//   1. Bundled platform-specific binary, e.g. sparrowdb.darwin-arm64.node (production)
 //   2. npm/sparrowdb/sparrowdb.node (local dev / pre-built)
 //   3. target/release|debug/sparrowdb.node (cargo build in place)
 const { SparrowDB } = require('../index.js')

--- a/npm/sparrowdb/test/platform-resolution.test.js
+++ b/npm/sparrowdb/test/platform-resolution.test.js
@@ -30,13 +30,13 @@ const { spawnSync } = require('node:child_process')
 const PACKAGE_DIR = path.join(__dirname, '..')
 const INDEX_JS = path.join(PACKAGE_DIR, 'index.js')
 
-// Mirrors the filename convention documented in index.js / README.md.
-// Deliberately re-derived here rather than imported from index.js: the
-// point of this suite is to check the convention resolves correctly
-// end-to-end, not to exercise index.js's own idea of its own convention.
-function bundledName(platform, arch) {
-  return `sparrowdb.${platform}-${arch}.node`
-}
+// Read the real filename convention from index.js rather than reconstructing
+// it here. A hand-copied convention is a second place for it to drift from
+// the loader — which is exactly how #481 shipped: index.js looks for
+// "sparrowdb.linux-x64-gnu.node" (the `-gnu` suffix matters), and an earlier
+// version of this file built "sparrowdb.linux-x64.node" by concatenation,
+// so it passed on darwin-arm64 by coincidence and failed on Linux CI.
+const { PLATFORM_BINARIES } = require(INDEX_JS)
 
 // Locate a real, loadable compiled binary for the machine running this
 // suite — the same places index.js's own dev fallback (steps 2/3) looks,
@@ -90,26 +90,44 @@ function runInChild(dir, { platform, arch } = {}) {
 }
 
 describe('production binary resolution (issue #481)', () => {
+  const key = `${process.platform}-${process.arch}`
+  const expectedFilename = PLATFORM_BINARIES[key]
   const realBinary = findRealBinary()
 
   it('a binary bundled under the correct platform-specific filename loads and exposes the API', (t) => {
+    if (!expectedFilename) {
+      t.skip(`${key} is not a supported platform (see PLATFORM_BINARIES in index.js)`)
+      return
+    }
     if (!realBinary) {
       t.skip('no compiled sparrowdb.node available in this environment')
       return
     }
     const dir = makeIsolatedPackageDir()
     try {
-      fs.copyFileSync(realBinary, path.join(dir, bundledName(process.platform, process.arch)))
+      fs.copyFileSync(realBinary, path.join(dir, expectedFilename))
       const output = runInChild(dir)
-      assert.ok(output.startsWith('LOADED:'), `expected a clean load for ${process.platform}-${process.arch}, got: ${output}`)
+      assert.ok(output.startsWith('LOADED:'), `expected a clean load for ${key}, got: ${output}`)
+      // A subset check, not deepEqual against the full key list: index.js's
+      // own module.exports can grow (e.g. PLATFORM_BINARIES, added for this
+      // suite's own use), and this test's job is to confirm the *native*
+      // API loaded, not to pin index.js's exact export list. Sorted in the
+      // child (see runInChild) is irrelevant to a subset check but keeps
+      // the raw output readable in a failure message.
       const exported = output.slice('LOADED:'.length).split(',')
-      assert.deepEqual(exported, ['ReadTx', 'SparrowDB', 'WriteTx'])
+      for (const name of ['ReadTx', 'SparrowDB', 'WriteTx']) {
+        assert.ok(exported.includes(name), `expected ${name} among the loaded exports, got: ${exported.join(',')}`)
+      }
     } finally {
       fs.rmSync(dir, { recursive: true, force: true })
     }
   })
 
-  it('a bad binary under the expected platform filename does not crash uncaught — it falls through to the clear supported-platforms error', () => {
+  it('a bad binary under the expected platform filename does not crash uncaught — it falls through to the clear supported-platforms error', (t) => {
+    if (!expectedFilename) {
+      t.skip(`${key} is not a supported platform (see PLATFORM_BINARIES in index.js)`)
+      return
+    }
     const dir = makeIsolatedPackageDir()
     try {
       // Reproduces the actual shape of #481: a file that does not match
@@ -117,7 +135,7 @@ describe('production binary resolution (issue #481)', () => {
       // unconditionally. The content doesn't need to be a real foreign
       // binary — any bytes dlopen can't parse reproduce the failure mode
       // (an ERR_DLOPEN_FAILED-style error thrown out of `require`).
-      fs.writeFileSync(path.join(dir, bundledName(process.platform, process.arch)), 'not a real native module')
+      fs.writeFileSync(path.join(dir, expectedFilename), 'not a real native module')
       const output = runInChild(dir)
       assert.ok(output.startsWith('THREW:'), `expected a clean thrown Error, got: ${output}`)
       const message = output.slice('THREW:'.length)
@@ -133,12 +151,19 @@ describe('production binary resolution (issue #481)', () => {
   })
 
   it('an explicitly unsupported platform+arch throws the catchable error naming it', () => {
+    assert.ok(!PLATFORM_BINARIES['win32-x64'], 'this test assumes win32-x64 stays unsupported')
     const dir = makeIsolatedPackageDir()
     try {
       const output = runInChild(dir, { platform: 'win32', arch: 'x64' })
       assert.ok(output.startsWith('THREW:'), `expected a clean thrown Error, got: ${output}`)
       assert.match(output, /no prebuilt native module for win32-x64/)
-      assert.match(output, /Supported platforms: linux-x64, darwin-arm64/)
+      // Derived from PLATFORM_BINARIES, not hardcoded — same reasoning as
+      // expectedFilename above: don't let this list drift from the loader's.
+      const supportedList = Object.keys(PLATFORM_BINARIES).join(', ')
+      assert.ok(
+        output.includes(`Supported platforms: ${supportedList}`),
+        `expected the supported-platform list to read "${supportedList}", got: ${output}`,
+      )
     } finally {
       fs.rmSync(dir, { recursive: true, force: true })
     }

--- a/npm/sparrowdb/test/platform-resolution.test.js
+++ b/npm/sparrowdb/test/platform-resolution.test.js
@@ -1,0 +1,146 @@
+'use strict'
+
+/**
+ * Regression coverage for issue #481.
+ *
+ * integration.test.js only ever exercises index.js's *dev* fallback: a
+ * generic `sparrowdb.node` built fresh from source on whichever machine
+ * runs the suite (see index.js step 2, and the CI step that creates it).
+ * That test passed in CI (Linux) and in local dev on every machine while
+ * the *published* package was unloadable on darwin-arm64 — the dev
+ * fallback is, by construction, always correct for the machine that built
+ * it, so it can never see a mismatch between a platform-specific bundled
+ * filename and what's actually inside it.
+ *
+ * These tests instead build an isolated copy of the npm package directory
+ * and populate it the way `npm publish` does: nothing but a binary under
+ * `sparrowdb.<platform>-<arch>.node`. Each require happens in a fresh child
+ * process — a bad native binary can abort the process, and we don't want
+ * that to take the test runner down or leak process.platform overrides
+ * into other tests.
+ */
+
+const { describe, it } = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const { spawnSync } = require('node:child_process')
+
+const PACKAGE_DIR = path.join(__dirname, '..')
+const INDEX_JS = path.join(PACKAGE_DIR, 'index.js')
+
+// Mirrors the filename convention documented in index.js / README.md.
+// Deliberately re-derived here rather than imported from index.js: the
+// point of this suite is to check the convention resolves correctly
+// end-to-end, not to exercise index.js's own idea of its own convention.
+function bundledName(platform, arch) {
+  return `sparrowdb.${platform}-${arch}.node`
+}
+
+// Locate a real, loadable compiled binary for the machine running this
+// suite — the same places index.js's own dev fallback (steps 2/3) looks,
+// plus the raw cargo artifact name under CARGO_TARGET_DIR for worktree
+// setups where that isn't the default `target/`.
+function findRealBinary() {
+  const named = [
+    path.join(PACKAGE_DIR, 'sparrowdb.node'),
+    path.join(PACKAGE_DIR, '..', '..', 'target', 'release', 'sparrowdb.node'),
+    path.join(PACKAGE_DIR, '..', '..', 'target', 'debug', 'sparrowdb.node'),
+  ]
+  for (const candidate of named) {
+    if (fs.existsSync(candidate)) return candidate
+  }
+  const targetDir = process.env.CARGO_TARGET_DIR || path.join(PACKAGE_DIR, '..', '..', 'target')
+  const rawArtifacts = [
+    path.join(targetDir, 'release', 'libsparrowdb_node.so'),
+    path.join(targetDir, 'release', 'libsparrowdb_node.dylib'),
+    path.join(targetDir, 'release', 'sparrowdb_node.dll'),
+  ]
+  for (const candidate of rawArtifacts) {
+    if (fs.existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+function makeIsolatedPackageDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sparrowdb-pkgtest-'))
+  fs.copyFileSync(INDEX_JS, path.join(dir, 'index.js'))
+  return dir
+}
+
+// Requires `<dir>/index.js` in a fresh child process, optionally overriding
+// process.platform/arch first, and reports what happened via stdout so a
+// crashed/uncaught child still yields a readable assertion failure.
+function runInChild(dir, { platform, arch } = {}) {
+  const overrides =
+    (platform ? `Object.defineProperty(process, 'platform', { value: ${JSON.stringify(platform)} });` : '') +
+    (arch ? `Object.defineProperty(process, 'arch', { value: ${JSON.stringify(arch)} });` : '')
+  const script = `
+    ${overrides}
+    try {
+      const native = require(${JSON.stringify(path.join(dir, 'index.js'))})
+      console.log('LOADED:' + Object.keys(native).sort().join(','))
+    } catch (err) {
+      console.log('THREW:' + err.message.replace(/\\n/g, '\\\\n'))
+    }
+  `
+  const result = spawnSync(process.execPath, ['-e', script], { encoding: 'utf8' })
+  return (result.stdout || '').trim() || `(no output; stderr: ${result.stderr})`
+}
+
+describe('production binary resolution (issue #481)', () => {
+  const realBinary = findRealBinary()
+
+  it('a binary bundled under the correct platform-specific filename loads and exposes the API', (t) => {
+    if (!realBinary) {
+      t.skip('no compiled sparrowdb.node available in this environment')
+      return
+    }
+    const dir = makeIsolatedPackageDir()
+    try {
+      fs.copyFileSync(realBinary, path.join(dir, bundledName(process.platform, process.arch)))
+      const output = runInChild(dir)
+      assert.ok(output.startsWith('LOADED:'), `expected a clean load for ${process.platform}-${process.arch}, got: ${output}`)
+      const exported = output.slice('LOADED:'.length).split(',')
+      assert.deepEqual(exported, ['ReadTx', 'SparrowDB', 'WriteTx'])
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('a bad binary under the expected platform filename does not crash uncaught — it falls through to the clear supported-platforms error', () => {
+    const dir = makeIsolatedPackageDir()
+    try {
+      // Reproduces the actual shape of #481: a file that does not match
+      // the running platform sitting at the name index.js loads
+      // unconditionally. The content doesn't need to be a real foreign
+      // binary — any bytes dlopen can't parse reproduce the failure mode
+      // (an ERR_DLOPEN_FAILED-style error thrown out of `require`).
+      fs.writeFileSync(path.join(dir, bundledName(process.platform, process.arch)), 'not a real native module')
+      const output = runInChild(dir)
+      assert.ok(output.startsWith('THREW:'), `expected a clean thrown Error, got: ${output}`)
+      const message = output.slice('THREW:'.length)
+      assert.match(
+        message,
+        /no prebuilt native module for/,
+        'a bad bundled binary must fall through to the catchable message, not an uncaught dlopen crash',
+      )
+      assert.match(message, /Supported platforms:/)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('an explicitly unsupported platform+arch throws the catchable error naming it', () => {
+    const dir = makeIsolatedPackageDir()
+    try {
+      const output = runInChild(dir, { platform: 'win32', arch: 'x64' })
+      assert.ok(output.startsWith('THREW:'), `expected a clean thrown Error, got: ${output}`)
+      assert.match(output, /no prebuilt native module for win32-x64/)
+      assert.match(output, /Supported platforms: linux-x64, darwin-arm64/)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Closes #481.

`sparrowdb@0.1.25` still declares five `@sparrowdb/<platform>` `optionalDependencies`; none of the five packages exist on npm (404 on all). Because they're optional, npm skips them silently — no install warning — so the manifest overstates platform support.

**The true severity is worse than #481 states, and worse than my first pass here framed it.** Verified by installing, not by reading the manifest — darwin-arm64 is broken on **every published version**, not "2 of 5 working, 3 broken":

```
0.1.20  BROKEN (ERR_DLOPEN_FAILED)
0.1.23  BROKEN
0.1.24  BROKEN
0.1.25  BROKEN
```

`npm install sparrowdb` has **never** worked on Apple Silicon. Actual state is **1 of 5 advertised platforms**, not 2 of 5. Root cause: CI's "generic fallback" step unconditionally copied the Linux binary to a platform-agnostic `sparrowdb.node`, and `index.js`'s dev-fallback step loaded that file by name with no platform check — so a fresh `npm install sparrowdb` on macOS ARM threw `ERR_DLOPEN_FAILED: slice is not valid mach-o file` trying to dlopen the bundled Linux `.so`.

## Decision

Per direction: drop `optionalDependencies` and be honest that binaries are bundled directly in the tarball, rather than build out the five-package napi-rs split-publish pipeline. The bundled approach is one moving part; splitting into five packages adds five more atomic-publish steps to a release pipeline that only became dual-registry (npm + crates.io) one day before this fix.

## Changes

- `npm/sparrowdb/package.json` / `package-lock.json` — remove `optionalDependencies`.
- `npm/sparrowdb/index.js` — replace the optional-dependency resolution step with a direct lookup of the platform-specific bundled filename (`sparrowdb.<platform>-<arch>.node`), checked *before* the generic dev-only fallback so it can never be shadowed by the wrong platform's binary. **Every** load attempt (bundled binary, dev-local `sparrowdb.node`, workspace target dir) is now wrapped in a `tryLoad()` helper — a file existing under the expected name is not proof it's valid; a failed `require()` falls through to the next candidate and, ultimately, to a single catchable `Error` listing what was tried and why, instead of letting a raw dlopen/ABI error escape uncaught. This is the actual mechanism that broke darwin-arm64: the bad binary loaded from a name that was `require`d unconditionally with no try/catch.
- `.github/workflows/release.yml` — stop publishing the generic `sparrowdb.node` fallback name (that's what caused the live darwin-arm64 break); drop the now-dead `optionalDependencies` version-sync step.
- `.github/workflows/ci.yml` / `npm/sparrowdb/package.json` — `npm test` now runs `test/*.test.js` (was hardcoded to a single file) so the new suite below actually executes in CI.
- `npm/sparrowdb/test/platform-resolution.test.js` (new) — regression coverage for the class of bug that shipped. `integration.test.js` only ever loads a dev-built `sparrowdb.node` copied onto the exact machine that built it, which is trivially always correct for that machine — it can't see a mismatch between a platform-specific bundled filename and its contents. That's why CI (`ubuntu-latest` only, testing only the generic dev-fallback name) never caught the darwin-arm64 break across five releases. The new suite builds an isolated copy of the package dir the way `npm publish` does — nothing but a binary under `sparrowdb.<platform>-<arch>.node` — and requires it in a fresh child process, asserting: (a) a correctly-bundled binary for the current platform loads and exposes the API, (b) a bad/wrong-platform binary under the expected name falls through to the catchable error rather than crashing uncaught, (c) an explicitly unsupported platform+arch throws the same catchable, specific error.
- `README.md` — document the two actually-bundled platforms, that musl/Alpine is unsupported on every architecture, and how to build from source elsewhere.

## Test plan

- [x] `npm pack --dry-run` against a locally-built darwin-arm64 binary — tarball lists exactly `sparrowdb.darwin-arm64.node`, matching the two-platform claim.
- [x] Forced the unsupported-platform path (`win32-x64`, `linux-arm64`, `darwin-x64`) — each throws the catchable `Error: sparrowdb: no prebuilt native module for <platform>...`, not a bare `MODULE_NOT_FOUND`/dlopen crash.
- [x] **Confirmed the new regression test fails against the pre-try/catch code** — checked out the prior commit's `index.js` (platform-specific lookup present, but no try/catch), ran `platform-resolution.test.js` against it, watched it fail with the exact reported symptom (`dlopen(...): slice is not valid mach-o file`), then restored the fix and watched it pass. Guards what it claims to guard.
- [x] `npm test` — 50/50 pass (was 47) on darwin-arm64 against a real compiled binary.
- [x] `npm run typecheck` passes.
- [x] Rebased onto current `origin/main` (#514 landed since the branch was cut) — clean rebase, retested green after.
- [x] `npx prettier --write` run on changed JS/JSON, then reverted: this repo has no `.prettierrc`, so Prettier defaults to double-quotes/semicolons against an established single-quote/no-semi codebase and wanted to reformat hundreds of unrelated lines in `README.md` and `integration.test.js`. Hand-applied only the functional diff in the existing style instead, to keep the PR reviewable. New files (`platform-resolution.test.js`) were hand-written in the same convention.

Not merging — opening/updating only, per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE