### PR TITLE
fix(execution): route hop.rs's 6 zero-sentineled read sites through nullable accessors

### DIFF
--- a/crates/sparrowdb-execution/src/engine/hop.rs
+++ b/crates/sparrowdb-execution/src/engine/hop.rs
@@ -237,7 +237,14 @@ impl Engine {
                         }
                         v
                     };
-                    self.snapshot.store.get_node_raw(src_node, &all_needed)?
+                    // #521: nullable accessor + drop-absent (matches the
+                    // read_node_props helper already used by execute_two_hop /
+                    // execute_n_hop), so a genuinely null-bound $param filter
+                    // can match a node whose property is actually absent
+                    // instead of silently never matching via get_node_raw's
+                    // zero-sentinel (read_col_slot returns Ok(0) for an absent
+                    // slot, indistinguishable from a stored Int64(0)).
+                    read_node_props(&self.snapshot.store, src_node, &all_needed)?
                 } else {
                     vec![]
                 };
@@ -336,9 +343,10 @@ impl Engine {
                                 .collect()
                         } else {
                             // Fallback: individual read (e.g. delta-only slot).
-                            self.snapshot
-                                .store
-                                .get_node_raw(dst_node, &all_needed_dst)?
+                            // #521: nullable accessor + drop-absent — see the
+                            // src_props comment above for why get_node_raw's
+                            // zero-sentinel is wrong here.
+                            read_node_props(&self.snapshot.store, dst_node, &all_needed_dst)?
                         }
                     } else {
                         vec![]
@@ -599,7 +607,9 @@ impl Engine {
                             }
                             v
                         };
-                        self.snapshot.store.get_node_raw(b_node, &all_needed)?
+                        // #521: nullable accessor + drop-absent — see the
+                        // src_props comment in the forward pass above.
+                        read_node_props(&self.snapshot.store, b_node, &all_needed)?
                     } else {
                         vec![]
                     };
@@ -668,7 +678,9 @@ impl Engine {
                                 }
                                 v
                             };
-                            self.snapshot.store.get_node_raw(a_node, &all_needed)?
+                            // #521: nullable accessor + drop-absent — see the
+                            // src_props comment in the forward pass above.
+                            read_node_props(&self.snapshot.store, a_node, &all_needed)?
                         } else {
                             vec![]
                         };

--- a/crates/sparrowdb-execution/src/engine/hop.rs
+++ b/crates/sparrowdb-execution/src/engine/hop.rs
@@ -304,8 +304,19 @@ impl Engine {
 
                 // Batch-read: one fs::read() per column for all neighbors.
                 // dst_batch[i] = raw column values for unique_dst_slots[i].
-                let dst_batch: Vec<Vec<u64>> = if !all_needed_dst.is_empty() {
-                    self.snapshot.store.batch_read_node_props(
+                //
+                // #521 (broader finding, expanded scope): use the nullable
+                // variant so absent columns arrive as `None` instead of the
+                // old raw-0-as-absent sentinel `batch_read_node_props` used —
+                // same defect as `get_node_raw`'s zero-sentinel (see the
+                // src_props comment above), but this is the *primary* path
+                // for dst_props below, not a rare fallback: every neighbor
+                // slot found via CSR/delta lands in `dst_slot_to_idx` and is
+                // read from this batch; the individual `read_node_props`
+                // fallback a few lines down is the one that's effectively
+                // unreachable.
+                let dst_batch: Vec<Vec<Option<u64>>> = if !all_needed_dst.is_empty() {
+                    self.snapshot.store.batch_read_node_props_nullable(
                         effective_dst_label_id,
                         &unique_dst_slots,
                         &all_needed_dst,
@@ -340,6 +351,7 @@ impl Engine {
                                 .iter()
                                 .copied()
                                 .zip(dst_batch[idx].iter().copied())
+                                .filter_map(|(c, opt)| opt.map(|v| (c, v)))
                                 .collect()
                         } else {
                             // Fallback: individual read (e.g. delta-only slot).
@@ -1641,8 +1653,18 @@ impl Engine {
             };
 
             // Batch-read fof properties once per src_slot.
-            let fof_batch: Vec<Vec<u64>> = if !col_ids_fof.is_empty() {
-                self.snapshot.store.batch_read_node_props(
+            //
+            // #521 (broader finding, expanded scope): use the nullable
+            // variant. The old `batch_read_node_props` + `.filter(v != 0)`
+            // combination below was a *different*, worse-direction bug than
+            // #521's null-under-match: it discarded any column whose raw
+            // value was literally 0, misreading a genuinely stored
+            // `Int64(0)` as absent — silent wrong data, not just a null-filter
+            // edge case. `batch_read_node_props_nullable` distinguishes the
+            // two via the null-bitmap sidecar, so absence and stored-zero no
+            // longer collide.
+            let fof_batch: Vec<Vec<Option<u64>>> = if !col_ids_fof.is_empty() {
+                self.snapshot.store.batch_read_node_props_nullable(
                     fof_label_id,
                     &all_fof_slots,
                     &col_ids_fof,
@@ -1679,7 +1701,7 @@ impl Engine {
                                 .iter()
                                 .copied()
                                 .zip(fof_batch[idx].iter().copied())
-                                .filter(|&(_, v)| v != 0)
+                                .filter_map(|(c, opt)| opt.map(|v| (c, v)))
                                 .collect()
                         } else {
                             // Fallback: individual read (delta-only slot not in batch).

--- a/crates/sparrowdb/tests/regression_521_hop_absent.rs
+++ b/crates/sparrowdb/tests/regression_521_hop_absent.rs
@@ -1,31 +1,51 @@
-//! Regression guards for issue #521 — the same "absent conflated with zero"
-//! defect #479/#522 fixed in mutation.rs/expr.rs, found on 4 remaining
-//! call sites in hop.rs's `execute_one_hop`: `get_node_raw` zero-sentinels
-//! an absent column to `Ok(0)` (decoding to `Value::Int64(0)`, never
-//! `None`), so a genuinely null-bound `$param` prop filter could never
-//! match the node whose property is actually absent on these traversal
-//! paths — silent under-matching (same direction as #472/#479, on the
-//! traversal path rather than the pipeline/mutation path).
+//! Regression guards for issue #521 — the "absent conflated with zero"
+//! defect #479/#522 fixed in mutation.rs/expr.rs, found on two families of
+//! call sites in hop.rs:
+//!
+//! 1. **4 `get_node_raw` sites** in `execute_one_hop` (the individual-read
+//!    accessor): `read_col_slot` zero-sentinels an absent column to `Ok(0)`
+//!    (decoding to `Value::Int64(0)`, never `None`), so a genuinely
+//!    null-bound `$param` prop filter could never match the node whose
+//!    property is actually absent — silent under-matching (same direction
+//!    as #472/#479, on the traversal path rather than pipeline/mutation).
+//! 2. **2 `batch_read_node_props` sites** (the batch-read accessor used by
+//!    `execute_one_hop`'s dst-side and `execute_two_hop`'s friend-of-friend
+//!    side) — found while building this PR, not in the original issue text
+//!    (which only grepped for `get_node_raw(` and missed the differently
+//!    named batch function entirely). These are the *primary* read path for
+//!    those two prop filters, not a rare fallback, so they matter more in
+//!    practice than family 1. One of the two sites additionally carried a
+//!    manual `.filter(|&(_, v)| v != 0)` workaround that fixed the null case
+//!    by accident while breaking the opposite case: a genuinely stored
+//!    `Int64(0)` was misread as absent. Both sites now use
+//!    `batch_read_node_props_nullable`, which distinguishes absence from
+//!    stored-zero via the null-bitmap sidecar.
 //!
 //! All expected values below are derived by hand from each fixture, never
 //! captured from a prior run (repo rule — see CLAUDE.md). Each test's
 //! pre-fix failure output is quoted in the PR description, captured by
-//! running these tests against the parent commit.
+//! running these tests against the relevant parent commit.
 //!
 //! ── Site coverage ───────────────────────────────────────────────────────
-//! - hop.rs:247 (src_props, forward pass)  → `src_prop_filter_forward_hop_matches_absent_node`
-//! - hop.rs:349 (dst_props, batch-miss fallback) → NOT independently testable;
-//!   see the doc comment on `dst_fallback_site_is_unreachable_note` below.
-//! - hop.rs:612 (b_props, backward "a"-role)     → `undirected_backward_a_role_filter_matches_absent_node`
-//! - hop.rs:683 (a_props, backward "b"-role)     → `undirected_backward_b_role_filter_matches_absent_node`
+//! - hop.rs `execute_one_hop` src_props (individual read, forward pass)
+//!   → `src_prop_filter_forward_hop_matches_absent_node`
+//! - hop.rs `execute_one_hop` dst_props (individual-read batch-miss
+//!   fallback) → NOT independently testable; see the doc comment on
+//!   `dst_fallback_site_is_unreachable_note` below.
+//! - hop.rs `execute_one_hop` dst_props (**batch read, primary path**)
+//!   → `one_hop_dst_batch_filter_matches_absent_and_preserves_real_zero`
+//! - hop.rs `execute_one_hop` b_props (individual read, backward "a"-role)
+//!   → `undirected_backward_a_role_filter_matches_absent_node`
+//! - hop.rs `execute_one_hop` a_props (individual read, backward "b"-role)
+//!   → `undirected_backward_b_role_filter_matches_absent_node`
+//! - hop.rs `execute_two_hop` fof_props (**batch read, primary path**,
+//!   forward-forward `(a)-[:R]->(m)-[:R]->(f)` branch)
+//!   → `two_hop_fof_batch_filter_matches_absent_and_preserves_real_zero`
 //!
-//! Each undirected test is built so the *forward* pass contributes either
-//! zero rows or only bug-independent rows (its dst-side filter always lands
-//! on a genuinely-*present* property, which both the old zero-sentineled
-//! `get_node_raw` and the fix read identically) — so a difference in the
-//! final row count is attributable only to the backward-pass site under
-//! test, not to the still-untouched `batch_read_node_props` path noted in
-//! the PR description's findings section.
+//! Each undirected (`execute_one_hop`, backward-pass) test is built so its
+//! forward-pass contribution is fully accounted for by hand, including
+//! through the (now also fixed) batch path — see each test's derivation
+//! comment for the exact row-by-row trace.
 
 use sparrowdb::GraphDb;
 use sparrowdb_execution::Value;
@@ -156,28 +176,29 @@ fn undirected_backward_a_role_filter_matches_absent_node() {
 
 // Mirrors the previous test with the filter moved to the "b" side instead:
 // `MATCH (a:Person)-[r]-(b:Person {tag:$t}) RETURN a.name, b.name`. `a` is
-// unfiltered, so hop.rs:612 (b_props) is only exercised vacuously here —
-// this isolates hop.rs:683.
+// unfiltered, so the backward pass's "a"-role filter (b_props) is only
+// exercised vacuously here — this isolates the backward pass's "b"-role
+// filter (a_props).
 //
 // Same fixture as above (Alice absent tag; Bob, Carol present).
 //
-// Hand-derived:
-// - Forward pass: `a` unfiltered so every node is tried as src, but the
-//   `b`-side filter is evaluated through the *unmodified* batch-read path
-//   (`batch_read_node_props`, hop.rs:308 — flagged as a separate, broader
-//   finding in the PR description, not fixed here). That path reads
-//   present-tag columns correctly regardless: Alice→Bob is excluded because
-//   Bob's tag is genuinely present ('x'). Carol→Alice is also excluded, but
-//   for the *wrong* reason (the untouched batch path zero-sentinels Alice's
-//   absent tag) — this happens to make the forward pass contribute zero
-//   rows in both the pre-fix and post-fix runs, so it does not affect this
-//   test's ability to isolate hop.rs:683.
+// Hand-derived, accounting for the dst-side filter also being evaluated via
+// the now-fixed `execute_one_hop` dst batch path (this test predates that
+// fix being in scope — its expected value changed once the batch path was
+// also corrected; see the PR description for the "before expansion" value):
+// - Forward pass: `a` unfiltered so every node is tried as src.
+//   src=Alice → neighbor Bob → dst filter (b.tag=null) on Bob via the fixed
+//   batch path: Bob's tag is genuinely present ('x') → excluded correctly.
+//   src=Bob → no outgoing edges → nothing.
+//   src=Carol → neighbor Alice → dst filter on Alice via the fixed batch
+//   path: Alice's tag is genuinely absent → now correctly matches → row
+//   (a=Carol, b=Alice).
 // - Backward pass: scanning Alice/Bob/Carol as candidate "b" via a_props —
 //   at b_slot=Bob, predecessor Alice is tested via a_props against the
-//   `b`-filter (hop.rs:683). Alice's absent tag must pass under the fix.
-//   At b_slot=Alice, predecessor Carol is tested the same way; Carol's
-//   present tag correctly fails regardless of the fix.
-// - Total: exactly one row, (Bob, Alice), present only post-fix.
+//   `b`-filter. Alice's absent tag passes under the fix → row (a=Bob,
+//   b=Alice). At b_slot=Alice, predecessor Carol is tested the same way;
+//   Carol's present tag correctly fails.
+// - Total, ORDER BY a.name: [(Bob,Alice), (Carol,Alice)].
 #[test]
 fn undirected_backward_b_role_filter_matches_absent_node() {
     let (db, _dir) = open_db();
@@ -203,14 +224,158 @@ fn undirected_backward_b_role_filter_matches_absent_node() {
 
     assert_eq!(
         r.rows,
-        vec![vec![
-            Value::String("Bob".into()),
-            Value::String("Alice".into())
-        ]],
-        "undirected backward pass: Alice (absent tag) must surface as 'b' \
-         via Bob's backward-scanned predecessor edge; Carol (tag present) \
-         must never appear as 'b'; got {:?}",
+        vec![
+            vec![Value::String("Bob".into()), Value::String("Alice".into())],
+            vec![Value::String("Carol".into()), Value::String("Alice".into())],
+        ],
+        "undirected backward pass + fixed forward dst-batch path: Alice \
+         (absent tag) must surface as 'b' via both the backward edge from \
+         Bob and the forward edge from Carol; Bob and Carol must never \
+         appear as 'b' themselves since neither's tag is absent; got {:?}",
         r.rows
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// execute_one_hop dst_props — BATCH read, primary path (not the fallback)
+// ═══════════════════════════════════════════════════════════════════════
+
+// Directed one-hop with a dst-side filter and 4 neighbours off a single src
+// node, so `unique_dst_slots.len() == 4` and every one of them is found in
+// `dst_slot_to_idx` — i.e. this exercises the batch read
+// (`batch_read_node_props_nullable` as of this fix), not the individual-read
+// fallback a few lines below it (which the earlier test in this file already
+// established is unreachable through the public API regardless). Direction
+// is Outgoing, so no backward pass runs — isolates the forward dst-batch
+// path cleanly.
+//
+// Fixture: single `a1` with 4 outgoing edges to `f_absent` (no tag),
+// `f_absent2` (no tag), `f_present` (tag='x'), `f_zero` (tag=0, a genuinely
+// stored zero — encoded via `StoreValue::Int64(0)`, same tag byte as any
+// other Int64, not a raw all-zero sentinel).
+//
+// Two queries against the same fixture, both hand-derived:
+// - Null filter (`tag: $t` with `$t = null`): must match only the two
+//   genuinely-absent nodes. `f_zero` must NOT match — it has a real stored
+//   value, just one that happens to be zero.
+// - Zero filter (`tag: $t` with `$t = Value::Int64(0)`): must match only
+//   `f_zero`. The two absent nodes must NOT match a literal-0 filter — this
+//   is the direction the pre-fix batch code got backwards: with no
+//   null-bitmap check, an absent column and a genuinely-stored 0 have the
+//   identical raw encoding (0u64), so pre-fix, `f_absent`/`f_absent2` were
+//   indistinguishable from `f_zero` to this filter.
+#[test]
+fn one_hop_dst_batch_filter_matches_absent_and_preserves_real_zero() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:A {id: 'a1'})").unwrap();
+    db.execute("CREATE (:F {id: 'f_absent'})").unwrap(); // no `tag`
+    db.execute("CREATE (:F {id: 'f_absent2'})").unwrap(); // no `tag`
+    db.execute("CREATE (:F {id: 'f_present', tag: 'x'})")
+        .unwrap();
+    db.execute("CREATE (:F {id: 'f_zero', tag: 0})").unwrap(); // genuinely stored 0
+    for fof in ["f_absent", "f_absent2", "f_present", "f_zero"] {
+        db.execute(&format!(
+            "MATCH (a:A {{id:'a1'}}),(f:F {{id:'{fof}'}}) CREATE (a)-[:R]->(f)"
+        ))
+        .unwrap();
+    }
+
+    let null_result = db
+        .execute_with_params(
+            "MATCH (a:A)-[:R]->(f:F {tag: $t}) RETURN f.id ORDER BY f.id",
+            params(vec![("t", Value::Null)]),
+        )
+        .expect("should not error");
+    assert_eq!(
+        null_result.rows,
+        vec![
+            vec![Value::String("f_absent".into())],
+            vec![Value::String("f_absent2".into())],
+        ],
+        "one-hop dst batch path: a null-bound filter must match only the \
+         genuinely absent-tag nodes, never f_zero (real stored 0) or \
+         f_present; got {:?}",
+        null_result.rows
+    );
+
+    let zero_result = db
+        .execute_with_params(
+            "MATCH (a:A)-[:R]->(f:F {tag: $t}) RETURN f.id",
+            params(vec![("t", Value::Int64(0))]),
+        )
+        .expect("should not error");
+    assert_eq!(
+        zero_result.rows,
+        vec![vec![Value::String("f_zero".into())]],
+        "one-hop dst batch path: a literal-0 filter must find the \
+         genuinely-stored-0 node and only that node — absent columns must \
+         not be misread as a stored 0; got {:?}",
+        zero_result.rows
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// execute_two_hop fof_props — BATCH read, primary path (forward-forward
+// branch, `(a)-[:R]->(m)-[:R]->(f)`)
+// ═══════════════════════════════════════════════════════════════════════
+
+// Mirrors the previous test one hop further out: `a1 -> m1 -> {4 fof
+// candidates}`, forcing `all_fof_slots.len() == 4` through the single batch
+// read in the forward-forward branch of `execute_two_hop` (hop.rs, the
+// "#487: this branch runs whenever the second hop is Outgoing" comment).
+// This is the site that carried the pre-existing `.filter(|&(_, v)| v != 0)`
+// workaround — the fix here is not just "match null correctly" but "stop
+// silently misreading a genuinely-stored 0 as absent".
+#[test]
+fn two_hop_fof_batch_filter_matches_absent_and_preserves_real_zero() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:A {id: 'a1'})").unwrap();
+    db.execute("CREATE (:M {id: 'm1'})").unwrap();
+    db.execute("CREATE (:F {id: 'f_absent'})").unwrap(); // no `tag`
+    db.execute("CREATE (:F {id: 'f_absent2'})").unwrap(); // no `tag`
+    db.execute("CREATE (:F {id: 'f_present', tag: 'x'})")
+        .unwrap();
+    db.execute("CREATE (:F {id: 'f_zero', tag: 0})").unwrap(); // genuinely stored 0
+    db.execute("MATCH (a:A {id:'a1'}),(m:M {id:'m1'}) CREATE (a)-[:R]->(m)")
+        .unwrap();
+    for fof in ["f_absent", "f_absent2", "f_present", "f_zero"] {
+        db.execute(&format!(
+            "MATCH (m:M {{id:'m1'}}),(f:F {{id:'{fof}'}}) CREATE (m)-[:R]->(f)"
+        ))
+        .unwrap();
+    }
+
+    let null_result = db
+        .execute_with_params(
+            "MATCH (a:A)-[:R]->(m:M)-[:R]->(f:F {tag: $t}) RETURN f.id ORDER BY f.id",
+            params(vec![("t", Value::Null)]),
+        )
+        .expect("should not error");
+    assert_eq!(
+        null_result.rows,
+        vec![
+            vec![Value::String("f_absent".into())],
+            vec![Value::String("f_absent2".into())],
+        ],
+        "two-hop fof batch path: a null-bound filter must match only the \
+         genuinely absent-tag nodes, never f_zero (real stored 0) or \
+         f_present; got {:?}",
+        null_result.rows
+    );
+
+    let zero_result = db
+        .execute_with_params(
+            "MATCH (a:A)-[:R]->(m:M)-[:R]->(f:F {tag: $t}) RETURN f.id",
+            params(vec![("t", Value::Int64(0))]),
+        )
+        .expect("should not error");
+    assert_eq!(
+        zero_result.rows,
+        vec![vec![Value::String("f_zero".into())]],
+        "two-hop fof batch path: a literal-0 filter must find the \
+         genuinely-stored-0 node and only that node — the old \
+         `.filter(v != 0)` workaround dropped it as if absent; got {:?}",
+        zero_result.rows
     );
 }
 

--- a/crates/sparrowdb/tests/regression_521_hop_absent.rs
+++ b/crates/sparrowdb/tests/regression_521_hop_absent.rs
@@ -141,10 +141,7 @@ fn undirected_backward_a_role_filter_matches_absent_node() {
         r.rows,
         vec![
             vec![Value::String("Alice".into()), Value::String("Bob".into())],
-            vec![
-                Value::String("Alice".into()),
-                Value::String("Carol".into())
-            ],
+            vec![Value::String("Alice".into()), Value::String("Carol".into())],
         ],
         "undirected backward pass: Alice (absent tag) must surface via both \
          the forward edge to Bob and the backward edge from Carol; Bob and \
@@ -206,7 +203,10 @@ fn undirected_backward_b_role_filter_matches_absent_node() {
 
     assert_eq!(
         r.rows,
-        vec![vec![Value::String("Bob".into()), Value::String("Alice".into())]],
+        vec![vec![
+            Value::String("Bob".into()),
+            Value::String("Alice".into())
+        ]],
         "undirected backward pass: Alice (absent tag) must surface as 'b' \
          via Bob's backward-scanned predecessor edge; Carol (tag present) \
          must never appear as 'b'; got {:?}",

--- a/crates/sparrowdb/tests/regression_521_hop_absent.rs
+++ b/crates/sparrowdb/tests/regression_521_hop_absent.rs
@@ -1,0 +1,234 @@
+//! Regression guards for issue #521 — the same "absent conflated with zero"
+//! defect #479/#522 fixed in mutation.rs/expr.rs, found on 4 remaining
+//! call sites in hop.rs's `execute_one_hop`: `get_node_raw` zero-sentinels
+//! an absent column to `Ok(0)` (decoding to `Value::Int64(0)`, never
+//! `None`), so a genuinely null-bound `$param` prop filter could never
+//! match the node whose property is actually absent on these traversal
+//! paths — silent under-matching (same direction as #472/#479, on the
+//! traversal path rather than the pipeline/mutation path).
+//!
+//! All expected values below are derived by hand from each fixture, never
+//! captured from a prior run (repo rule — see CLAUDE.md). Each test's
+//! pre-fix failure output is quoted in the PR description, captured by
+//! running these tests against the parent commit.
+//!
+//! ── Site coverage ───────────────────────────────────────────────────────
+//! - hop.rs:247 (src_props, forward pass)  → `src_prop_filter_forward_hop_matches_absent_node`
+//! - hop.rs:349 (dst_props, batch-miss fallback) → NOT independently testable;
+//!   see the doc comment on `dst_fallback_site_is_unreachable_note` below.
+//! - hop.rs:612 (b_props, backward "a"-role)     → `undirected_backward_a_role_filter_matches_absent_node`
+//! - hop.rs:683 (a_props, backward "b"-role)     → `undirected_backward_b_role_filter_matches_absent_node`
+//!
+//! Each undirected test is built so the *forward* pass contributes either
+//! zero rows or only bug-independent rows (its dst-side filter always lands
+//! on a genuinely-*present* property, which both the old zero-sentineled
+//! `get_node_raw` and the fix read identically) — so a difference in the
+//! final row count is attributable only to the backward-pass site under
+//! test, not to the still-untouched `batch_read_node_props` path noted in
+//! the PR description's findings section.
+
+use sparrowdb::GraphDb;
+use sparrowdb_execution::Value;
+use std::collections::HashMap;
+use tempfile::tempdir;
+
+fn open_db() -> (GraphDb, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    (db, dir)
+}
+
+fn params(pairs: Vec<(&str, Value)>) -> HashMap<String, Value> {
+    pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Site hop.rs:247 — src_props, forward pass (directed, no backward pass)
+// ═══════════════════════════════════════════════════════════════════════
+
+// `MATCH (a:A {tag:$t})-[:R]->(b:B) RETURN a.id` reaches `execute_one_hop`
+// (the inline node prop filter bails the chunked one-hop path — see
+// `can_use_one_hop_chunked`'s "Inline prop filters on node patterns" guard).
+// Direction is Outgoing, so the undirected backward pass never runs —
+// this test exercises hop.rs:247 in isolation.
+//
+// Fixture: a1 has no `tag` (absent), a2 has `tag:'x'` (present); both have
+// an edge to b1. Hand-derived: a null-bound $t matches only the node whose
+// property is genuinely absent (mirrors the `Null == Null` convention
+// `matches_prop_filter_static` already documents) — only a1.
+#[test]
+fn src_prop_filter_forward_hop_matches_absent_node() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:A {id: 'a1'})").unwrap(); // no `tag`
+    db.execute("CREATE (:A {id: 'a2', tag: 'x'})").unwrap(); // `tag` present
+    db.execute("CREATE (:B {id: 'b1'})").unwrap();
+    db.execute("MATCH (a:A {id:'a1'}),(b:B {id:'b1'}) CREATE (a)-[:R]->(b)")
+        .unwrap();
+    db.execute("MATCH (a:A {id:'a2'}),(b:B {id:'b1'}) CREATE (a)-[:R]->(b)")
+        .unwrap();
+
+    let r = db
+        .execute_with_params(
+            "MATCH (a:A {tag: $t})-[:R]->(b:B) RETURN a.id ORDER BY a.id",
+            params(vec![("t", Value::Null)]),
+        )
+        .expect("should not error");
+
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::String("a1".into())]],
+        "one-hop forward src-side filter: only the absent-tag node (a1) may \
+         match a null-bound $t; a2 (tag='x', present) must not; got {:?}",
+        r.rows
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Site hop.rs:612 — b_props, backward pass "a"-role filter
+// ═══════════════════════════════════════════════════════════════════════
+
+// `MATCH (a:Person {tag:$t})-[r]-(b:Person) RETURN a.name, b.name` — dir is
+// Both (undirected), so the backward pass (SPA-193) runs, re-scanning the
+// same rel table's dst-label pool as candidate "a" values via `b_props`.
+// The `b` side has no inline filter, so `dst_node_pat.props` is empty and
+// hop.rs:683 (a_props) is exercised only vacuously here — this isolates
+// hop.rs:612.
+//
+// Fixture: Alice (no tag) --KNOWS--> Bob (tag='x'); Carol (tag='y')
+// --KNOWS--> Alice. Bob and Carol both have their (irrelevant) tag column
+// genuinely *present*, so their exclusion from the forward src-role and
+// from the backward "a"-role is correct regardless of the fix — it does
+// not depend on absent-vs-zero at all, keeping this test's pass/fail tied
+// only to Alice's absent-tag read.
+//
+// Hand-derived:
+// - Forward pass: only Alice's own filter passes (absent tag) → row
+//   (Alice, Bob) via her one outgoing edge.
+// - Backward pass: scanning Bob/Carol/Alice as candidate "a" via b_props —
+//   Bob and Carol are excluded (tag present, fails `stored_val.is_none()`
+//   regardless of fix). Alice's absent tag must pass via a fixed hop.rs:612,
+//   surfacing her one predecessor, Carol, as "b" → row (Alice, Carol).
+// - Total: {(Alice,Bob), (Alice,Carol)}. Pre-fix, hop.rs:247 (forward
+//   src_props) and hop.rs:612 (backward b_props) share the same bug, so
+//   Alice's absent tag is misread as `Some(0)` (never `None`) on *both*
+//   passes — she is wrongly excluded as forward src too, not just from the
+//   backward branch, so the pre-fix result is empty, not `[(Alice,Bob)]`.
+//   Confirmed by running this test against the pre-fix commit: got `[]`.
+#[test]
+fn undirected_backward_a_role_filter_matches_absent_node() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:Person {name: 'Alice'})").unwrap(); // no `tag`
+    db.execute("CREATE (:Person {name: 'Bob', tag: 'x'})")
+        .unwrap();
+    db.execute("CREATE (:Person {name: 'Carol', tag: 'y'})")
+        .unwrap();
+    db.execute("MATCH (a:Person {name:'Alice'}),(b:Person {name:'Bob'}) CREATE (a)-[:KNOWS]->(b)")
+        .unwrap();
+    db.execute(
+        "MATCH (a:Person {name:'Carol'}),(b:Person {name:'Alice'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+
+    let r = db
+        .execute_with_params(
+            "MATCH (a:Person {tag: $t})-[r]-(b:Person) RETURN a.name, b.name \
+             ORDER BY a.name, b.name",
+            params(vec![("t", Value::Null)]),
+        )
+        .expect("should not error");
+
+    assert_eq!(
+        r.rows,
+        vec![
+            vec![Value::String("Alice".into()), Value::String("Bob".into())],
+            vec![
+                Value::String("Alice".into()),
+                Value::String("Carol".into())
+            ],
+        ],
+        "undirected backward pass: Alice (absent tag) must surface via both \
+         the forward edge to Bob and the backward edge from Carol; Bob and \
+         Carol (tag present) must never appear as 'a'; got {:?}",
+        r.rows
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Site hop.rs:683 — a_props, backward pass "b"-role filter
+// ═══════════════════════════════════════════════════════════════════════
+
+// Mirrors the previous test with the filter moved to the "b" side instead:
+// `MATCH (a:Person)-[r]-(b:Person {tag:$t}) RETURN a.name, b.name`. `a` is
+// unfiltered, so hop.rs:612 (b_props) is only exercised vacuously here —
+// this isolates hop.rs:683.
+//
+// Same fixture as above (Alice absent tag; Bob, Carol present).
+//
+// Hand-derived:
+// - Forward pass: `a` unfiltered so every node is tried as src, but the
+//   `b`-side filter is evaluated through the *unmodified* batch-read path
+//   (`batch_read_node_props`, hop.rs:308 — flagged as a separate, broader
+//   finding in the PR description, not fixed here). That path reads
+//   present-tag columns correctly regardless: Alice→Bob is excluded because
+//   Bob's tag is genuinely present ('x'). Carol→Alice is also excluded, but
+//   for the *wrong* reason (the untouched batch path zero-sentinels Alice's
+//   absent tag) — this happens to make the forward pass contribute zero
+//   rows in both the pre-fix and post-fix runs, so it does not affect this
+//   test's ability to isolate hop.rs:683.
+// - Backward pass: scanning Alice/Bob/Carol as candidate "b" via a_props —
+//   at b_slot=Bob, predecessor Alice is tested via a_props against the
+//   `b`-filter (hop.rs:683). Alice's absent tag must pass under the fix.
+//   At b_slot=Alice, predecessor Carol is tested the same way; Carol's
+//   present tag correctly fails regardless of the fix.
+// - Total: exactly one row, (Bob, Alice), present only post-fix.
+#[test]
+fn undirected_backward_b_role_filter_matches_absent_node() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (:Person {name: 'Alice'})").unwrap(); // no `tag`
+    db.execute("CREATE (:Person {name: 'Bob', tag: 'x'})")
+        .unwrap();
+    db.execute("CREATE (:Person {name: 'Carol', tag: 'y'})")
+        .unwrap();
+    db.execute("MATCH (a:Person {name:'Alice'}),(b:Person {name:'Bob'}) CREATE (a)-[:KNOWS]->(b)")
+        .unwrap();
+    db.execute(
+        "MATCH (a:Person {name:'Carol'}),(b:Person {name:'Alice'}) CREATE (a)-[:KNOWS]->(b)",
+    )
+    .unwrap();
+
+    let r = db
+        .execute_with_params(
+            "MATCH (a:Person)-[r]-(b:Person {tag: $t}) RETURN a.name, b.name \
+             ORDER BY a.name, b.name",
+            params(vec![("t", Value::Null)]),
+        )
+        .expect("should not error");
+
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::String("Bob".into()), Value::String("Alice".into())]],
+        "undirected backward pass: Alice (absent tag) must surface as 'b' \
+         via Bob's backward-scanned predecessor edge; Carol (tag present) \
+         must never appear as 'b'; got {:?}",
+        r.rows
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Site hop.rs:349 — dst_props batch-miss fallback: NOT independently
+// testable; documented here rather than covered by a misleading test.
+// ═══════════════════════════════════════════════════════════════════════
+//
+// `unique_dst_slots` (hop.rs:297) is built by deduplicating `all_neighbors`
+// — the exact same collection the outer `for &dst_slot in &all_neighbors`
+// loop (hop.rs:324) iterates. `dst_slot_to_idx` (hop.rs:317) indexes every
+// entry of `unique_dst_slots`, and `batch_read_node_props` always returns
+// exactly one row per requested slot (verified in
+// crates/sparrowdb-storage/src/node_store.rs:1595-1645). So
+// `dst_slot_to_idx.get(&dst_slot)` at hop.rs:338 can never miss for any
+// `dst_slot` reached by that loop — the fallback branch at hop.rs:349 is
+// unreachable through the public query API as currently structured. No
+// fixture can force a pre-fix/post-fix behavioral difference there because
+// the branch never executes either way. The site was still converted to
+// `read_node_props` for consistency with the other 3 sites and in case a
+// future change (e.g. a partial/streamed batch read) makes it reachable.


### PR DESCRIPTION
## Summary

`read_col_slot` (storage layer) zero-sentinels an absent column to `Ok(0)`, which decodes to `Value::Int64(0)` and never `None`. This defect exists on **two independent call paths in `hop.rs`**, not just the one the issue named:

1. **4 `get_node_raw` sites** in `execute_one_hop` — the individual-node-read accessor. This is what issue #521 named (its own survey grepped for `get_node_raw(` occurrences).
2. **2 `batch_read_node_props` sites** — the *batch*-read accessor, used by `execute_one_hop`'s dst-side and `execute_two_hop`'s friend-of-friend side. **Not in the original issue text** — its grep-based survey only counted `get_node_raw(` and missed this differently-named function entirely, the same class of gap #521 itself calls out in #479's survey ("#479 states that the read-path call sites are safe... That is wrong about hop.rs"). I found this mid-task, flagged it to @ryaker before proceeding, and was told to expand scope to fix it in this PR rather than defer it — see the corrected picture below.

Both families are fixed here. `read_col_slot` and `batch_read_node_props`/`get_node_raw` themselves are **unchanged** — every other reader in the storage layer is unaffected. Only the 6 call sites inside `hop.rs` were touched.

closes #521

## The corrected picture (my issue's survey was wrong)

Family 2 turned out to matter *more* in practice than family 1: `get_node_raw` at the individual-read sites is mostly a rare/unreachable fallback (see below), but `batch_read_node_props` is the **primary** read path for two prop filters — the common case, not an edge case. One of its two sites additionally carried a manual `.filter(|&(_, v)| v != 0)` workaround that happened to fix the null-under-match symptom by accident, while introducing the *opposite* bug: a genuinely stored `Int64(0)` was silently misread as absent — live wrong data on `main` for any integer property that happens to be zero, not just a null-filter edge case.

## What changed (1 file, `crates/sparrowdb-execution/src/engine/hop.rs`)

All 6 sites converted to the existing nullable read paths already used elsewhere in this file (`execute_two_hop`/`execute_n_hop`'s other reads):

| Site | Accessor | Role | Query shape that reaches it |
|---|---|---|---|
| `execute_one_hop` src_props | `get_node_raw` → `read_node_props` | forward pass, individual read | `MATCH (a:A {tag:$t})-[:R]->(b:B) ...` — directed, source-side filter |
| `execute_one_hop` dst_props (fallback) | `get_node_raw` → `read_node_props` | batch-miss fallback, individual read | **Not independently reachable** — see "Could not verify" |
| `execute_one_hop` dst_props (**primary**) | `batch_read_node_props` → `batch_read_node_props_nullable` | forward pass, batch read | Any one-hop query with a dst-side filter and ≥1 neighbor found via CSR/delta (the common case) |
| `execute_one_hop` b_props | `get_node_raw` → `read_node_props` | backward "a"-role, individual read | Undirected: `MATCH (a:P {tag:$t})-[r]-(b:P) ...`, only when `dir == EdgeDir::Both` |
| `execute_one_hop` a_props | `get_node_raw` → `read_node_props` | backward "b"-role, individual read | Undirected: `MATCH (a:P)-[r]-(b:P {tag:$t}) ...`, only when `dir == EdgeDir::Both` |
| `execute_two_hop` fof_props (**primary**) | `batch_read_node_props` + `.filter(v != 0)` → `batch_read_node_props_nullable` | forward-forward branch, batch read | `MATCH (a)-[:R]->(m)-[:R]->(f) ...` with an `f`-side filter, second hop Outgoing |

`read_node_props` (individual sites) and the new `batch_read_node_props_nullable` calls (batch sites) both drop absent columns from the props vec entirely (`filter_map`), rather than zero-filling — matching the pattern the rest of this file already uses for its correct sites.

**Loop-nesting check**: all 6 conversions are 1:1 substitutions at the exact call site — same position in the same loop, same arguments (plus the `filter_map`/`Option` unwrap where the batch signature changed), no code moved between loop levels. The two batch calls remain computed once per `src_slot` (outside their respective inner per-neighbor loops), exactly as before — I checked this specifically given the repo's prior 44x HNSW regression from a block landing in the wrong loop during a port.

## Tests (`crates/sparrowdb/tests/regression_521_hop_absent.rs`)

5 tests total, each isolating one site (4 covered end-to-end; the 5th site is the unreachable fallback, documented not faked):

1. **`src_prop_filter_forward_hop_matches_absent_node`** (individual, forward src) — directed one-hop. Pre-fix: `got []` (confirmed against `44f27de~1`).
2. **`undirected_backward_a_role_filter_matches_absent_node`** (individual, backward a-role) — undirected. Pre-fix: `got []` (confirmed against `44f27de~1`).
3. **`undirected_backward_b_role_filter_matches_absent_node`** (individual, backward b-role) — undirected. **Its expected value changed with the scope expansion**: fixing the dst-batch path (site 3 in the table) means a forward-pass row that used to be excluded only *because of* the batch bug now correctly appears. Quoted outputs:
   - Against `44f27de~1` (pre any #521 fix): `got []`
   - Against the commit with only the 4-site individual-read fix (`f014bf6`, i.e. before batch expansion): `got [[Bob, Alice]]` — one row, not the current expected two
   - Against this PR's full fix: `[[Bob,Alice],[Carol,Alice]]` ✓ (the currently-expected value)
4. **`one_hop_dst_batch_filter_matches_absent_and_preserves_real_zero`** (**batch**, dst primary path) — 4 neighbors off one src node, forcing `unique_dst_slots.len() == 4` through the actual batch read, not the fallback. Two assertions:
   - Null filter must match only the 2 genuinely-absent nodes. Pre-fix (`f014bf6`): `got []` — under-match, every neighbor's tag column reads back as `Some(0)` regardless of absence.
   - A literal-`0` filter must find only the genuinely-stored-0 node. Pre-fix (`f014bf6`, isolated via a throwaway probe since the first assertion already fails and short-circuits the function): `got [f_absent, f_absent2, f_zero]` — over-match, absent columns are indistinguishable from a real `Int64(0)` at the raw-byte level (both are `0u64`) without the null-bitmap check.
5. **`two_hop_fof_batch_filter_matches_absent_and_preserves_real_zero`** (**batch**, fof primary path, forward-forward branch) — same shape one hop further out, forces the batch through `all_fof_slots.len() == 4`. Two assertions:
   - Null filter pre-fix (`f014bf6`): `got [f_absent, f_absent2, f_zero]` — the old `.filter(v != 0)` workaround over-matches, since it also treats real zero as absent.
   - Literal-`0` filter pre-fix (isolated via probe): `got []` — the workaround drops `f_zero` from the props vec entirely (raw value `0`), so it can never be found again, even by an exact-zero filter.

**Over-match direction verified in every test**: each fixture includes a node with the property genuinely present (non-zero string, or non-empty other-tag node), and each assertion is an exact-set match.

**Could not verify** — read this section first:
- `execute_one_hop`'s dst-props individual-read fallback is **unreachable through the public query API as currently structured**: `unique_dst_slots` (dedup of `all_neighbors`) and the outer per-neighbor loop iterate the same collection, `dst_slot_to_idx` indexes every entry of `unique_dst_slots`, and both `batch_read_node_props` and `batch_read_node_props_nullable` always return exactly one row per requested slot. `dst_slot_to_idx.get(&dst_slot)` can never miss. I converted it anyway (consistency, and in case a future change — e.g. a partial/streamed batch — makes it reachable), but it's unverified by test.
- I did **not** run `cargo test --workspace` locally (excludes `sparrowdb-ruby`, which doesn't compile on this machine; redundant with CI per repo `CLAUDE.md`).
- I have **not** verified interaction with `execute_variable_length`/varlen-hop paths — those don't call into the functions I touched per the `scan.rs` dispatch logic I read, so I believe they're unaffected, but didn't add tests for them specifically.
- The two `zero_result` pre-fix outputs quoted above were captured via a throwaway probe test (not committed) rather than the shipped test itself, because each shipped test's first assertion (`null_result`) already fails and panics before the second assertion (`zero_result`) would run — so the shipped test file only directly demonstrates one failure mode per test pre-fix, with the other confirmed separately. Both probe runs were against the same `f014bf6` checkout as the corresponding shipped-test failures, immediately before restoring the fix.

## Verification run (all local, `CARGO_TARGET_DIR=/Volumes/Dev/target-521`)

- `cargo fmt` — clean
- `cargo clippy -p sparrowdb -p sparrowdb-execution --all-targets --keep-going` — 0 warnings
- `cargo check -p sparrowdb` — passes (merge-discipline gate)
- `cargo test -p sparrowdb-execution --lib` — 50/50 pass
- Targeted e2e suites (`--no-fail-fast`), all pass: `regression_521_hop_absent` (new, 5), `regression_467` (11), `regression_472_479` (9), `regression_487_488_edge_direction` (10), `spa_193_undirected_pattern` (3), `spa_201_csr_backward` (5), `spa_299_phase4_parity` (17), `spa_188_two_hop_where` (4), `spa_200_batch_hop_perf` (5), `spa_241_multihop_props` (4), `spa_252_three_hop_binding` (4), `spa_263_two_hop_agg` (3), `spa_263_two_hop_null` (3)
- Did not run `cargo test --workspace` — see "Could not verify"
- Every new test independently confirmed to fail against the relevant pre-fix commit with the quoted output above, then confirmed to pass again after restoring the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE
