### PR TITLE
fix(engine): fail closed on unresolvable pipeline filters, fix absent-vs-zero conflation

### DIFF
--- a/crates/sparrowdb-execution/src/engine/expr.rs
+++ b/crates/sparrowdb-execution/src/engine/expr.rs
@@ -957,9 +957,19 @@ impl Engine {
                         .iter()
                         .map(|p| prop_name_to_col_id(&p.key))
                         .collect();
-                    match self.snapshot.store.get_node_raw(probe_id, &col_ids) {
-                        Ok(props) => {
+                    // #479: nullable accessor + drop-absent, matching every
+                    // read-path prop-filter site — see node_matches_prop_filter.
+                    match self
+                        .snapshot
+                        .store
+                        .get_node_raw_nullable(probe_id, &col_ids)
+                    {
+                        Ok(raw_props) => {
                             let params = self.dollar_params();
+                            let props: Vec<(u32, u64)> = raw_props
+                                .into_iter()
+                                .filter_map(|(c, opt)| opt.map(|v| (c, v)))
+                                .collect();
                             if !matches_prop_filter_static(
                                 &props,
                                 &dst_pat.props,
@@ -1073,8 +1083,16 @@ impl Engine {
         let params = self.dollar_params();
         for slot in 0..hwm {
             let node_id = NodeId(((label_id as u64) << 32) | slot);
-            if let Ok(raw_props) = self.snapshot.store.get_node_raw(node_id, &col_ids) {
-                if matches_prop_filter_static(&raw_props, props, &params, &self.snapshot.store) {
+            // #479: route through the nullable accessor (as the read-path scan
+            // does) and drop absent columns, so a genuinely null-bound filter
+            // can match the node whose property is actually absent instead of
+            // silently never matching via `get_node_raw`'s zero-sentinel.
+            if let Ok(raw_props) = self.snapshot.store.get_node_raw_nullable(node_id, &col_ids) {
+                let stored: Vec<(u32, u64)> = raw_props
+                    .into_iter()
+                    .filter_map(|(c, opt)| opt.map(|v| (c, v)))
+                    .collect();
+                if matches_prop_filter_static(&stored, props, &params, &self.snapshot.store) {
                     return Some(slot);
                 }
             }

--- a/crates/sparrowdb-execution/src/engine/mutation.rs
+++ b/crates/sparrowdb-execution/src/engine/mutation.rs
@@ -279,13 +279,31 @@ impl Engine {
         if props.is_empty() {
             return true;
         }
-        match self.snapshot.store.get_node_raw(node_id, filter_col_ids) {
-            Ok(raw_props) => matches_prop_filter_static(
-                &raw_props,
-                props,
-                &self.dollar_params(),
-                &self.snapshot.store,
-            ),
+        // #479: use the nullable accessor and drop absent columns from the
+        // list entirely, mirroring every read-path call site. `get_node_raw`'s
+        // `read_col_slot` zero-sentinels an absent slot to `Ok(0)` (decodes to
+        // `Value::Int64(0)`), which made `matches_prop_filter_static`'s
+        // `Value::Null => stored_val.is_none()` arm unreachable here — a
+        // genuinely null-bound `$param` filter could never match the node
+        // whose property is actually absent, even though the read path
+        // matches it correctly.
+        match self
+            .snapshot
+            .store
+            .get_node_raw_nullable(node_id, filter_col_ids)
+        {
+            Ok(raw_props) => {
+                let stored: Vec<(u32, u64)> = raw_props
+                    .into_iter()
+                    .filter_map(|(c, opt)| opt.map(|v| (c, v)))
+                    .collect();
+                matches_prop_filter_static(
+                    &stored,
+                    props,
+                    &self.dollar_params(),
+                    &self.snapshot.store,
+                )
+            }
             Err(_) => false,
         }
     }

--- a/crates/sparrowdb-execution/src/engine/scan.rs
+++ b/crates/sparrowdb-execution/src/engine/scan.rs
@@ -304,10 +304,19 @@ impl Engine {
             if self.is_node_tombstoned(node_id) {
                 continue;
             }
-            let props = match self.snapshot.store.get_node_raw(node_id, &col_ids) {
+            // Nullable read so absent columns are omitted rather than
+            // zero-sentineled, matching the main MATCH scan (#479-adjacent:
+            // this pipeline leading-match scan had the same absent-vs-zero
+            // conflation as the three sites #479 named explicitly).
+            let nullable_props = match self.snapshot.store.get_node_raw_nullable(node_id, &col_ids)
+            {
                 Ok(p) => p,
                 Err(_) => continue,
             };
+            let props: Vec<(u32, u64)> = nullable_props
+                .into_iter()
+                .filter_map(|(c, opt)| opt.map(|v| (c, v)))
+                .collect();
             if !self.matches_prop_filter(&props, &node.props) {
                 continue;
             }
@@ -377,10 +386,19 @@ impl Engine {
             if self.is_node_tombstoned(node_id) {
                 continue;
             }
-            let props = match self.snapshot.store.get_node_raw(node_id, &col_ids) {
+            // Nullable read so absent columns are omitted rather than
+            // zero-sentineled — same #479-adjacent fix as collect_pipeline_match_rows
+            // above, needed so a genuinely null-bound binding var matches the
+            // node whose property is actually absent (see matches_prop_filter_with_binding).
+            let nullable_props = match self.snapshot.store.get_node_raw_nullable(node_id, &col_ids)
+            {
                 Ok(p) => p,
                 Err(_) => continue,
             };
+            let props: Vec<(u32, u64)> = nullable_props
+                .into_iter()
+                .filter_map(|(c, opt)| opt.map(|v| (c, v)))
+                .collect();
 
             // Evaluate inline prop filters, resolving variable references from binding.
             if !self.matches_prop_filter_with_binding(&props, &node.props, binding, &params) {
@@ -507,7 +525,16 @@ impl Engine {
                 if self.is_node_tombstoned(node_id) {
                     continue;
                 }
-                if let Ok(props) = self.snapshot.store.get_node_raw(node_id, &src_col_ids) {
+                // Nullable read — see the analogous fix a few lines above.
+                if let Ok(nullable_props) = self
+                    .snapshot
+                    .store
+                    .get_node_raw_nullable(node_id, &src_col_ids)
+                {
+                    let props: Vec<(u32, u64)> = nullable_props
+                        .into_iter()
+                        .filter_map(|(c, opt)| opt.map(|v| (c, v)))
+                        .collect();
                     if self.matches_prop_filter_with_binding(
                         &props,
                         &src_pat.props,
@@ -527,11 +554,16 @@ impl Engine {
         let mut frontier: Vec<(u32, NodeId, HashMap<String, Value>)> =
             Vec::with_capacity(src_candidates.len());
         for src_id in src_candidates {
-            let src_props = self
+            // Nullable read so row_vals reflects true absence for downstream
+            // WHERE/RETURN/next-stage evaluation rather than the zero-sentinel.
+            let src_props: Vec<(u32, u64)> = self
                 .snapshot
                 .store
-                .get_node_raw(src_id, &src_col_ids)
-                .unwrap_or_default();
+                .get_node_raw_nullable(src_id, &src_col_ids)
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|(c, opt)| opt.map(|v| (c, v)))
+                .collect();
             let mut row_vals =
                 build_row_vals(&src_props, &src_pat.var, &src_col_ids, &self.snapshot.store);
             row_vals.insert(src_pat.var.clone(), Value::NodeRef(src_id));
@@ -599,8 +631,16 @@ impl Engine {
                     if self.is_node_tombstoned(dst_id) {
                         continue;
                     }
-                    let dst_props = match self.snapshot.store.get_node_raw(dst_id, &dst_col_ids) {
-                        Ok(p) => p,
+                    // Nullable read — see the analogous fix above for src_candidates.
+                    let dst_props: Vec<(u32, u64)> = match self
+                        .snapshot
+                        .store
+                        .get_node_raw_nullable(dst_id, &dst_col_ids)
+                    {
+                        Ok(p) => p
+                            .into_iter()
+                            .filter_map(|(c, opt)| opt.map(|v| (c, v)))
+                            .collect(),
                         Err(_) => continue,
                     };
                     if !self.matches_prop_filter_with_binding(
@@ -663,14 +703,32 @@ impl Engine {
         binding: &HashMap<String, Value>,
         params: &HashMap<String, Value>,
     ) -> bool {
+        // #472: fail closed on the same "unresolvable" gate #467 introduced
+        // for `matches_prop_filter_static`, extended so that a bare `Expr::Var`
+        // present in `binding` counts as locally resolvable (it's a real
+        // pipeline-stage variable, threaded through from the preceding WITH).
+        // A `Expr::Var` NOT in `binding` is unresolved — a correlated/outer
+        // variable never carried into this stage's binding, or a typo — not a
+        // deliberate null, and must not be silently treated as `Value::Null`.
+        // Before this gate, an unresolved var defaulted to `Value::Null` and
+        // then only matched nodes whose own property happened to be absent
+        // (via the `(None, Value::Null) => true` arm below) — a
+        // symptom-free wrong answer rather than the fail-open "match every
+        // node" #467 fixed, but still wrong (issue #472).
+        let locals: Vec<&str> = binding.keys().map(|s| s.as_str()).collect();
         for f in filters {
+            if !super::is_filter_expr_resolvable_scoped(&f.value, params, &locals) {
+                return false;
+            }
+
             let col_id = prop_name_to_col_id(&f.key);
             let stored_raw = props.iter().find(|(c, _)| *c == col_id).map(|(_, v)| *v);
 
             // Evaluate the filter expression, first substituting from binding.
             let filter_val = match &f.value {
                 sparrowdb_cypher::ast::Expr::Var(v) => {
-                    // Variable reference — look up in binding.
+                    // Variable reference — resolvability just confirmed `v` is
+                    // present in `binding`.
                     binding.get(v).cloned().unwrap_or(Value::Null)
                 }
                 other => eval_expr(other, params),

--- a/crates/sparrowdb/tests/regression_472_479.rs
+++ b/crates/sparrowdb/tests/regression_472_479.rs
@@ -1,0 +1,305 @@
+//! Regression guards for issues #472 and #479 — two remaining directions of
+//! the "absent / unresolved / null are three different things" conflation
+//! family that #467/#471 partly closed.
+//!
+//! All expected values below are derived by hand from each fixture, never
+//! captured from a prior run (repo rule — see CLAUDE.md).
+//!
+//! ── #472 ─────────────────────────────────────────────────────────────────
+//! `matches_prop_filter_with_binding` (`engine/scan.rs`), used by the
+//! pipeline `WITH … MATCH` re-traversal stage, had the same "unresolved
+//! expression treated as `Value::Null`" conflation in its `Expr::Var` arm
+//! that #467 fixed in `matches_prop_filter_static`. A bare variable not
+//! present in the row `binding` (a typo, or a variable never carried
+//! through from the preceding `WITH`) defaulted to `Value::Null`, which then
+//! matched every node whose own property happened to be absent — a
+//! symptom-free wrong answer, not the "match everything" #467 guarded
+//! against, but wrong all the same.
+//!
+//! ── #479 ─────────────────────────────────────────────────────────────────
+//! After #471, a pattern-property filter whose `$param` is genuinely bound
+//! to null matches absent-property nodes on the read path, which combines
+//! `get_node_raw_nullable` with `filter_map`, but it matches nothing on
+//! three call sites that used the plain, zero-sentineled `get_node_raw`:
+//! `mutation.rs::node_matches_prop_filter` (every SET/DELETE),
+//! `expr.rs::find_node_by_props` (shortestPath endpoint resolution by
+//! label+props), and the EXISTS-pattern dst-node check in
+//! `expr.rs::eval_exists_subquery`.
+
+use sparrowdb::GraphDb;
+use sparrowdb_execution::Value;
+use std::collections::HashMap;
+use tempfile::tempdir;
+
+fn open_db() -> (GraphDb, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    (db, dir)
+}
+
+fn params(pairs: Vec<(&str, Value)>) -> HashMap<String, Value> {
+    pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// #472 — matches_prop_filter_with_binding (pipeline WITH … MATCH)
+// ═══════════════════════════════════════════════════════════════════════
+
+// ── 1. An unresolved bare var in the second MATCH's prop filter must fail
+// closed, not match the node whose own property happens to be absent. ──────
+//
+// `undefined_var` is never projected by the WITH stage (only `dummy` is), so
+// it cannot be resolved from `binding`. Fixture: 'a' has no `tag` (absent),
+// 'b' has `tag: 'x'` (present). Pre-fix, the unresolved var defaulted to
+// Value::Null, which matched 'a' via the `(None, Value::Null) => true` arm.
+// Hand-derived correct answer: neither node may match an unresolvable filter.
+#[test]
+fn unresolved_var_in_pipeline_match_prop_filter_matches_nothing() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:Trigger {x: 1})").unwrap(); // drives one WITH…MATCH pass
+    db.execute("CREATE (:Item {id: 'a'})").unwrap(); // no `tag`
+    db.execute("CREATE (:Item {id: 'b', tag: 'x'})").unwrap(); // `tag` present
+
+    let r = db
+        .execute(
+            "MATCH (t:Trigger) \
+             WITH t.x AS dummy \
+             MATCH (m:Item {tag: undefined_var}) \
+             RETURN m.id",
+        )
+        .expect("should not error");
+
+    assert_eq!(
+        r.rows,
+        Vec::<Vec<Value>>::new(),
+        "an unresolved bare var in a pipeline-stage prop filter must fail \
+         closed, not match the node whose property is absent; got {:?}",
+        r.rows
+    );
+}
+
+// ── 2. Control: a var that IS resolvable via binding still matches by value. ──
+//
+// Confirms the resolvability gate doesn't also break the legitimate case.
+// Hand-derived: `want` = "x", only 'b' has tag = "x".
+#[test]
+fn resolvable_binding_var_in_pipeline_match_still_matches_by_value() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:Trigger {x: 1})").unwrap();
+    db.execute("CREATE (:Item {id: 'a'})").unwrap();
+    db.execute("CREATE (:Item {id: 'b', tag: 'x'})").unwrap();
+
+    let r = db
+        .execute(
+            "MATCH (t:Trigger) \
+             WITH 'x' AS want \
+             MATCH (m:Item {tag: want}) \
+             RETURN m.id",
+        )
+        .expect("should not error");
+
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::String("b".into())]],
+        "a resolvable binding var must match by its actual value; got {:?}",
+        r.rows
+    );
+}
+
+// ── 3. Control: a resolvable var whose value matches no node returns empty,
+// not the absent-prop node — proves the fix doesn't overcorrect into always
+// matching 'a' regardless of resolvability. ─────────────────────────────────
+#[test]
+fn resolvable_binding_var_with_no_matching_value_matches_nothing() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:Trigger {x: 1})").unwrap();
+    db.execute("CREATE (:Item {id: 'a'})").unwrap(); // no `tag`
+    db.execute("CREATE (:Item {id: 'b', tag: 'x'})").unwrap();
+
+    let r = db
+        .execute(
+            "MATCH (t:Trigger) \
+             WITH 'y' AS want \
+             MATCH (m:Item {tag: want}) \
+             RETURN m.id",
+        )
+        .expect("should not error");
+
+    assert_eq!(
+        r.rows,
+        Vec::<Vec<Value>>::new(),
+        "'y' matches neither node's tag ('a' absent, 'b' = 'x'); got {:?}",
+        r.rows
+    );
+}
+
+// ── 4. A binding var genuinely bound to null (via WITH) must still match the
+// absent-prop node — the resolvability gate must not break this pre-existing,
+// intentional case (mirrors regression_467's test 4 for the static function). ──
+#[test]
+fn genuinely_null_bound_binding_var_matches_only_absent_prop_node() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:Trigger {x: 1})").unwrap();
+    db.execute("CREATE (:Item {id: 'a'})").unwrap(); // no `tag`
+    db.execute("CREATE (:Item {id: 'b', tag: 'x'})").unwrap();
+
+    let r = db
+        .execute(
+            "MATCH (t:Trigger) \
+             WITH null AS want \
+             MATCH (m:Item {tag: want}) \
+             RETURN m.id",
+        )
+        .expect("should not error");
+
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::String("a".into())]],
+        "a binding var genuinely bound to null must match only the node \
+         whose own property is likewise absent; got {:?}",
+        r.rows
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// #479 — absent conflated with zero (mutation-side call sites)
+// ═══════════════════════════════════════════════════════════════════════
+
+// ── 5. READ control: a $param genuinely bound to null matches the node with
+// the absent property (already covered by regression_467, restated here as
+// the read-side half of the read/mutation divergence #479 is about). ───────
+#[test]
+fn read_side_null_bound_param_matches_absent_prop_node() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:Item {id: 'a', val: 1})").unwrap(); // no `tag`
+    db.execute("CREATE (:Item {id: 'b', tag: 'x', val: 1})")
+        .unwrap();
+
+    let r = db
+        .execute_with_params(
+            "MATCH (n:Item {tag: $t}) RETURN n.id",
+            params(vec![("t", Value::Null)]),
+        )
+        .unwrap();
+
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::String("a".into())]],
+        "read path: only the absent-tag node must match; got {:?}",
+        r.rows
+    );
+}
+
+// ── 6. SET: the exact divergence from the issue. Same fixture and query
+// shape as test 5, but SET instead of RETURN. Hand-derived: only 'a' (absent
+// tag) matches, so only 'a' gets val=99; 'b' (tag present) is untouched. ───
+#[test]
+fn set_with_null_bound_param_updates_only_absent_prop_node() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:Item {id: 'a', val: 1})").unwrap(); // no `tag`
+    db.execute("CREATE (:Item {id: 'b', tag: 'x', val: 1})")
+        .unwrap();
+
+    db.execute_with_params(
+        "MATCH (n:Item {tag: $t}) SET n.val = 99",
+        params(vec![("t", Value::Null)]),
+    )
+    .unwrap();
+
+    let check = db
+        .execute("MATCH (n:Item) RETURN n.id, n.val ORDER BY n.id")
+        .unwrap();
+
+    assert_eq!(
+        check.rows,
+        vec![
+            vec![Value::String("a".into()), Value::Int64(99)],
+            vec![Value::String("b".into()), Value::Int64(1)],
+        ],
+        "SET must update only the node whose property is genuinely absent \
+         (matching the read path), not leave every node untouched; got {:?}",
+        check.rows
+    );
+}
+
+// ── 7. DELETE: same shape, mutation.rs::node_matches_prop_filter also backs
+// DELETE. Hand-derived: only 'a' (absent tag) is deleted; 'b' survives. ────
+#[test]
+fn delete_with_null_bound_param_removes_only_absent_prop_node() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:Item {id: 'a'})").unwrap(); // no `tag`
+    db.execute("CREATE (:Item {id: 'b', tag: 'x'})").unwrap();
+
+    db.execute_with_params(
+        "MATCH (n:Item {tag: $t}) DELETE n",
+        params(vec![("t", Value::Null)]),
+    )
+    .unwrap();
+
+    let check = db
+        .execute("MATCH (n:Item) RETURN n.id ORDER BY n.id")
+        .unwrap();
+
+    assert_eq!(
+        check.rows,
+        vec![vec![Value::String("b".into())]],
+        "DELETE must remove only the node whose property is genuinely \
+         absent, leaving the present-tag node in place; got {:?}",
+        check.rows
+    );
+}
+
+// ── 8. EXISTS { }: the dst-node prop filter inside an EXISTS subquery must
+// also see absence as absence. 'a1' has one edge to 'b1' (tag absent) and
+// none to a tag-present node. Hand-derived: EXISTS { (a)-[:R]->(:B {tag:
+// $t}) } with $t = null must be true for 'a1' via the b1 edge. ─────────────
+#[test]
+fn exists_subquery_dst_prop_filter_matches_absent_prop_node() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:A {id: 'a1'})").unwrap();
+    db.execute("CREATE (:B {id: 'b1'})").unwrap(); // no `tag`
+    db.execute("CREATE (:B {id: 'b2', tag: 'x'})").unwrap();
+    db.execute("MATCH (a:A {id: 'a1'}), (b:B {id: 'b1'}) CREATE (a)-[:R]->(b)")
+        .unwrap();
+
+    let r = db
+        .execute_with_params(
+            "MATCH (a:A) WHERE EXISTS { (a)-[:R]->(:B {tag: $t}) } RETURN a.id",
+            params(vec![("t", Value::Null)]),
+        )
+        .unwrap();
+
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::String("a1".into())]],
+        "EXISTS {{ }} dst-node prop filter must match the neighbour whose \
+         property is genuinely absent; got {:?}",
+        r.rows
+    );
+}
+
+// ── 9. EXISTS { } control: when the only neighbour HAS the property set,
+// a null-bound filter must not match it (proves test 8 isn't vacuously true). ──
+#[test]
+fn exists_subquery_dst_prop_filter_does_not_match_present_prop_node() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:A {id: 'a1'})").unwrap();
+    db.execute("CREATE (:B {id: 'b2', tag: 'x'})").unwrap();
+    db.execute("MATCH (a:A {id: 'a1'}), (b:B {id: 'b2'}) CREATE (a)-[:R]->(b)")
+        .unwrap();
+
+    let r = db
+        .execute_with_params(
+            "MATCH (a:A) WHERE EXISTS { (a)-[:R]->(:B {tag: $t}) } RETURN a.id",
+            params(vec![("t", Value::Null)]),
+        )
+        .unwrap();
+
+    assert_eq!(
+        r.rows,
+        Vec::<Vec<Value>>::new(),
+        "a null-bound filter must not match a neighbour whose property is \
+         actually present; got {:?}",
+        r.rows
+    );
+}


