### PR TITLE
fix(db): refuse vector writes to a quarantined-no-live-index pair (#451)

### DIFF
--- a/crates/sparrowdb-node/src/lib.rs
+++ b/crates/sparrowdb-node/src/lib.rs
@@ -293,6 +293,7 @@ pub struct VectorIndexHealth {
 ///   prop: string;    // vector property the index was built on
 ///   path: string;    // exact file on disk; the machine-readable field
 ///   reason: string;  // human-readable; see the caveat below
+///   kind: string;    // "live_unserviceable" | "quarantined_no_live_index" — see below
 /// }
 /// ```
 ///
@@ -301,6 +302,20 @@ pub struct VectorIndexHealth {
 /// RECONSTRUCTED rather than recovered, because #442 reports the original
 /// decode failure only in the error it returns at quarantine time and writes no
 /// sidecar. Do not parse it and do not present it as the authoritative cause.
+///
+/// `kind` is the machine-checkable version of the same distinction `reason`
+/// only describes in prose (#451):
+/// - `"live_unserviceable"` — a `.bin` is present but does not resolve or does
+///   not load. `SparrowDB.open` (the Rust/other-binding equivalent) refuses to
+///   start while this is true; there is no running store to guard a write on.
+/// - `"quarantined_no_live_index"` — a `.bin.corrupt.<millis>` quarantine
+///   artifact is present and no live index currently serves the pair. The
+///   store **opened successfully** and looks healthy, but
+///   `db.executeWithParams` now throws on a vector write against this exact
+///   `(label, prop)` instead of silently discarding it — see
+///   `SparrowDB.prototype.executeWithParams`. Call `db.createVectorIndex(...)`
+///   to clear it; the entry then moves from `active` to `historical` on the
+///   next `vectorIndexDamageScan`/`vectorIndexLoadFailures` call.
 ///
 /// The `//` comments above are deliberate rather than nested doc comments: a
 /// close-comment marker inside a generated JSDoc block ends it early, which is
@@ -318,6 +333,10 @@ pub struct VectorIndexLoadFailure {
     /// Human-readable description. Reconstructed for quarantine artifacts;
     /// not authoritative and not machine-parseable.
     pub reason: String,
+    /// `"live_unserviceable"` or `"quarantined_no_live_index"` — see the
+    /// struct doc comment. Check this before deciding whether a vector write
+    /// against this `(label, prop)` would currently succeed or throw.
+    pub kind: String,
 }
 
 /// Convert the crate-level health report into its napi shape.
@@ -326,6 +345,16 @@ pub struct VectorIndexLoadFailure {
 /// valid UTF-8 must still be reported, and these functions have no error
 /// channel by design.
 fn to_damage_report(health: ::sparrowdb::VectorIndexHealth) -> VectorIndexDamageReport {
+    fn kind_str(kind: ::sparrowdb::VectorIndexFailureKind) -> String {
+        match kind {
+            ::sparrowdb::VectorIndexFailureKind::LiveUnserviceable => {
+                "live_unserviceable".to_owned()
+            }
+            ::sparrowdb::VectorIndexFailureKind::QuarantinedNoLiveIndex => {
+                "quarantined_no_live_index".to_owned()
+            }
+        }
+    }
     fn convert(v: Vec<::sparrowdb::VectorIndexFailure>) -> Vec<VectorIndexLoadFailure> {
         v.into_iter()
             .map(|f| VectorIndexLoadFailure {
@@ -333,6 +362,7 @@ fn to_damage_report(health: ::sparrowdb::VectorIndexHealth) -> VectorIndexDamage
                 prop: f.prop,
                 path: f.path.to_string_lossy().into_owned(),
                 reason: f.reason,
+                kind: kind_str(f.kind),
             })
             .collect()
     }
@@ -471,11 +501,21 @@ impl SparrowDB {
     /// - **already quarantined** — `hnsw_<label>_<prop>.bin.corrupt.<millis>`,
     ///   bytes a previous load attempt moved aside (#442).
     ///
-    /// The second arm is why this is the only usable health signal for #451:
-    /// once a damaged file has been quarantined, the *first* `open` has already
-    /// thrown and every later `open` succeeds with the index silently absent,
-    /// so vector writes for that pair are dropped and searches return nothing.
-    /// Nothing else distinguishes that store from a healthy one.
+    /// The second arm used to be the *only* usable signal for #451: once a
+    /// damaged file had been quarantined, the *first* `open` had already
+    /// thrown and every later `open` succeeded with the index silently
+    /// absent, and nothing else distinguished that store from a healthy one
+    /// — vector writes for that pair were dropped or, after #475, rejected
+    /// with a message naming neither the pair nor the quarantine.
+    ///
+    /// That is fixed as of #451: a vector write against a `(label, prop)` in
+    /// this state now throws, naming the label, the property, and this exact
+    /// quarantine artifact — see `SparrowDB.prototype.executeWithParams`.
+    /// This diagnostic remains the way to find the condition *before* a write
+    /// hits it, and each entry's `kind` field
+    /// (`VectorIndexLoadFailure.kind === "quarantined_no_live_index"`) is now
+    /// the machine-checkable way to tell it apart from a `"live_unserviceable"`
+    /// entry, which `open()` refusing to start already makes loud on its own.
     ///
     /// **Read-only since #456.** It used to quarantine the live entries it
     /// probed, so a second call answered differently from the first and the

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -9,8 +9,8 @@ use crate::helpers::{
     build_label_row_counts_from_disk, collect_maintenance_params, dir_size_bytes, eval_expr_merge,
     exec_value_to_storage, expr_to_value, expr_to_value_with_params, fnv1a_col_id,
     is_edge_delete_mutation, is_reserved_label, load_constraints, load_vector_indexes,
-    open_csr_map, resolve_create_prop_value, save_constraints, storage_value_to_exec,
-    try_open_csr_map, VectorIndexHealth,
+    open_csr_map, quarantined_no_index_pairs, resolve_create_prop_value, save_constraints,
+    storage_value_to_exec, try_open_csr_map, VectorIndexHealth,
 };
 use crate::read_tx::ReadTx;
 use crate::types::{DbInner, NodeVersions, PendingOp, VersionStore, WriteBuffer, WriteGuard};
@@ -121,6 +121,13 @@ impl GraphDb {
             0
         };
         let vector_indexes = RwLock::new(load_vector_indexes(path)?);
+        // #451: `load_vector_indexes` above just ran the identical directory
+        // scan and would have already refused to open had it failed, so this
+        // second (cheap, names-only) pass is known-good.  It seeds the
+        // write-guard that keeps a "clean" second `open()` after a quarantine
+        // from silently dropping every subsequent vector write for the
+        // affected pair — see `DbInner::quarantined_vector_writes`.
+        let quarantined_vector_writes = RwLock::new(quarantined_no_index_pairs(path));
         Ok(GraphDb {
             inner: Arc::new(DbInner {
                 path: path.to_path_buf(),
@@ -139,6 +146,7 @@ impl GraphDb {
                 active_readers: Mutex::new(BTreeMap::new()),
                 commits_since_gc: AtomicU64::new(0),
                 vector_indexes,
+                quarantined_vector_writes,
             }),
         })
     }
@@ -186,6 +194,8 @@ impl GraphDb {
             0
         };
         let vector_indexes = RwLock::new(load_vector_indexes(path)?);
+        // See the identical comment in `GraphDb::open` (#451).
+        let quarantined_vector_writes = RwLock::new(quarantined_no_index_pairs(path));
         Ok(GraphDb {
             inner: Arc::new(DbInner {
                 path: path.to_path_buf(),
@@ -204,6 +214,7 @@ impl GraphDb {
                 active_readers: Mutex::new(BTreeMap::new()),
                 commits_since_gc: AtomicU64::new(0),
                 vector_indexes,
+                quarantined_vector_writes,
             }),
         })
     }
@@ -1474,39 +1485,86 @@ impl GraphDb {
         Ok(QueryResult::empty(vec![]))
     }
 
-    /// True when `value` is a `$param` reference bound to `Value::Vector` for
-    /// a property that has a registered HNSW vector index.
+    /// Build the #451 write-refusal error for `(label, prop)`, if that pair
+    /// currently has an unrecovered quarantine artifact and no live index.
     ///
-    /// A vector has no property-column representation — `exec_value_to_storage`
-    /// rejects it (#475/#473) — but a vector `$param` on a genuinely indexed
-    /// property is a real, tested feature (#410): it is written to the HNSW
-    /// index by a dedicated block, not the property column. Callers use this
-    /// to skip the column write for exactly that one case, so the value
-    /// resolver's rejection only fires for a vector with nowhere to go (no
-    /// index registered for this property at all), not for the indexed case
-    /// this whole write-path exists to support.
-    fn set_value_is_indexed_vector_param(
+    /// `None` means the pair is not in that state — either it was never
+    /// indexed, or a live index already serves it — and the caller should
+    /// fall through to its existing behaviour unchanged.
+    fn quarantine_write_blocked_error(&self, label: &str, prop: &str) -> Option<Error> {
+        let guard = self
+            .inner
+            .quarantined_vector_writes
+            .read()
+            .expect("quarantined_vector_writes poisoned");
+        let paths = guard.get(&(label.to_string(), prop.to_string()))?;
+        let path_list = paths
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        Some(Error::Corruption(format!(
+            "vector write to ({label}, {prop}) refused: a previous load quarantined this \
+             index's bytes ({path_list}) and no live index has replaced it since. `open()` \
+             already succeeded — this pair looks configured but every vector write to it is \
+             being silently discarded and every search silently returns nothing (#451). To \
+             recover: call createVectorIndex('{label}', '{prop}', <dimensions>, <similarity>) \
+             to register a fresh index, then retry this write. The quarantined bytes are the \
+             only surviving evidence of the original damage; if the vectors themselves need to \
+             be recovered from them, do that before or alongside re-registering the index."
+        )))
+    }
+
+    /// Decide how a SET-clause value bound to `(label, prop)` should be
+    /// handled, and fail loudly right here when it must not proceed.
+    ///
+    /// `Ok(true)` — `value` is a `$param` bound to a vector and a live HNSW
+    /// index is registered for `(label, prop)`. The caller must skip the
+    /// ordinary property-column write for this value: it is written to the
+    /// HNSW index by a dedicated block instead (#410), never to the property
+    /// column — a vector has no column representation and
+    /// `exec_value_to_storage` rejects it (#475/#473).
+    ///
+    /// `Ok(false)` — not that case. The caller proceeds with its existing
+    /// write path unchanged, including the existing rejection a non-scalar
+    /// value with no live index hits today.
+    ///
+    /// `Err(_)` — `(label, prop)` has an unrecovered #451 quarantine artifact
+    /// and no live index. The caller must propagate this immediately rather
+    /// than let the value fall through to the ordinary write path, whose
+    /// rejection does not mention quarantine, the artifact, or how to
+    /// recover — the entire reason this check exists.
+    fn resolve_vector_write_route(
         &self,
         value: &sparrowdb_cypher::ast::Expr,
+        label: &str,
         prop: &str,
         params: &HashMap<String, sparrowdb_execution::Value>,
-    ) -> bool {
+    ) -> Result<bool> {
         use sparrowdb_cypher::ast::{Expr, Literal};
         let Expr::Literal(Literal::Param(p)) = value else {
-            return false;
+            return Ok(false);
         };
         let Some(v) = params.get(p.as_str()) else {
-            return false;
+            return Ok(false);
         };
         if v.as_vector().is_none() {
-            return false;
+            return Ok(false);
         }
-        self.inner
+        let key = (label.to_string(), prop.to_string());
+        if self
+            .inner
             .vector_indexes
             .read()
             .expect("vector_indexes")
-            .keys()
-            .any(|(_, prop_name)| prop_name == prop)
+            .contains_key(&key)
+        {
+            return Ok(true);
+        }
+        match self.quarantine_write_blocked_error(label, prop) {
+            Some(e) => Err(e),
+            None => Ok(false),
+        }
     }
 
     /// Params-aware MERGE with $param support (SPA-218).
@@ -1517,17 +1575,18 @@ impl GraphDb {
     ) -> Result<QueryResult> {
         // A vector `$param` bound to an indexed property is written to the
         // HNSW index by the block below, not the merge-key/property columns
-        // — see `set_value_is_indexed_vector_param`. Excluded from `props`
-        // here rather than resolved to a storage `Value`.
-        let props: HashMap<String, Value> = m
-            .props
-            .iter()
-            .filter(|pe| !self.set_value_is_indexed_vector_param(&pe.value, &pe.key, params))
-            .map(|pe| {
-                let val = expr_to_value_with_params(&pe.value, params)?;
-                Ok((pe.key.clone(), val))
-            })
-            .collect::<Result<HashMap<_, _>>>()?;
+        // — see `resolve_vector_write_route`. Excluded from `props` here
+        // rather than resolved to a storage `Value`. A pair with a #451
+        // quarantine artifact and no live index fails loudly right here,
+        // before `merge_node` ever runs.
+        let mut props: HashMap<String, Value> = HashMap::new();
+        for pe in &m.props {
+            if self.resolve_vector_write_route(&pe.value, &m.label, &pe.key, params)? {
+                continue;
+            }
+            let val = expr_to_value_with_params(&pe.value, params)?;
+            props.insert(pe.key.clone(), val);
+        }
         let mut tx = self.begin_write()?;
         let dirty_before = tx.dirty_nodes.len();
         let node_id = tx.merge_node(&m.label, props)?;
@@ -1542,7 +1601,7 @@ impl GraphDb {
         };
         for mutation in on_set_items {
             if let sparrowdb_cypher::ast::Mutation::Set { prop, value, .. } = mutation {
-                if self.set_value_is_indexed_vector_param(value, prop, params) {
+                if self.resolve_vector_write_route(value, &m.label, prop, params)? {
                     continue;
                 }
                 let sv = expr_to_value_with_params(value, params)?;
@@ -1663,20 +1722,54 @@ impl GraphDb {
         if matching_ids.is_empty() {
             return Ok(QueryResult::empty(vec![]));
         }
+        // Resolved once, up front, from the catalog: needed both by the
+        // per-node vector-write routing below and by the HNSW write-path
+        // block further down.  Label is derived per matched NodeId (upper 32
+        // bits of node_id.0 encode the label_id) rather than from the AST.
+        // This correctly handles:
+        //   • Anonymous matches (`MATCH (n) SET n.embedding = $emb`) where
+        //     the AST carries no label — the label is resolved from the node.
+        //   • Multi-pattern queries: each matched node's label is used, not
+        //     the first MATCH pattern's label (multi-pattern is currently
+        //     rejected by the engine guard, but this code is future-proof).
+        let cat = self.catalog_snapshot();
+        let label_id_to_name: std::collections::HashMap<u16, String> =
+            cat.list_labels().unwrap_or_default().into_iter().collect();
+        let node_label = |node_id: &NodeId| -> &str {
+            let lid = (node_id.0 >> 32) as u16;
+            label_id_to_name.get(&lid).map(String::as_str).unwrap_or("")
+        };
+
         let mut has_detach_delete = false;
         for mutation in &mm.mutations {
             match mutation {
                 sparrowdb_cypher::ast::Mutation::Set { prop, value, .. } => {
                     // A vector `$param` bound to an indexed property has no
                     // property-column representation — it is written to the
-                    // HNSW index by the dedicated block below instead. Skip
-                    // the column write for this one mutation.
-                    if self.set_value_is_indexed_vector_param(value, prop, params) {
-                        continue;
-                    }
-                    let sv = expr_to_value_with_params(value, params)?;
+                    // HNSW index by the dedicated block below instead.
+                    // Routed per matched node's own label so a #451
+                    // quarantine-blocked `(label, prop)` fails loudly right
+                    // here, before any property write for it is attempted,
+                    // and a live-indexed pair is skipped correctly even when
+                    // other matched nodes carry a different label that
+                    // happens to share the property name.
+                    let mut to_write: Vec<NodeId> = Vec::with_capacity(matching_ids.len());
                     for node_id in &matching_ids {
-                        tx.set_property(*node_id, prop, sv.clone())?;
+                        if self.resolve_vector_write_route(
+                            value,
+                            node_label(node_id),
+                            prop,
+                            params,
+                        )? {
+                            continue;
+                        }
+                        to_write.push(*node_id);
+                    }
+                    if !to_write.is_empty() {
+                        let sv = expr_to_value_with_params(value, params)?;
+                        for node_id in &to_write {
+                            tx.set_property(*node_id, prop, sv.clone())?;
+                        }
                     }
                 }
                 sparrowdb_cypher::ast::Mutation::Delete { detach: true, .. } => {
@@ -1704,22 +1797,9 @@ impl GraphDb {
         // block, `MATCH (n:L {id: $id}) SET n.embedding = $emb` would silently
         // store the property but leave the HNSW file untouched — silent data
         // loss surfaced by KMSmcp channel message #202.
-        //
-        // Label is derived per matched NodeId (upper 32 bits of node_id.0
-        // encode the label_id) rather than from the AST.  This correctly
-        // handles:
-        //   • Anonymous matches (`MATCH (n) SET n.embedding = $emb`) where
-        //     the AST carries no label — the label is resolved from the node.
-        //   • Multi-pattern queries: each matched node's label is used, not
-        //     the first MATCH pattern's label (multi-pattern is currently
-        //     rejected by the engine guard, but this code is future-proof).
         {
             use sparrowdb_cypher::ast::{Expr, Literal};
             let vidx_dir = self.inner.path.join("vector_indexes");
-            // Build a label_id → name map from the catalog once.
-            let cat = self.catalog_snapshot();
-            let label_id_to_name: std::collections::HashMap<u16, String> =
-                cat.list_labels().unwrap_or_default().into_iter().collect();
             let vidx_guard = self.inner.vector_indexes.read().expect("vector_indexes");
             for mutation in &mm.mutations {
                 if let sparrowdb_cypher::ast::Mutation::Set {
@@ -1905,6 +1985,18 @@ impl GraphDb {
         // the HNSW index is serialised once per (label, prop), not once per row.
         let mut pending_vectors: std::collections::HashMap<String, (Vec<f32>, Vec<u64>)> =
             std::collections::HashMap::new();
+        // Resolved once, up front: needed both by the per-row vector-write
+        // routing below and by the accumulated-write block after the row
+        // loop. Label is derived per matched NodeId (upper 32 bits of
+        // node_id.0 encode the label_id) rather than from the AST, so
+        // anonymous and multi-label UNWIND patterns resolve correctly.
+        let cat = self.catalog_snapshot();
+        let label_id_to_name: std::collections::HashMap<u16, String> =
+            cat.list_labels().unwrap_or_default().into_iter().collect();
+        let node_label = |node_id: &NodeId| -> &str {
+            let lid = (node_id.0 >> 32) as u16;
+            label_id_to_name.get(&lid).map(String::as_str).unwrap_or("")
+        };
 
         for element in list {
             // Honour caller's deadline between iterations (fixes #310).
@@ -1950,12 +2042,29 @@ impl GraphDb {
                         // vector `$param` bound to an indexed property is
                         // handled entirely by the accumulation block below
                         // and must not go through the column-value resolver.
-                        let is_indexed_vector = params
-                            .map(|p| self.set_value_is_indexed_vector_param(value, prop, p))
-                            .unwrap_or(false);
-                        if !is_indexed_vector {
-                            let sv = resolve_set_value(value, &umm.alias, row, params)?;
+                        // Routed per matched node's own label — see
+                        // `resolve_vector_write_route` — so a #451
+                        // quarantine-blocked `(label, prop)` fails loudly
+                        // right here rather than silently rewriting nothing.
+                        let mut to_write: Vec<NodeId> = Vec::with_capacity(matching_ids.len());
+                        if let Some(p) = params {
                             for node_id in &matching_ids {
+                                if self.resolve_vector_write_route(
+                                    value,
+                                    node_label(node_id),
+                                    prop,
+                                    p,
+                                )? {
+                                    continue;
+                                }
+                                to_write.push(*node_id);
+                            }
+                        } else {
+                            to_write.extend(matching_ids.iter().copied());
+                        }
+                        if !to_write.is_empty() {
+                            let sv = resolve_set_value(value, &umm.alias, row, params)?;
+                            for node_id in &to_write {
                                 tx.set_property(*node_id, prop, sv.clone())?;
                             }
                         }
@@ -2031,9 +2140,6 @@ impl GraphDb {
         // patterns resolve correctly.
         if !pending_vectors.is_empty() {
             let vidx_dir = self.inner.path.join("vector_indexes");
-            let cat = self.catalog_snapshot();
-            let label_id_to_name: std::collections::HashMap<u16, String> =
-                cat.list_labels().unwrap_or_default().into_iter().collect();
             let vidx_guard = self.inner.vector_indexes.read().expect("vector_indexes");
             for (prop, (vec, raw_ids)) in &pending_vectors {
                 // A node accumulates once per matching row and again per
@@ -2594,6 +2700,18 @@ impl GraphDb {
         };
 
         let key = (label.to_string(), prop.to_string());
+        // #451: registering (or confirming) an index for this pair is exactly
+        // the remediation step the write-guard error tells a caller to take,
+        // so clear it here regardless of which branch below returns —
+        // already-live, lost-update, or freshly created all mean a live
+        // index now exists (or will, on the next `open`) for `(label,
+        // prop)`, and a cleared entry is what makes `vectorIndexHealth`'s
+        // `quarantined_no_live_index` state go clean without a restart.
+        self.inner
+            .quarantined_vector_writes
+            .write()
+            .expect("quarantined_vector_writes poisoned")
+            .remove(&key);
         {
             let guard = self
                 .inner

--- a/crates/sparrowdb/src/helpers.rs
+++ b/crates/sparrowdb/src/helpers.rs
@@ -670,13 +670,42 @@ pub(crate) fn load_vector_indexes(db_root: &Path) -> crate::Result<crate::types:
     Ok(map)
 }
 
+/// Which of the two shapes of "not in service" a [`VectorIndexFailure`]
+/// represents (#451).
+///
+/// The two demand different responses from a caller, which is why this is a
+/// field rather than something inferred from `reason` prose:
+///
+/// * [`LiveUnserviceable`](Self::LiveUnserviceable) is a `.bin` `open()`
+///   already refused to load, or refuses right now — there is no running
+///   store to guard a write on; the fix happens before or at `open()`.
+/// * [`QuarantinedNoLiveIndex`](Self::QuarantinedNoLiveIndex) is the #451
+///   state: `open()` already **succeeded**, "clean", and every vector write
+///   to this `(label, prop)` is being silently dropped *right now*. This is
+///   what `GraphDb`'s write paths refuse on, and what a monitor should page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VectorIndexFailureKind {
+    /// `hnsw_<label>_<prop>.bin` is present but does not resolve (dangling
+    /// symlink) or — at [`vector_index_load_failures`]'s depth — does not
+    /// load.  `GraphDb::open` refuses to start while this is true.
+    LiveUnserviceable,
+    /// `hnsw_<label>_<prop>.bin.corrupt.<millis>` is present and no live
+    /// index currently serves the pair (#442 quarantine, #451 residual
+    /// hole).  `open()` succeeds anyway — the damaged bytes are already out
+    /// of service — which is exactly why this needs its own tag: nothing
+    /// else distinguishes this store from a healthy one.
+    QuarantinedNoLiveIndex,
+}
+
 /// One vector index that is not in service, and why.
 ///
 /// `path` names bytes that are actually on disk when the report is handed to
 /// you — the machine-readable field, and the one a caller can act on.  `reason`
 /// is prose: for a live file it is the loader's own error, for a quarantine
 /// artifact it is reconstructed, because #442 records the decode failure only in
-/// the `io::Error` it returns at quarantine time and writes no sidecar.
+/// the `io::Error` it returns at quarantine time and writes no sidecar.  `kind`
+/// is the machine-checkable field for the same distinction `reason` describes
+/// in prose — see [`VectorIndexFailureKind`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VectorIndexFailure {
     /// Node label the index belongs to.
@@ -687,6 +716,9 @@ pub struct VectorIndexFailure {
     pub path: PathBuf,
     /// Human-readable explanation.  Not machine-parseable; not stable.
     pub reason: String,
+    /// Which of the two "not in service" shapes this is.  Check this before
+    /// deciding whether a write against this pair would currently succeed.
+    pub kind: VectorIndexFailureKind,
 }
 
 /// What an inspection of `<db_root>/vector_indexes/` observed.
@@ -887,6 +919,7 @@ fn health(db_root: &Path, depth: Depth) -> VectorIndexHealth {
                          treating it as unconfigured would silently drop every vector write \
                          for it."
                     .to_owned(),
+                kind: VectorIndexFailureKind::LiveUnserviceable,
             });
             continue;
         }
@@ -911,6 +944,7 @@ fn health(db_root: &Path, depth: Depth) -> VectorIndexHealth {
                     prop: prop.clone(),
                     path,
                     reason: e.to_string(),
+                    kind: VectorIndexFailureKind::LiveUnserviceable,
                 }),
             },
         }
@@ -948,6 +982,7 @@ fn health(db_root: &Path, depth: Depth) -> VectorIndexHealth {
             prop,
             path,
             reason,
+            kind: VectorIndexFailureKind::QuarantinedNoLiveIndex,
         };
         if superseded {
             historical.push(failure);
@@ -968,6 +1003,36 @@ fn health(db_root: &Path, depth: Depth) -> VectorIndexHealth {
         active,
         historical,
     }
+}
+
+/// `(label, prop)` pairs currently in the #451 write-guard state: an
+/// unrecovered quarantine artifact exists and no live index serves the pair,
+/// so a vector write would be silently dropped were it not refused.
+///
+/// Computed with the cheap names-only tier — the same one-`read_dir`,
+/// no-content-I/O cost as [`vector_index_health`] — because this runs once at
+/// `GraphDb::open` time and must not become the thing that makes `open` slow.
+/// Quarantining only ever happens on the open path (`load_and_quarantine`),
+/// so nothing that happens *after* `open` can add to this set within a
+/// session; [`crate::db::GraphDb::create_vector_index`] is the only thing
+/// that removes an entry, once a fresh index actually replaces the artifact.
+///
+/// An unscannable directory yields an empty map rather than an error: `open`
+/// already ran the identical scan via `load_vector_indexes` and would have
+/// refused to start had it failed, so by the time this runs the directory is
+/// known-good for this session.
+pub(crate) fn quarantined_no_index_pairs(
+    db_root: &Path,
+) -> HashMap<(String, String), Vec<PathBuf>> {
+    let mut out: HashMap<(String, String), Vec<PathBuf>> = HashMap::new();
+    for failure in vector_index_health(db_root).active {
+        if failure.kind == VectorIndexFailureKind::QuarantinedNoLiveIndex {
+            out.entry((failure.label, failure.prop))
+                .or_default()
+                .push(failure.path);
+        }
+    }
+    out
 }
 
 // ── Storage-size helpers (SPA-171) ────────────────────────────────────────────

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -99,7 +99,7 @@ pub use helpers::cypher_escape_string;
 
 /// Vector index health reporting — see [`GraphDb::vector_index_health`] and
 /// [`GraphDb::vector_index_load_failures`].
-pub use helpers::{VectorIndexFailure, VectorIndexHealth};
+pub use helpers::{VectorIndexFailure, VectorIndexFailureKind, VectorIndexHealth};
 
 // ── Legacy alias ──────────────────────────────────────────────────────────────
 

--- a/crates/sparrowdb/src/types.rs
+++ b/crates/sparrowdb/src/types.rs
@@ -299,6 +299,19 @@ pub(crate) struct DbInner {
     /// Each index is wrapped in `Arc<RwLock<VectorIndex>>` for SWMR access
     /// without holding the outer write-lock.
     pub vector_indexes: RwLock<VectorIndexMap>,
+    /// `(label, property)` pairs with an unrecovered #451 quarantine
+    /// artifact and no live index serving them right now — the paths are the
+    /// quarantined `.bin.corrupt.<millis>` files, kept for the write-refusal
+    /// error message.
+    ///
+    /// Populated once at `GraphDb::open`/`open_encrypted` time (quarantining
+    /// only happens on the open path, so nothing later in a session can add
+    /// to this) and cleared per-pair by `GraphDb::create_vector_index` once a
+    /// fresh index actually replaces the artifact. Every vector-write path
+    /// consults this before falling through to the ordinary property-write
+    /// rejection, so `open()`'s silent "healthy" success on a quarantined
+    /// store cannot let writes for that pair disappear a second time.
+    pub quarantined_vector_writes: RwLock<HashMap<(String, String), Vec<PathBuf>>>,
 }
 
 /// Run GC on the version store every this many commits.

--- a/crates/sparrowdb/src/types.rs
+++ b/crates/sparrowdb/src/types.rs
@@ -311,6 +311,19 @@ pub(crate) struct DbInner {
     /// consults this before falling through to the ordinary property-write
     /// rejection, so `open()`'s silent "healthy" success on a quarantined
     /// store cannot let writes for that pair disappear a second time.
+    ///
+    /// **Scope: this `GraphDb` instance only, not the process or the file.**
+    /// This is in-memory state seeded once at `open()`, not re-derived from
+    /// disk on every write. A second `GraphDb` handle opened against the same
+    /// `path` — in this process or another — computes its own copy at its own
+    /// `open()` and the two are never reconciled; nothing here detects or
+    /// guards against concurrent access to one database directory from
+    /// multiple handles. This is a real limitation, not an oversight to "fix
+    /// later" casually: correctness would require either re-scanning disk on
+    /// every write (defeats the point of caching this) or a cross-process
+    /// coordination mechanism this crate does not otherwise have. Out of
+    /// scope for #451, which is about a single handle's `open()` being
+    /// stale, not about multiple handles disagreeing.
     pub quarantined_vector_writes: RwLock<HashMap<(String, String), Vec<PathBuf>>>,
 }
 

--- a/crates/sparrowdb/tests/regression_451_quarantine_write_guard.rs
+++ b/crates/sparrowdb/tests/regression_451_quarantine_write_guard.rs
@@ -277,7 +277,8 @@ fn cross_label_prop_name_collision_does_not_silently_drop_the_write() {
     db.create_vector_index("Doc", "embedding", DIMS, "cosine")
         .expect("create Doc.embedding index");
     // Note never gets an index on "embedding" at all.
-    db.execute("CREATE (:Note {key: 'n1'})").expect("create Note node");
+    db.execute("CREATE (:Note {key: 'n1'})")
+        .expect("create Note node");
 
     let err = db
         .execute_with_params(
@@ -313,7 +314,8 @@ fn cross_label_prop_name_collision_does_not_silently_drop_the_write() {
 
     // The unrelated Doc.embedding write path must still work — this fix must
     // not have broken the case it was meant to leave untouched.
-    db.execute("CREATE (:Doc {key: 'd1'})").expect("create Doc node");
+    db.execute("CREATE (:Doc {key: 'd1'})")
+        .expect("create Doc node");
     db.execute_with_params(
         "MATCH (n:Doc {key: 'd1'}) SET n.embedding = $emb",
         params(&[("emb", embedding_param())]),

--- a/crates/sparrowdb/tests/regression_451_quarantine_write_guard.rs
+++ b/crates/sparrowdb/tests/regression_451_quarantine_write_guard.rs
@@ -1,0 +1,431 @@
+//! Regression guard for #451 — fail-closed `open()` is one-shot.
+//!
+//! #441/#442/#445/#446/#447 all closed instances of the same silent-drop
+//! shape on the *open* path. The residual hole #451 names is different: it
+//! is not about `open()` at all, it is about what happens **after** `open()`
+//! has already succeeded a second time.
+//!
+//! 1. An index is damaged. The **first** `open()` after that correctly
+//!    refuses (`Error::Corruption`) and quarantines the bad bytes to
+//!    `<path>.corrupt.<millis>` (#442).
+//! 2. The **second** `open()` sees no live `.bin` for that `(label, prop)`,
+//!    which is indistinguishable from "never indexed" by every signal that
+//!    existed before this fix, so it succeeds — silently, with no index
+//!    registered.
+//! 3. Every vector write to that `(label, prop)` from that point on used to
+//!    fall through to whatever the ordinary (non-vector) write path does for
+//!    a value with no live index — which, depending on caller, ranged from a
+//!    generic non-scalar-value rejection that never mentions quarantine to,
+//!    in `addToVectorIndex`'s pre-#410 shape, an outright silent drop.
+//!
+//! The fix: a write against a `(label, prop)` with an unrecovered #451
+//! quarantine artifact and no live index now fails loudly, naming the label,
+//! the property, the quarantine file, and the recovery step
+//! (`createVectorIndex`) — instead of silently doing nothing or erroring with
+//! a message that gives no indication anything was ever indexed at all.
+//!
+//! A `(label, prop)` that was genuinely never indexed is a different, legal
+//! case and must not be affected by this change; this file checks both.
+//!
+//! Every expected value below is derived by hand from the fixture this file
+//! builds, not recorded from a run of the code — see
+//! `~/Dev/SparrowDB/CLAUDE.md`.
+
+use sparrowdb::GraphDb;
+use sparrowdb_execution::types::Value;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+// ── Fixture helpers (mirrors regression_456_load_is_not_destructive.rs) ──────
+
+const DIMS: usize = 3;
+
+/// Path of the on-disk index file for `(label, prop)` inside a db root.
+fn index_file(db_root: &Path, label: &str, prop: &str) -> PathBuf {
+    db_root
+        .join("vector_indexes")
+        .join(format!("hnsw_{label}_{prop}.bin"))
+}
+
+/// Every file in `<db_root>/vector_indexes/` whose name contains `.corrupt.`,
+/// i.e. every #442 quarantine artifact.
+fn quarantine_artifacts(db_root: &Path) -> Vec<PathBuf> {
+    let dir = db_root.join("vector_indexes");
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.contains(".corrupt."))
+        })
+        .collect()
+}
+
+/// Truncate `file` to its first 4 bytes — guaranteed undecodable by either the
+/// v2 header (which needs >= 36 bytes) or the legacy bincode path (whose
+/// 8-byte length prefix alone does not fit in 4 bytes). Identical rationale to
+/// `regression_456_load_is_not_destructive.rs`'s helper of the same name.
+fn truncate_to_4_bytes(file: &Path) {
+    let original = std::fs::metadata(file).expect("stat index file").len();
+    assert!(
+        original > 4,
+        "fixture precondition: a serialised VectorIndex must exceed the \
+         4-byte truncation point, got {original} bytes"
+    );
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(file)
+        .expect("open index file for truncation")
+        .set_len(4)
+        .expect("truncate index file to 4 bytes");
+}
+
+fn params(pairs: &[(&str, Value)]) -> HashMap<String, Value> {
+    pairs
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.clone()))
+        .collect()
+}
+
+fn embedding_param() -> Value {
+    Value::List(vec![
+        Value::Float64(1.0),
+        Value::Float64(2.0),
+        Value::Float64(3.0),
+    ])
+}
+
+/// Build a fresh db with a damaged-then-quarantined `(Doc, embedding)` index,
+/// two nodes (`key: 'x'` and `key: 'y'`), and hand back the db handle from
+/// the *second* `open()` — the "clean-looking but silently dropping" state
+/// #451 is about. Also hands back the (single) quarantine artifact path.
+fn make_quarantined_db() -> (tempfile::TempDir, GraphDb, PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().to_path_buf();
+    {
+        let db = GraphDb::open(&root).expect("open fresh db");
+        db.create_vector_index("Doc", "embedding", DIMS, "cosine")
+            .expect("create Doc.embedding index");
+        db.execute("CREATE (:Doc {key: 'x'})").expect("create x");
+        db.execute("CREATE (:Doc {key: 'y'})").expect("create y");
+    }
+
+    let file = index_file(&root, "Doc", "embedding");
+    truncate_to_4_bytes(&file);
+
+    // First open: refuses, quarantines.
+    let first = GraphDb::open(&root);
+    assert!(
+        first.is_err(),
+        "fixture precondition: open() must refuse while the damaged file is live"
+    );
+    let artifacts = quarantine_artifacts(&root);
+    assert_eq!(
+        artifacts.len(),
+        1,
+        "fixture precondition: exactly one artifact after the first open, got {artifacts:?}"
+    );
+    let artifact = artifacts[0].clone();
+
+    // Second open: the #451 state — succeeds, no index registered.
+    let db = GraphDb::open(&root).expect("fixture precondition: the second open must succeed");
+    assert!(
+        db.get_vector_index("Doc", "embedding").is_none(),
+        "fixture precondition: no live index is registered after the second open"
+    );
+
+    (dir, db, artifact)
+}
+
+// ── 1. The write-refusal itself, across every $param write path ─────────────
+
+/// `MATCH ... SET n.embedding = $emb` against the quarantined pair must fail
+/// loudly, naming the label, the property, the artifact, and the recovery
+/// step — not silently do nothing and not error with a message that gives no
+/// indication the property was ever indexed.
+#[test]
+fn match_set_on_quarantined_pair_is_refused_with_actionable_error() {
+    let (_dir, db, artifact) = make_quarantined_db();
+
+    let err = db
+        .execute_with_params(
+            "MATCH (n:Doc {key: 'x'}) SET n.embedding = $emb",
+            params(&[("emb", embedding_param())]),
+        )
+        .expect_err("a vector write against a quarantined, unrecovered pair must be refused");
+    let msg = err.to_string();
+
+    for token in ["Doc", "embedding", "createVectorIndex", "451"] {
+        assert!(
+            msg.contains(token),
+            "error must be actionable — missing `{token}`; got: {msg}"
+        );
+    }
+    let artifact_name = artifact
+        .file_name()
+        .and_then(|n| n.to_str())
+        .expect("artifact must have a utf8 file name");
+    assert!(
+        msg.contains(artifact_name),
+        "error must name the exact quarantine file ({artifact_name}); got: {msg}"
+    );
+
+    // The write must not have landed as an ordinary property either — this is
+    // a refusal, not a silent downgrade to plain-property storage.
+    let rows = db
+        .execute("MATCH (n:Doc {key: 'x'}) RETURN n.embedding")
+        .expect("read back")
+        .rows;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0][0],
+        sparrowdb_execution::Value::Null,
+        "the refused write must leave no trace on the property either"
+    );
+}
+
+/// Same guard, reached through `MERGE ... ON CREATE SET`.
+#[test]
+fn merge_on_create_set_on_quarantined_pair_is_refused() {
+    let (_dir, db, _artifact) = make_quarantined_db();
+
+    let err = db
+        .execute_with_params(
+            "MERGE (n:Doc {key: 'new'}) ON CREATE SET n.embedding = $emb",
+            params(&[("emb", embedding_param())]),
+        )
+        .expect_err("MERGE...ON CREATE SET against a quarantined pair must be refused");
+    let msg = err.to_string();
+    for token in ["Doc", "embedding", "createVectorIndex"] {
+        assert!(msg.contains(token), "missing `{token}`; got: {msg}");
+    }
+}
+
+/// Same guard, reached through `UNWIND ... MATCH ... SET` (the second entry
+/// point #410's fix had to cover independently — see db.rs's
+/// `execute_unwind_mutate_inner`).
+#[test]
+fn unwind_match_set_on_quarantined_pair_is_refused() {
+    let (_dir, db, _artifact) = make_quarantined_db();
+
+    let rows = vec![sparrowdb_execution::Value::Map(vec![(
+        "key".to_string(),
+        sparrowdb_execution::Value::String("x".to_string()),
+    )])];
+    let err = db
+        .execute_with_params(
+            "UNWIND $rows AS row MATCH (n:Doc {key: row.key}) SET n.embedding = $emb",
+            params(&[("rows", Value::List(rows)), ("emb", embedding_param())]),
+        )
+        .expect_err("UNWIND...MATCH...SET against a quarantined pair must be refused");
+    let msg = err.to_string();
+    for token in ["Doc", "embedding", "createVectorIndex"] {
+        assert!(msg.contains(token), "missing `{token}`; got: {msg}");
+    }
+}
+
+// ── 2. A never-indexed pair is a different, legal case — unaffected ─────────
+
+/// `(Doc, other)` was never indexed at all — no `.bin`, no quarantine
+/// artifact. Writing a vector-shaped value to it hits the ordinary,
+/// unrelated non-scalar-value rejection, unchanged by this fix, and that
+/// error must NOT claim anything about quarantine, since nothing was ever
+/// indexed there.
+#[test]
+fn never_indexed_pair_is_unaffected_and_does_not_mention_quarantine() {
+    let (_dir, db, _artifact) = make_quarantined_db();
+
+    let err = db
+        .execute_with_params(
+            "MATCH (n:Doc {key: 'x'}) SET n.other = $emb",
+            params(&[("emb", embedding_param())]),
+        )
+        .expect_err("a non-scalar value still has nowhere to go without an index");
+    let msg = err.to_string();
+    assert!(
+        !msg.to_lowercase().contains("quarantine") && !msg.contains("451"),
+        "a pair that was never indexed must not be blamed on a quarantine \
+         that never happened for it; got: {msg}"
+    );
+}
+
+/// A second label sharing a property *name* with an indexed pair on a
+/// *different* label must not be silently treated as indexed.
+///
+/// This is not the quarantine scenario at all — it is a bug the refactor
+/// needed to introduce a `label` parameter incidentally fixed: routing used
+/// to key off `prop` name alone (`vector_indexes.keys().any(|(_, p)| p ==
+/// prop)`), ignoring which label the index actually belongs to. With
+/// `(Doc, embedding)` live-indexed and `(Note, embedding)` never indexed at
+/// all, writing a vector to `Note.embedding` used to be routed as "skip the
+/// property write, an index will handle it" — and then the HNSW write-path
+/// block looked up `(Note, embedding)`, found nothing, and did nothing.
+/// Net effect: no property written, no index entry, no error — a true
+/// silent drop, just not the one #451 is named for. Hand-derivation of the
+/// pre-fix result: run this test against the parent commit (`git stash` the
+/// four source-file changes, keep this test) and the assertions below fail
+/// because no `Err` is returned at all.
+#[test]
+fn cross_label_prop_name_collision_does_not_silently_drop_the_write() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let db = GraphDb::open(root).expect("open fresh db");
+    db.create_vector_index("Doc", "embedding", DIMS, "cosine")
+        .expect("create Doc.embedding index");
+    // Note never gets an index on "embedding" at all.
+    db.execute("CREATE (:Note {key: 'n1'})").expect("create Note node");
+
+    let err = db
+        .execute_with_params(
+            "MATCH (n:Note {key: 'n1'}) SET n.embedding = $emb",
+            params(&[("emb", embedding_param())]),
+        )
+        .expect_err(
+            "a vector written to a label with no index of its own must not be silently \
+             swallowed just because a DIFFERENT label happens to index a property with \
+             the same name",
+        );
+    let msg = err.to_string();
+    assert!(
+        !msg.to_lowercase().contains("quarantine"),
+        "Note.embedding was never quarantined; got: {msg}"
+    );
+
+    // Nothing landed anywhere: not as a property, not in Doc's index (wrong
+    // pair entirely), and no Note index was implicitly created.
+    let rows = db
+        .execute("MATCH (n:Note {key: 'n1'}) RETURN n.embedding")
+        .expect("read back")
+        .rows;
+    assert_eq!(
+        rows[0][0],
+        sparrowdb_execution::Value::Null,
+        "the refused write must leave no property behind"
+    );
+    assert!(
+        db.get_vector_index("Note", "embedding").is_none(),
+        "no index must have been implicitly created for Note"
+    );
+
+    // The unrelated Doc.embedding write path must still work — this fix must
+    // not have broken the case it was meant to leave untouched.
+    db.execute("CREATE (:Doc {key: 'd1'})").expect("create Doc node");
+    db.execute_with_params(
+        "MATCH (n:Doc {key: 'd1'}) SET n.embedding = $emb",
+        params(&[("emb", embedding_param())]),
+    )
+    .expect("Doc.embedding is genuinely indexed and must still accept the write");
+}
+
+// ── 3. Recovery: create_vector_index clears the guard, health goes clean ────
+
+#[test]
+fn creating_a_fresh_index_clears_the_guard_and_health_goes_clean() {
+    let (dir, db, _artifact) = make_quarantined_db();
+    let root = dir.path();
+
+    // Blocked before remediation (already covered above; re-confirm inline
+    // so this test is self-contained about the state it starts from).
+    assert!(
+        db.execute_with_params(
+            "MATCH (n:Doc {key: 'x'}) SET n.embedding = $emb",
+            params(&[("emb", embedding_param())]),
+        )
+        .is_err(),
+        "fixture precondition: write must be blocked before remediation"
+    );
+
+    // Static health: the pair must be `active` (unrecovered) before
+    // remediation.
+    let before = GraphDb::vector_index_health(root);
+    assert_eq!(
+        before
+            .active
+            .iter()
+            .map(|f| (f.label.as_str(), f.prop.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("Doc", "embedding")],
+        "fixture precondition: the pair must be active before remediation, got {:?}",
+        before.active
+    );
+    assert!(before.historical.is_empty());
+
+    // Remediate.
+    db.create_vector_index("Doc", "embedding", DIMS, "cosine")
+        .expect("create a fresh index for the quarantined pair");
+
+    // The write must now succeed.
+    db.execute_with_params(
+        "MATCH (n:Doc {key: 'x'}) SET n.embedding = $emb",
+        params(&[("emb", embedding_param())]),
+    )
+    .expect("a fresh live index must accept the write");
+
+    // And it must have actually landed in the new index, not been silently
+    // dropped a second time under a different disguise.
+    let idx = db
+        .get_vector_index("Doc", "embedding")
+        .expect("a live index must be registered now");
+    let node_id = match &db
+        .execute("MATCH (n:Doc {key: 'x'}) RETURN id(n) AS nid")
+        .expect("id query")
+        .rows[0][0]
+    {
+        sparrowdb_execution::Value::Int64(n) => *n as u64,
+        other => panic!("expected Int64 node id, got {other:?}"),
+    };
+    assert!(
+        idx.read().expect("read lock").has_vector(node_id),
+        "the vector must actually be present in the newly created index"
+    );
+
+    // Static health must go clean: the artifact is now superseded
+    // (`historical`), not `active` — this is the "must clear after
+    // remediation" half of the diagnostic-design rule this repo holds
+    // itself to.
+    let after = GraphDb::vector_index_health(root);
+    assert!(
+        after.active.is_empty(),
+        "the pair must no longer be active once a live index supersedes the \
+         artifact, got {:?}",
+        after.active
+    );
+    assert_eq!(
+        after
+            .historical
+            .iter()
+            .map(|f| (f.label.as_str(), f.prop.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("Doc", "embedding")],
+        "the artifact must still be visible as historical forensic evidence, \
+         got {:?}",
+        after.historical
+    );
+
+    // The in-memory write-guard itself must have cleared too, not merely be
+    // masked by the now-live index winning the first check in
+    // `resolve_vector_write_route`. Prove it by dropping the index again —
+    // an explicit, deliberate operator action distinct from quarantine — and
+    // confirming the write now hits the *ordinary* unindexed-write path
+    // (case (a), unaffected by this fix) rather than a stale claim that this
+    // pair is still quarantined.
+    db.drop_vector_index("Doc", "embedding")
+        .expect("drop the index again");
+    let err_after_drop = db
+        .execute_with_params(
+            "MATCH (n:Doc {key: 'y'}) SET n.embedding = $emb",
+            params(&[("emb", embedding_param())]),
+        )
+        .expect_err("still no scalar representation for a vector without any index");
+    let msg = err_after_drop.to_string();
+    assert!(
+        !msg.to_lowercase().contains("quarantine") && !msg.contains("451"),
+        "after create_vector_index + drop_vector_index, the pair must not be \
+         reported as quarantined — that state was cleared by create_vector_index \
+         and must not resurrect itself; got: {msg}"
+    );
+}

--- a/npm/sparrowdb/index.d.ts
+++ b/npm/sparrowdb/index.d.ts
@@ -76,6 +76,7 @@ export interface VectorIndexHealth {
  *   prop: string;    // vector property the index was built on
  *   path: string;    // exact file on disk; the machine-readable field
  *   reason: string;  // human-readable; see the caveat below
+ *   kind: string;    // "live_unserviceable" | "quarantined_no_live_index" — see below
  * }
  * ```
  *
@@ -84,6 +85,20 @@ export interface VectorIndexHealth {
  * RECONSTRUCTED rather than recovered, because #442 reports the original
  * decode failure only in the error it returns at quarantine time and writes no
  * sidecar. Do not parse it and do not present it as the authoritative cause.
+ *
+ * `kind` is the machine-checkable version of the same distinction `reason`
+ * only describes in prose (#451):
+ * - `"live_unserviceable"` — a `.bin` is present but does not resolve or does
+ *   not load. `SparrowDB.open` (the Rust/other-binding equivalent) refuses to
+ *   start while this is true; there is no running store to guard a write on.
+ * - `"quarantined_no_live_index"` — a `.bin.corrupt.<millis>` quarantine
+ *   artifact is present and no live index currently serves the pair. The
+ *   store **opened successfully** and looks healthy, but
+ *   `db.executeWithParams` now throws on a vector write against this exact
+ *   `(label, prop)` instead of silently discarding it — see
+ *   `SparrowDB.prototype.executeWithParams`. Call `db.createVectorIndex(...)`
+ *   to clear it; the entry then moves from `active` to `historical` on the
+ *   next `vectorIndexDamageScan`/`vectorIndexLoadFailures` call.
  *
  * The `//` comments above are deliberate rather than nested doc comments: a
  * close-comment marker inside a generated JSDoc block ends it early, which is
@@ -105,6 +120,12 @@ export interface VectorIndexLoadFailure {
    * not authoritative and not machine-parseable.
    */
   reason: string
+  /**
+   * `"live_unserviceable"` or `"quarantined_no_live_index"` — see the
+   * interface doc comment. Check this before deciding whether a vector write
+   * against this `(label, prop)` would currently succeed or throw.
+   */
+  kind: string
 }
 /**
  * What an inspection of a database's `vector_indexes/` observed — see
@@ -215,11 +236,21 @@ export declare class SparrowDB {
    * - **already quarantined** — `hnsw_<label>_<prop>.bin.corrupt.<millis>`,
    *   bytes a previous load attempt moved aside (#442).
    *
-   * The second arm is why this is the only usable health signal for #451:
-   * once a damaged file has been quarantined, the *first* `open` has already
-   * thrown and every later `open` succeeds with the index silently absent,
-   * so vector writes for that pair are dropped and searches return nothing.
-   * Nothing else distinguishes that store from a healthy one.
+   * The second arm used to be the *only* usable signal for #451: once a
+   * damaged file had been quarantined, the *first* `open` had already
+   * thrown and every later `open` succeeded with the index silently
+   * absent, and nothing else distinguished that store from a healthy one
+   * — vector writes for that pair were dropped or, after #475, rejected
+   * with a message naming neither the pair nor the quarantine.
+   *
+   * That is fixed as of #451: a vector write against a `(label, prop)` in
+   * this state now throws, naming the label, the property, and this exact
+   * quarantine artifact — see `SparrowDB.prototype.executeWithParams`.
+   * This diagnostic remains the way to find the condition *before* a write
+   * hits it, and each entry's `kind` field
+   * (`VectorIndexLoadFailure.kind === "quarantined_no_live_index"`) is now
+   * the machine-checkable way to tell it apart from a `"live_unserviceable"`
+   * entry, which `open()` refusing to start already makes loud on its own.
    *
    * **Read-only since #456.** It used to quarantine the live entries it
    * probed, so a second call answered differently from the first and the

--- a/npm/sparrowdb/test/integration.test.js
+++ b/npm/sparrowdb/test/integration.test.js
@@ -753,15 +753,20 @@ describe('SparrowDB vector index damage reporting — issues #446 / #451 / #455 
     )
   }
 
-  function assertFailureShape(entry, indexFile) {
+  // The two `kind` values a `VectorIndexLoadFailure` can carry (#451) — see
+  // `VectorIndexFailureKind` in `crates/sparrowdb/src/helpers.rs`.
+  const KIND_LIVE_UNSERVICEABLE = 'live_unserviceable'
+  const KIND_QUARANTINED_NO_LIVE_INDEX = 'quarantined_no_live_index'
+
+  function assertFailureShape(entry, indexFile, expectedKind) {
     // Named fields, not tuple positions — a consumer building an alert needs
     // to read `entry.path`, not `entry[2]`.
     assert.deepEqual(
       Object.keys(entry).sort(),
-      ['label', 'path', 'prop', 'reason'],
-      'entry must expose exactly { label, prop, path, reason }'
+      ['kind', 'label', 'path', 'prop', 'reason'],
+      'entry must expose exactly { label, prop, path, reason, kind }'
     )
-    for (const field of ['label', 'prop', 'path', 'reason']) {
+    for (const field of ['label', 'prop', 'path', 'reason', 'kind']) {
       assert.equal(
         typeof entry[field], 'string',
         `${field} must be a string, got ${typeof entry[field]}`
@@ -777,6 +782,16 @@ describe('SparrowDB vector index damage reporting — issues #446 / #451 / #455 
       `path must name the damaged index (${indexFile} or its .corrupt.* ` +
       `artifact); got ${entry.path}`
     )
+    assert.ok(
+      entry.kind === KIND_LIVE_UNSERVICEABLE || entry.kind === KIND_QUARANTINED_NO_LIVE_INDEX,
+      `kind must be one of the two documented values, got ${entry.kind}`
+    )
+    if (expectedKind !== undefined) {
+      assert.equal(
+        entry.kind, expectedKind,
+        `expected kind ${expectedKind} for this scenario, got ${entry.kind}`
+      )
+    }
   }
 
   it('both tiers are static methods on the class, not instance methods', () => {
@@ -970,7 +985,7 @@ describe('SparrowDB vector index damage reporting — issues #446 / #451 / #455 
       assert.equal(report.historical.length, 0, 'nothing has been rebuilt')
       assert.equal(report.healthy, false, 'a damaged live index is not healthy')
 
-      assertFailureShape(report.active[0], indexFile)
+      assertFailureShape(report.active[0], indexFile, KIND_LIVE_UNSERVICEABLE)
       assert.equal(
         report.active[0].path, indexFile,
         'the live arm reports the .bin path it scanned'
@@ -1108,7 +1123,7 @@ describe('SparrowDB vector index damage reporting — issues #446 / #451 / #455 
         `expected exactly ${EXPECTED_FAILURES} damaged index while open() is ` +
         `failing, got ${JSON.stringify(duringOutage.active)}`
       )
-      assertFailureShape(duringOutage.active[0], indexFile)
+      assertFailureShape(duringOutage.active[0], indexFile, KIND_QUARANTINED_NO_LIVE_INDEX)
 
       // The failed open() quarantined the bytes, so the reported path is now
       // the artifact: `<indexFile>.corrupt.<unix_millis>`.  The stem is
@@ -1136,8 +1151,8 @@ describe('SparrowDB vector index damage reporting — issues #446 / #451 / #455 
         duringOutage.active[0].reason
       )
 
-      // ── Phase 2: #451. The .bin is gone, so this is now the "absent" case
-      //    and open() succeeds — with the index silently missing. ───────────
+      // ── Phase 2: #451. The .bin is gone, so this is the "looks absent, but
+      //    was actually quarantined" state — open() succeeds. ────────────────
       const db = SparrowDB.open(dbPath)
       assert.ok(
         db instanceof SparrowDB,
@@ -1151,7 +1166,27 @@ describe('SparrowDB vector index damage reporting — issues #446 / #451 / #455 
         'the quarantined index must be absent from the reopened database'
       )
 
-      // ── Phase 3: the diagnostic is the ONLY remaining signal. ────────────
+      // A vector write against this exact (label, prop) must now be refused
+      // loudly rather than silently discarded — the fix for #451, exercised
+      // through the actual Node binding a JS caller (e.g. KMSmcp) would use.
+      db.execute(`CREATE (:${LABEL} {id: 'after-quarantine'})`)
+      assert.throws(
+        () => db.executeWithParams(
+          `MATCH (n:${LABEL} {id: 'after-quarantine'}) SET n.${PROP} = $emb`,
+          { emb: [0.1, 0.2, 0.3] }
+        ),
+        err => {
+          const msg = String(err.message || err)
+          for (const token of [LABEL, PROP, 'createVectorIndex']) {
+            assert.ok(msg.includes(token), `write-refusal error missing '${token}': ${msg}`)
+          }
+          return true
+        },
+        'a vector write against a quarantined, unrecovered pair must throw, not silently no-op'
+      )
+
+      // ── Phase 3: the diagnostic is now one of two signals — writes throw,
+      //    and this call finds the condition before a write ever hits it. ───
       const afterReopen = SparrowDB.vectorIndexLoadFailures(dbPath)
       assertReportShape(afterReopen)
       assert.equal(
@@ -1163,7 +1198,7 @@ describe('SparrowDB vector index damage reporting — issues #446 / #451 / #455 
         afterReopen.healthy, false,
         'a store silently dropping vector writes is not healthy'
       )
-      assertFailureShape(afterReopen.active[0], indexFile)
+      assertFailureShape(afterReopen.active[0], indexFile, KIND_QUARANTINED_NO_LIVE_INDEX)
       assert.equal(
         afterReopen.active[0].path, duringOutage.active[0].path,
         'the artifact path must be stable across calls'


### PR DESCRIPTION
## Summary

Closes #451.

**Lead finding: a real, previously-untested silent data-loss bug, distinct from what #451 describes.** Vector-write routing was keyed on property name alone (`vector_indexes.keys().any(|(_, prop_name)| prop_name == prop)`), ignoring which *label* the index actually belonged to. With a live index on `(Doc, embedding)` and no index at all on `(Note, embedding)`, writing a vector to `Note.embedding` was routed as "an index will handle this" — skipped the property write — and then the HNSW block looked up `(Note, embedding)`, found nothing, and did nothing. **No error, no property write, no index entry.** Confirmed pre-fix (see Testing): the call returns `Ok(QueryResult { columns: [], rows: [] })`. Fixed here as a consequence of threading `label` through the routing decision, which the #451 guard needed anyway.

**#451 itself, and a correction to its own framing:** after #442/#456's fail-closed `open()` quarantines a damaged HNSW index, the second `open()` finds no live `.bin` for that `(label, prop)` — indistinguishable from "never indexed." I verified the actual pre-fix behavior rather than trusting the issue text: **#475 (already merged) had already made every non-scalar property write loud**, so a vector write against the quarantined pair did *not* silently no-op — it already errored with `"property value is a list, which has no scalar storage representation..."`. The bug is that this message names neither the pair nor the quarantine, giving an operator (or KMSmcp) no way to tell "you configured this wrong" from "this used to work and your data is stuck in a quarantine file." **The fix's value is actionable vs. generic error, not silence vs. noise** — the issue's framing overstates what was silent; correcting that here so it doesn't get inherited as fact.

## What changed

**`crates/sparrowdb/src/{helpers,types,db}.rs`**
- `VectorIndexFailureKind` (`LiveUnserviceable` / `QuarantinedNoLiveIndex`) added as a field on `VectorIndexFailure`, so `vectorIndexHealth()`'s `active` list is machine-distinguishable, not just prose. Verified it clears: after `create_vector_index`, the artifact moves from `active` to `historical`.
- `DbInner.quarantined_vector_writes`: `(label, prop) → quarantine file paths`, seeded once at `open()`/`open_encrypted()` from the same scan `load_vector_indexes` already runs (no extra I/O cost beyond one more cheap `read_dir`), cleared per-pair by `create_vector_index` once a fresh index replaces the artifact.
- `resolve_vector_write_route()` replaces the old label-oblivious `set_value_is_indexed_vector_param`, wired into all three `$param` vector-write paths (`MERGE`, `MATCH...SET`, `UNWIND...MATCH...SET`). A write against a blocked pair now fails loudly, naming the label, property, exact quarantine file, and the `createVectorIndex` recovery step.
- Documented, not silently accepted: `quarantined_vector_writes` is scoped to one `GraphDb` instance, in-memory, seeded once at `open()`. A second handle on the same path (same or different process) computes its own copy; nothing reconciles them. Real limitation, out of scope here — see the doc comment on the field.

**`crates/sparrowdb-node/src/lib.rs`**
- No code change was needed for the throw itself — `execute()`/`executeWithParams()` already convert any `Result::Err` to a thrown exception, so JS callers get the loud refusal for free.
- Exposes `VectorIndexFailureKind` as `kind: "live_unserviceable" | "quarantined_no_live_index"` on `VectorIndexLoadFailure` — a plain documented string, not a new napi enum type, matching the file's existing convention and minimizing new surface.
- Corrects a doc comment that asserted the diagnostic was "the only usable signal" for #451 and that writes "are dropped" — both false as of this PR.

**`npm/sparrowdb/index.d.ts`**
- Hand-patched to match the Rust doc comment changes exactly (same `kind` field, same corrected prose). **Not regenerated** — a full napi codegen run risks pulling in unrelated drift that belongs to #513. The Rust doc comment is the actual source of truth; the next real regen will reproduce this by construction. Flagging explicitly so nobody "fixes" the `.d.ts` back to the stale prose later.

**Tests**
- New `crates/sparrowdb/tests/regression_451_quarantine_write_guard.rs`: 6 e2e tests covering all three write paths, the never-indexed unaffected case, the cross-label collision, and the create-index-clears-the-guard recovery path.
- `npm/sparrowdb/test/integration.test.js`: `assertFailureShape()` now validates `kind` per scenario; the existing `#451` reopen test gained a functional assertion that `executeWithParams` throws on the quarantined pair through the real Node binding, naming label/prop/`createVectorIndex`.

## Testing

**Rust**, `CARGO_TARGET_DIR=/Volumes/Dev/target-451`:
- `cargo build -p sparrowdb -p sparrowdb-node` — clean.
- `cargo fmt --check` — clean.
- `cargo clippy -p sparrowdb -p sparrowdb-execution -p sparrowdb-node --all-targets --keep-going` — clean.
- `cargo test -p sparrowdb --no-fail-fast` — clean, `EXIT_CODE=0`, 191 `test result: ok` blocks, 0 `FAILED` across 2404 lines of output (includes doc-tests).
- `cargo test -p sparrowdb --test regression_451_quarantine_write_guard` — 6/6 pass.

**Pre-fix confirmation** (`git stash` the 4 source files, keep the test, run, `git stash pop`) — regression tests fail against the pre-fix commit as required:
```
error must be actionable — missing `Doc`; got: invalid argument: property value is a list,
which has no scalar storage representation and cannot be written as a property value
```
```
a vector written to a label with no index of its own must not be silently swallowed
just because a DIFFERENT label happens to index a property with the same name:
QueryResult { columns: [], rows: [] }
```

**JS**, real compiled binary (`cargo build --release -p sparrowdb-node`, artifact copied to `npm/sparrowdb/sparrowdb.node`, matching CI's exact build steps):
- `npx tsc -p tsconfig.json` — clean.
- `node --test npm/sparrowdb/test/*.test.js` — **50/50 pass**, 0 fail (matches #517's count; includes my new functional #451 assertion).

## Could not verify

- **Cross-process concurrent access to `quarantined_vector_writes`** — not tested against a second `GraphDb` handle (same or different process) attached to the same db root mid-session. Documented as out of scope on the field itself.
- **napi codegen drift** — I did not run the actual napi build/codegen pipeline; the `.d.ts` change is hand-matched. If a real regen produces something different from my hand patch beyond the intended field, that's for #513 to reconcile, not this PR.
- **Windows / Linux native builds** — only verified darwin-arm64 locally, matching this machine.

## Not merging — per instructions, opening for review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE