### PR TITLE
chore: bump 0.1.25 → 0.1.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.25"
+version = "0.1.26"
 edition = "2021"
 license = "MIT"
 authors = ["Rich Yaker"]
@@ -28,13 +28,13 @@ documentation = "https://docs.rs/sparrowdb"
 readme = "README.md"
 
 [workspace.dependencies]
-sparrowdb-common = { path = "crates/sparrowdb-common", version = "0.1.25" }
-sparrowdb-storage = { path = "crates/sparrowdb-storage", version = "0.1.25" }
-sparrowdb-catalog = { path = "crates/sparrowdb-catalog", version = "0.1.25" }
-sparrowdb-cypher  = { path = "crates/sparrowdb-cypher", version = "0.1.25" }
-sparrowdb-execution = { path = "crates/sparrowdb-execution", version = "0.1.25" }
-sparrowdb = { path = "crates/sparrowdb", version = "0.1.25" }
-sparrowdb-metrics = { path = "crates/sparrowdb-metrics", version = "0.1.25" }
+sparrowdb-common = { path = "crates/sparrowdb-common", version = "0.1.26" }
+sparrowdb-storage = { path = "crates/sparrowdb-storage", version = "0.1.26" }
+sparrowdb-catalog = { path = "crates/sparrowdb-catalog", version = "0.1.26" }
+sparrowdb-cypher  = { path = "crates/sparrowdb-cypher", version = "0.1.26" }
+sparrowdb-execution = { path = "crates/sparrowdb-execution", version = "0.1.26" }
+sparrowdb = { path = "crates/sparrowdb", version = "0.1.26" }
+sparrowdb-metrics = { path = "crates/sparrowdb-metrics", version = "0.1.26" }
 tiny_http         = "0.12"
 tempfile          = "3"
 crc32fast         = "1"

--- a/crates/sparrowdb-python/pyproject.toml
+++ b/crates/sparrowdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "sparrowdb-py"
-version = "0.1.8"
+version = "0.1.26"
 description = "Python bindings for SparrowDB embedded graph database"
 requires-python = ">=3.9"
 license = { text = "MIT OR Apache-2.0" }

--- a/crates/sparrowdb-ruby/Cargo.toml
+++ b/crates/sparrowdb-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sparrowdb-ruby"
-version = "0.1.8"
+version = "0.1.26"
 edition = "2021"
 # Ships as a Ruby gem (extconf.rb + Gemfile + lib/), not as a crate. It has never
 # been published to crates.io and cannot be: its path dependencies carry no version

--- a/npm/sparrowdb/package-lock.json
+++ b/npm/sparrowdb/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparrowdb",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparrowdb",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",

--- a/npm/sparrowdb/package.json
+++ b/npm/sparrowdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparrowdb",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Native Node.js/TypeScript bindings for SparrowDB — embedded graph database with Cypher query support",
   "main": "index.js",
   "types": "index.d.ts",
@@ -28,7 +28,13 @@
     "type": "git",
     "url": "https://github.com/ryaker/SparrowDB"
   },
-  "keywords": ["graph", "database", "cypher", "native", "napi"],
+  "keywords": [
+    "graph",
+    "database",
+    "cypher",
+    "native",
+    "napi"
+  ],
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4",
     "typescript": "^5.6.0"


### PR DESCRIPTION
Version bump for **0.1.26**. Cut specifically to ship #517.

## Why now

**`npm install sparrowdb` has never worked on macOS ARM.** Verified by installing each published version on this Mac mini (darwin/arm64, Node 22.22.0) rather than reading the manifest:

| version | result |
|---|---|
| 0.1.20 | `ERR_DLOPEN_FAILED` |
| 0.1.23 | `ERR_DLOPEN_FAILED` |
| 0.1.24 | `ERR_DLOPEN_FAILED` |
| 0.1.25 | `ERR_DLOPEN_FAILED` |

Real platform coverage was **1 of 5** advertised — not the 2 of 5 that #481 and our own notes claimed. Both had inferred it from seeing the right `.node` file in the tarball; a different file was being loaded.

## What ships

- **#517 / #481** — `index.js` resolved through five `@sparrowdb/*` `optionalDependencies` that were never published, then fell through to a generic `sparrowdb.node` that CI had filled with a copy of the **Linux x86-64** binary. The correct Mach-O arm64 file was in the tarball the whole time, unused. Load failures are now catchable and name the real dlopen cause instead of escaping uncaught.
- **#516 / #459** — `hybrid_search()` / `full_text_search()` / `bm25_score()` returned Null from `MATCH … RETURN` and `UNWIND … RETURN` against a **healthy** index.
- **#514 / #444, #430** — `RETURN n.prop AS alias` silently returned Null unless `alias == prop`; the same path fabricated rows for multi-hop patterns after `WITH` that don't exist in the graph.
- **#512 / #436** — `DELETE` left dangling edges and `DETACH DELETE` polluted across rel tables.
- **#511 / #449** — `index.d.ts` did not parse as TypeScript.

Every fix ships with regression tests confirmed to fail against their parent commit.

## Expected failure on the release run

`update-homebrew-tap` **will fail** — `TAP_GITHUB_TOKEN` is expired (#508). That job is a leaf in `release.yml` (nothing declares `needs:` on it), and `npm-publish` / `publish-crates` sit on independent branches, so **npm and crates.io publish regardless**. The only consequence is a stale Homebrew formula. Publishing is not transactional — the artifacts are out before the leaf fails.

## Verification

- `cargo check -p sparrowdb` clean at 0.1.26 across all workspace crates.
- No `0.1.25` remains in any tracked `.toml` / `.json` / `.lock`.
- Confirmed the sync script did **not** re-introduce the `optionalDependencies` that #517 removed — it only re-expanded the `keywords` array that prettier had collapsed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SparrowDB release version to 0.1.26 across supported packages and integrations.
  * Synchronized package metadata for Python, Ruby, Rust, and npm distributions.
  * Reformatted npm package keywords for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->