### PR DESCRIPTION
closes #472, closes #479

## Root cause — #472

`matches_prop_filter_with_binding` (`engine/scan.rs`, the pipeline `WITH … MATCH` re-traversal stage) treated an unresolved `Expr::Var` — a bare variable not present in the row `binding` (a typo, or a correlated/outer variable never carried through from the preceding `WITH`) — as `Value::Null` by default (`binding.get(v).cloned().unwrap_or(Value::Null)`). Combined with the `(None, Value::Null) => true` match arm, this silently matched every node whose own property happened to be absent — a symptom-free wrong answer, not the fail-open "match everything" #467 guarded against, but wrong all the same. Fix: apply the same `is_filter_expr_resolvable_scoped` gate #467/#471 introduced for the static filter path, extended so a variable present in `binding` counts as locally resolvable (mirrors the existing `locals` mechanism for comprehension-bound loop variables). An unresolvable filter now fails closed (the node does not match) instead of defaulting to null.

## Root cause — #479

Three mutation-side call sites read node props via `get_node_raw`, whose `read_col_slot` zero-sentinels an absent column to `Ok(0)` — indistinguishable from a stored `Int64(0)`. Every read-path call site instead uses `get_node_raw_nullable` + `filter_map` to drop absent columns entirely, so `matches_prop_filter_static`'s `Value::Null => stored_val.is_none()` arm works correctly there. On the three non-nullable sites it never fired, so a genuinely null-bound `$param` filter matched on read but nothing on SET/DELETE/EXISTS. Fixed by routing all three through the same nullable-accessor + drop-absent pattern already established on every read path, per repo guidance to avoid touching `read_col_slot`'s zero-sentinel itself (SPA-406, commit `49246b3` — changing it would alter every reader in the storage layer, a blast radius far beyond these two issues).

