### PR TITLE
docs: warn that concurrent multi-process access can destroy the database (#524)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,29 @@
 
 ---
 
+> ## ⚠️ Single-process only — concurrent access can permanently destroy your database
+>
+> **Open a SparrowDB database from one process at a time.** Two processes writing concurrently to the
+> same database root can corrupt `catalog.tlv` beyond recovery, after which the database **cannot be
+> opened at all**:
+>
+> ```
+> Error: corruption: duplicate label_id 0 in catalog file
+> ```
+>
+> Measured on `sparrowdb@0.1.26`: **4 of 5 concurrent runs left the database permanently unopenable.**
+> There is currently **no lock file and no guard at `open()`** — nothing stops a second process from
+> attaching. Sequential access (one process exits, the next opens) is safe.
+>
+> This is easy to hit by accident: a CLI invoked while a daemon is running, two workers, a cron job
+> overlapping a service, or a health check. The bindings expose only `open()` with **no read-only
+> mode**, so *every* attach is a potential writer.
+>
+> Tracked as [#524](https://github.com/ryaker/SparrowDB/issues/524). Until it is fixed, ensure exactly
+> one process holds a given database root.
+
+---
+
 **SparrowDB is an embedded graph database.** It links directly into your process — Rust, Python, Node.js, or Ruby — and gives you a real Cypher query interface backed by a WAL-durable store on disk. No server. No JVM. No cloud subscription. No daemon to babysit.
 
 If your data is fundamentally relational — recommendations, social graphs, dependency trees, fraud rings, knowledge graphs — and you want to query it with multi-hop traversals instead of JOIN chains, SparrowDB is the drop-in answer.


### PR DESCRIPTION
Docs only. Ships **ahead of** the fix for #524 to cap blast radius on an already-published defect.

## Why this shouldn't wait for the fix

`sparrowdb@0.1.26` is live on npm and crates.io. It has **no lock file and no guard at `open()`**, and two processes writing concurrently corrupt `catalog.tlv` permanently — measured **4 of 5 runs** left the database unopenable. A user today can lose a database with no warning anywhere in the docs.

The fix prevents *new* damage. It does nothing for someone who hits this tomorrow, and by construction they cannot open their data to get it out. A one-paragraph warning is a five-minute change that caps exposure while the real fix is designed.

## Honest limitation

**This does not reach users of the currently-published package.** npm and crates.io render the README from the *published* version, so this warning only appears there on the next release. It does cover the GitHub landing page, which is where most people look first, and it will ship with the next version regardless.

## What it says

Single-process only; sequential multi-process access is safe; the failure is total and terminal; every attach is a potential writer because the bindings expose only `open()` with no read-only mode; tracked as #524.

## Provenance

The urgency argument came from cross-session peer review, along with a concrete exposed downstream: a local service on this machine has **four entry points** defaulting to one database root with no lock file, so running its CLI while its server is up is exactly the reproduction. Verified at the process level (one holder currently, so it is healthy) without opening that database — the binding has no read-only mode, so inspecting it would itself have been a write.

Related decisions still open in #524 and deliberately **not** made here: whether concurrent *readers* stay supported (an exclusive `flock` at `open()` is simplest and would close this, but changes the concurrency contract), and whether a repair tool for already-bricked databases is feasible given that node ids embed `label_id` in their upper bits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a prominent warning that SparrowDB supports single-process access only.
  * Clarified that concurrent writes may corrupt the database and prevent it from being reopened.
  * Documented that sequential process access is safe and writable access is currently the only available mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->