## What changed, per file

- **`crates/sparrowdb-execution/src/engine/scan.rs`**
  - `matches_prop_filter_with_binding`: added the resolvability gate (#472).
  - `collect_pipeline_match_rows` and the three `get_node_raw` calls inside `execute_pipeline_match_stage` (leading-match scan, src-candidate scan, dst-node scan in the hop loop): switched to `get_node_raw_nullable` + `filter_map`. **This was not optional** — while building an end-to-end test for #472's "genuinely null-bound variable must still match the absent-prop node" control case, the test failed even with the resolvability gate in place, because these four sites never produced `stored_val = None` regardless of the gate. Fixing #472 correctly required fixing this #479-shaped bug in the same file; isolated to confirm both fixes carry independent weight (see Verification).
- **`crates/sparrowdb-execution/src/engine/mutation.rs`** — `node_matches_prop_filter`: routed through `get_node_raw_nullable` + `filter_map`. Reaches every SET, DELETE (node), DELETE (edge, via `scan_match_mutate_edges`), and MATCH…CREATE / MATCH…MERGE-rel candidate scan (all route through `scan_nodes_for_label_with_index`'s fallback path).
- **`crates/sparrowdb-execution/src/engine/expr.rs`** — `find_node_by_props` (shortestPath endpoint resolution by label+props — *not* MERGE, see below) and the EXISTS-pattern dst-node check in `eval_exists_subquery`: same fix.
- **`crates/sparrowdb/tests/regression_472_479.rs`** — 9 new tests (added).

## Test output — quoted, pre-fix

All source changes stashed, tests rerun against unfixed `main`:

```
delete_with_null_bound_param_removes_only_absent_prop_node ... FAILED
  got [[String("a")], [String("b")]]     expected [[String("b")]]
set_with_null_bound_param_updates_only_absent_prop_node ... FAILED
  got [[a,1],[b,1]]                      expected [[a,99],[b,1]]
exists_subquery_dst_prop_filter_matches_absent_prop_node ... FAILED
  got []                                 expected [[a1]]
genuinely_null_bound_binding_var_matches_only_absent_prop_node ... FAILED
  got []                                 expected [[a]]
```

The other 5 tests (read control, resolvable-var controls, unresolved-var test) passed pre-fix too — expected, since they either don't depend on the fix or are guarded by the zero-sentinel bug masking the #472 symptom (see next section).

**Isolating the #472 gate specifically**: with the zero-sentinel fix applied but `is_filter_expr_resolvable_scoped` disabled (`if false && !...`), `unresolved_var_in_pipeline_match_prop_filter_matches_nothing` failed: `got [[String("a")]]  expected []`. This confirms the resolvability gate is independently load-bearing, not just riding on the nullable-read fix — two fixes landed together, and each was shown to matter on its own.

## Blast radius checked

- `node_matches_prop_filter`'s callers: `scan_match_mutate` (SET/DELETE), `scan_match_mutate_edges` (edge DELETE), `scan_nodes_for_label_with_index` (MATCH…CREATE, MATCH…MERGE-rel candidate scans). All changes are correctness-only for the narrow null-bound-filter case; behavior is unchanged for every other filter shape.
- `find_node_by_props` is used only by `eval_shortest_path_expr` (shortestPath endpoint resolution), never by MERGE.
- Ran `regression_467`, `spa_134_multi_clause`, `regression_444_430_null_projection`, `spa_137_exists_subquery` post-rebase — all green, no regressions in the pipeline/WITH/EXISTS suites this PR touches.
- `cargo fmt` (no-op), `cargo clippy -p sparrowdb -p sparrowdb-execution --all-targets --keep-going` (clean).
- Local `cargo test --workspace --exclude sparrowdb-ruby --no-fail-fast` was still running at push time (the suite is known-slow, 60+ min); not used as a merge gate — CI runs the authoritative version of this suite plus the Ruby job this machine can't compile.

## Resolving the issue's own "Unverified" section (#479)

> Whether `find_node_by_props`'s participation makes a null-matched MERGE create a duplicate node.

Checked directly: `find_node_by_props` is **not** in MERGE's path at all — MERGE uses its own comparison logic in `write_tx.rs::merge_node` (line ~303), which has the *same* absent-vs-zero conflation in principle. But it's unreachable in practice: a null-valued MERGE property is rejected upfront ("property value is null; use a concrete value" — `helpers.rs:72/110/230`, `engine/mod.rs:1615`) before that comparison is ever reached. Confirmed by probe (`MERGE (n:Item {tag: $t})` with `$t = Null` returns `InvalidArgument`, not a duplicate). So: real bug in principle in `merge_node`, unreachable today for a different reason than guessed — worth stating explicitly so nobody re-derives it, and so it's on record if the upfront null rejection ever moves.

## Found, not fixed — filed separately

**#521**: `hop.rs` (two-hop/n-hop/friend-of-friend traversal) has the identical zero-sentinel bug on 4 `get_node_raw` call sites (lines 240, 341, 602, 671), feeding ~14 `matches_prop_filter` call sites. This contradicts #479's own claim that "path.rs, hop.rs, pipeline_exec.rs all route through `get_node_raw_nullable`" — confirmed by direct count, `hop.rs` uses the plain accessor exclusively. Not fixed here: separate file, larger mechanical diff, not required to prove this PR's fix. `path.rs` is safe for a different reason than #479 states (it calls neither accessor — no prop-filter reads at all in that file); `pipeline_exec.rs` is genuinely nullable-clean.

## Could not verify

- Full `cargo test --workspace --exclude sparrowdb-ruby --no-fail-fast` completion post-rebase — the suite takes 60+ min on this box and was still running when this PR was pushed. Will report any failures it surfaces as a follow-up; not treating it as a merge gate since CI runs the authoritative version (plus the Ruby job this machine can't compile at all).
- Whether any other write-path (beyond the two crates touched here) shares this conflation — I checked `operators.rs` (a separate columnar/vectorized scan operator) and it reads raw column values without a null-vs-zero filter comparison, so it's out of the "prop filter" family this PR is about, but I did not audit it exhaustively.
- `write_tx.rs::merge_node`'s own latent absent-vs-zero conflation (see above) is unreachable today given the upfront null-value rejection; I did not verify whether any other code path could construct a `Value::Null` `want_val` that bypasses that rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE