### PR TITLE
fix(sparrowdb): reject $-prefixed parameter keys in execute_with_params

### DIFF
--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -1233,7 +1233,22 @@ impl GraphDb {
         // branches, list comprehensions, subqueries, ...) and is left as a
         // separate, larger change.
         for key in params.keys() {
-            if let Some(bare) = key.strip_prefix('$') {
+            if key.starts_with('$') {
+                // `trim_start_matches`, not `strip_prefix`: a key can carry
+                // more than one leading sigil (`"$$t"`), and suggesting the
+                // single-strip result (`"$t"`) would hand back a value this
+                // same check rejects on the very next call — an error whose
+                // own advice fails.
+                let bare = key.trim_start_matches('$');
+                if bare.is_empty() {
+                    // The key was only sigils (`"$"`, `"$$"`) — there is no
+                    // bare name left to suggest.
+                    return Err(Error::InvalidArgument(format!(
+                        "parameter key {key:?} has no name left once its \
+                         leading '$' is removed; the params map must be \
+                         keyed by a real parameter name, not the sigil alone"
+                    )));
+                }
                 return Err(Error::InvalidArgument(format!(
                     "parameter key {key:?} must not include the leading '$' \
                      sigil; use {bare:?} instead — the params map is keyed by \

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -1210,6 +1210,39 @@ impl GraphDb {
         cypher: &str,
         params: HashMap<String, sparrowdb_execution::Value>,
     ) -> Result<QueryResult> {
+        // SPA-523: the params map is keyed by the bare parameter name — the
+        // lexer strips the `$` sigil when tokenizing `$name` inside Cypher
+        // source (see `sparrowdb_cypher::lexer`), so `Expr`/`Literal::Param`
+        // and the engine's lookup (`params.get(name)`, `EngineBuilder::
+        // with_params`) never see a leading `$`. A caller who mirrors the
+        // query text and keys the map `"$t"` instead of `"t"` was previously
+        // silently mis-keyed: the lookup missed, the filter fell back to an
+        // unresolvable value, and (post-#467) that now fails *closed* —
+        // zero rows, no error. That is indistinguishable from a query that
+        // legitimately matched nothing. Reject the sigil form outright: it
+        // is unambiguously a caller mistake (no legitimate parameter name
+        // can contain `$`, since the lexer would never let one reach the
+        // caller's params map to begin with) and the error can name the
+        // exact fix.
+        //
+        // Unknown-but-unreferenced keys (a key present in the map that no
+        // `$name` in the query text refers to) are deliberately NOT rejected
+        // here — see issue #523 discussion. A typo'd key (`tt` for `t`) still
+        // returns silent-empty rather than erroring; catching that requires
+        // walking the full bound AST for every `$param` reference (CASE
+        // branches, list comprehensions, subqueries, ...) and is left as a
+        // separate, larger change.
+        for key in params.keys() {
+            if let Some(bare) = key.strip_prefix('$') {
+                return Err(Error::InvalidArgument(format!(
+                    "parameter key {key:?} must not include the leading '$' \
+                     sigil; use {bare:?} instead — the params map is keyed by \
+                     the bare name (e.g. `{{{bare:?}: ...}}`), and `$` is only \
+                     written in the Cypher query text itself (e.g. `${bare}`)"
+                )));
+            }
+        }
+
         use sparrowdb_cypher::{bind, parse};
 
         let stmt = parse(cypher)?;

--- a/crates/sparrowdb/tests/regression_523_param_key_sigil.rs
+++ b/crates/sparrowdb/tests/regression_523_param_key_sigil.rs
@@ -1,0 +1,173 @@
+//! Regression guard for issue #523 — a mis-keyed parameter silently returns
+//! zero rows instead of erroring.
+//!
+//! `GraphDb::execute_with_params` takes a `HashMap<String, Value>` keyed by
+//! the *bare* parameter name. The Cypher lexer (`sparrowdb_cypher::lexer`)
+//! strips the `$` sigil when tokenizing `$name` in query text, so
+//! `Expr`/`Literal::Param` and the engine's lookup never see a leading `$`.
+//! A caller who keys the map with the sigil — the natural mistake, since
+//! that's how the parameter appears in the query text — was previously
+//! silently mis-keyed: the lookup missed, the filter fell back to an
+//! unresolvable value, and (post-#467) that fails *closed*: zero rows, no
+//! error, indistinguishable from a query that legitimately matched nothing.
+//!
+//! The fix rejects any params-map key with a leading `$` outright, in
+//! `GraphDb::execute_with_params` (`crates/sparrowdb/src/db.rs`) — the single
+//! entry point shared by every binding (Node's `executeWithParams`, Python's
+//! `execute_with_params`, the HTTP server's `/cypher` handler, and
+//! `helpers.rs`), so the fix is inherited by all of them without any binding
+//! changes.
+//!
+//! Deliberately unchanged (out of scope, #467/#471 territory):
+//!   - a typo'd key (`tt` for `t`) — still returns silent-empty. Catching
+//!     that requires walking the full bound AST for every `$param`
+//!     reference and was not attempted here (see #523 discussion).
+//!   - an *omitted* parameter (`params {}`) — still returns silent-empty,
+//!     which is the correct fail-closed behavior `regression_467.rs` guards.
+//!
+//! All expected values below are derived by hand from each fixture, never
+//! captured from a prior run.
+
+use sparrowdb::GraphDb;
+use sparrowdb_execution::Value;
+use std::collections::HashMap;
+use tempfile::tempdir;
+
+fn open_db() -> (GraphDb, tempfile::TempDir) {
+    let dir = tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    (db, dir)
+}
+
+fn params(pairs: Vec<(&str, Value)>) -> HashMap<String, Value> {
+    pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
+}
+
+// ── 1. Control: the correct bare key must keep working ──────────────────
+//
+// Hand-derived: one `:Item` node has `tag: 'x'`, so `MATCH (n:Item {tag: $t})`
+// with `$t` bound to `'x'` must return exactly that node's name.
+
+#[test]
+fn correct_bare_key_still_matches() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {name: 'a', tag: 'x'})").unwrap();
+
+    let r = db
+        .execute_with_params(
+            "MATCH (n:Item {tag: $t}) RETURN n.name",
+            params(vec![("t", Value::String("x".into()))]),
+        )
+        .unwrap();
+
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::String("a".into())]],
+        "the correctly-keyed param must still match; got {:?}",
+        r.rows
+    );
+}
+
+// ── 2. The sigil form must now error, not silently return empty ─────────
+//
+// Pre-fix (confirmed against the pre-fix commit below): this returned
+// `Ok(QueryResult { rows: [], .. })` — the mis-keyed "$t" entry in the map
+// never matched the engine's bare-name lookup, so the filter fell back to
+// unresolvable and failed closed with no error signal at all.
+
+#[test]
+fn sigil_prefixed_key_errors_instead_of_silently_empty() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {name: 'a', tag: 'x'})").unwrap();
+
+    let r = db.execute_with_params(
+        "MATCH (n:Item {tag: $t}) RETURN n.name",
+        params(vec![("$t", Value::String("x".into()))]),
+    );
+
+    let err = r.expect_err(
+        "a params-map key with a leading '$' must be rejected, not silently \
+         return empty rows",
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("$t") && msg.contains('t'),
+        "error should name the offending key and the expected bare form; got: {msg}"
+    );
+}
+
+// ── 3. Control: a typo'd key is explicitly out of scope — still empty ───
+//
+// Hand-derived: no node has `tag` matching an unresolvable filter value, so
+// the correct answer remains the empty set (not an error) — this fix does
+// not attempt to catch unreferenced/typo'd keys.
+
+#[test]
+fn typo_key_still_silently_empty_out_of_scope() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {name: 'a', tag: 'x'})").unwrap();
+
+    let r = db
+        .execute_with_params(
+            "MATCH (n:Item {tag: $t}) RETURN n.name",
+            params(vec![("tt", Value::String("x".into()))]),
+        )
+        .unwrap();
+
+    assert_eq!(
+        r.rows,
+        Vec::<Vec<Value>>::new(),
+        "a typo'd key is out of scope for this fix and must remain \
+         silent-empty, not error; got {:?}",
+        r.rows
+    );
+}
+
+// ── 4. Control: the omitted-parameter case must keep failing closed ─────
+//
+// This is the #467/#471 behavior explicitly out of scope for #523 — must
+// not become an error as a side effect of this fix.
+
+#[test]
+fn omitted_param_still_silently_empty_control() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {name: 'a', tag: 'x'})").unwrap();
+
+    let r = db
+        .execute_with_params("MATCH (n:Item {tag: $t}) RETURN n.name", HashMap::new())
+        .unwrap();
+
+    assert_eq!(
+        r.rows,
+        Vec::<Vec<Value>>::new(),
+        "omitting the param entirely must remain silent-empty (#467/#471 \
+         territory, not this fix); got {:?}",
+        r.rows
+    );
+}
+
+// ── 5. A sigil-prefixed key must error even when other keys are correct ──
+//
+// Guards against a naive implementation that only checks a single key or
+// bails after the first "good" key.
+
+#[test]
+fn sigil_key_errors_even_alongside_correct_keys() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {name: 'a', tag: 'x', extra: 1})")
+        .unwrap();
+
+    let r = db.execute_with_params(
+        "MATCH (n:Item {tag: $t, extra: $e}) RETURN n.name",
+        params(vec![
+            ("t", Value::String("x".into())),
+            ("$e", Value::Int64(1)),
+        ]),
+    );
+
+    assert!(
+        r.is_err(),
+        "a sigil-prefixed key must be rejected even when a sibling key in \
+         the same map is correctly formed"
+    );
+}

--- a/crates/sparrowdb/tests/regression_523_param_key_sigil.rs
+++ b/crates/sparrowdb/tests/regression_523_param_key_sigil.rs
@@ -96,6 +96,77 @@ fn sigil_prefixed_key_errors_instead_of_silently_empty() {
     );
 }
 
+// ── 2b. A key with *multiple* leading sigils must suggest a valid bare
+// name, not one that the same check would reject on the caller's next try ──
+//
+// `strip_prefix('$')` on `"$$t"` removes exactly one `$`, leaving `"$t"` —
+// suggesting that would send a caller who follows the error's own advice
+// straight back into this same rejection. `trim_start_matches('$')` removes
+// all of them, so the suggested name (`"t"`) must actually be accepted.
+
+#[test]
+fn double_sigil_key_suggests_a_name_that_is_itself_valid() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {name: 'a', tag: 'x'})").unwrap();
+
+    let r = db.execute_with_params(
+        "MATCH (n:Item {tag: $t}) RETURN n.name",
+        params(vec![("$$t", Value::String("x".into()))]),
+    );
+
+    let err = r.expect_err("a double-sigil key must also be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("\"t\""),
+        "the suggested bare name must be \"t\" (all sigils stripped), not \
+         \"$t\" (only one stripped); got: {msg}"
+    );
+
+    // Prove the suggestion actually works: retry with the suggested key.
+    let retried = db
+        .execute_with_params(
+            "MATCH (n:Item {tag: $t}) RETURN n.name",
+            params(vec![("t", Value::String("x".into()))]),
+        )
+        .expect("the name the error message suggested must itself be accepted");
+    assert_eq!(
+        retried.rows,
+        vec![vec![Value::String("a".into())]],
+        "got {:?}",
+        retried.rows
+    );
+}
+
+// ── 2c. A key that is only sigils has no bare name to suggest — its own
+// distinct error, not a suggestion of the empty string ──────────────────
+//
+// `"$"` and `"$$"` both trim down to `""`. Recommending `""` as a parameter
+// name would be nonsense (no Cypher `$name` token can be empty — the lexer
+// itself rejects `$` with nothing after it, see
+// `sparrowdb_cypher::lexer.rs`'s "empty parameter name after $" error), so
+// this must be its own error, not the generic "use {bare} instead" message.
+
+#[test]
+fn sigil_only_key_gets_its_own_error_not_an_empty_suggestion() {
+    let (db, _dir) = open_db();
+    db.execute("CREATE (n:Item {name: 'a', tag: 'x'})").unwrap();
+
+    for bad_key in ["$", "$$"] {
+        let r = db.execute_with_params(
+            "MATCH (n:Item {tag: $t}) RETURN n.name",
+            params(vec![(bad_key, Value::String("x".into()))]),
+        );
+
+        let err = r.expect_err(&format!("key {bad_key:?} (sigils only) must be rejected"));
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("use \"\""),
+            "{bad_key:?}: must not suggest the empty string as the bare \
+             name; got: {msg}"
+        );
+    }
+}
+
 // ── 3. Control: a typo'd key is explicitly out of scope — still empty ───
 //
 // Hand-derived: no node has `tag` matching an unresolvable filter value, so


### PR DESCRIPTION
## Summary
Closes #523.

`GraphDb::execute_with_params` takes a `HashMap<String, Value>` keyed by the *bare* parameter name (the Cypher lexer strips the `$` sigil when tokenizing `$name` in query text, so `Expr`/`Literal::Param` and the engine's lookup never see a leading `$`). A caller who mirrors the query text and keys the map `"$t"` instead of `"t"` was previously silently mis-keyed: the lookup missed, the filter fell back to unresolvable, and (post-#467) that fails **closed** — zero rows, no error. That's indistinguishable from a query that legitimately matched nothing, and it cost a reviewer a false "fix doesn't work" finding on correct code.

**Root cause:** `execute_with_params` (`crates/sparrowdb/src/db.rs`) had no validation on the incoming params-map keys before handing them to the engine's bare-name lookup.

**Fix:** `execute_with_params` now rejects any params-map key with a leading `$` up front, with an error naming both the offending key and the expected bare form. This is the single entry point shared by every binding (Node's `executeWithParams`, Python's `execute_with_params`, the HTTP `/cypher` handler, and `helpers.rs`), so the fix is inherited by all of them with **zero binding changes**.

**Function changed:** `GraphDb::execute_with_params` in `crates/sparrowdb/src/db.rs` only — a validation loop added at the top of the function, before parsing/binding. No other function touched.

## Shared-param-map pattern — investigated, not found in this repo
The issue asked me to check whether callers pass a shared param map across several queries (which unknown-key rejection could break) before deciding whether to also reject unreferenced/unknown keys. I checked every `execute_with_params` call site in this repo (Node/Python bindings, HTTP server, `helpers.rs`, and all test fixtures) — every one builds a params map tailored to exactly the query it's passed to; none reuse a map with extra keys across calls. That's not proof no external caller does this, but I found no in-repo evidence either way.

Given that, and given that full unknown-key detection requires walking the entire bound AST for every `$param` reference (`CASE` branches, list comprehensions, subqueries, function args, ...) — the same kind of AST-completeness problem that caused #478 and #502 when a `Statement`/`Expr` variant fell through a match that wasn't kept in sync — I implemented **only** the `$`-prefix rejection here. It's unambiguous (no legitimate parameter name can contain `$`) and complete by construction. A typo'd key (`tt` for `t`) still returns silent-empty; closing that gap is a separate, larger change I'm leaving for a follow-up decision rather than bundling into this fix.

## Deliberately out of scope
The omitted-parameter case (`params {}`) is unchanged — still fails closed (empty rows, no error), which is correct #467/#471 behavior. `regression_467.rs`'s existing tests for this pass unmodified. Whether an *unresolvable* filter (as opposed to a caller mistake) should itself be an error is a separate design decision, called out in the issue as the maintainer's call, not mine.

## Test plan
- [x] New file `crates/sparrowdb/tests/regression_523_param_key_sigil.rs`, 5 tests: correct bare key still matches; sigil-prefixed key now errors (naming both `"$t"` and `"t"` in the message); typo'd key still silent-empty (control, explicitly out of scope); omitted param still silent-empty (control, #467/#471); sigil key errors even when a sibling key in the same map is correctly formed.
- [x] Confirmed each new test **fails against the pre-fix commit** (stashed the `db.rs` change, kept the new test file, ran it): both the sigil-key tests failed with the exact reported symptom — `rows: []`, `Ok(...)`, no error — while the three controls passed. Restored the fix afterward.
- [x] Verified through the **Node binding** (`executeWithParams`), not just the Rust API — built `sparrowdb-node` release, copied the `.node` artifact into `npm/sparrowdb/`, and reran the issue's exact repro:
  - `{t: 'x'}` → `[{"n.name":"a"}]` (unchanged, correct)
  - `{'$t': 'x'}` → now **throws**: `invalid argument: parameter key "$t" must not include the leading '$' sigil; use "t" instead — ...`
  - `{tt: 'x'}` → `[]` (unchanged, out of scope)
  - `{}` → `[]` (unchanged, control)
  Since the fix is in `GraphDb::execute_with_params` (shared code), Python's `execute_with_params`, the HTTP server's `/cypher` handler, and `helpers.rs` all inherit it automatically — I did not build/test those bindings individually, but they route through the identical entry point verified above.
- [x] `cargo fmt` — clean, no diff.
- [x] `cargo clippy -p sparrowdb -p sparrowdb-execution --all-targets --keep-going` — no warnings.
- [x] `regression_467` (11 tests) and `regression_472_479` (9 tests) — both pass unmodified, confirming this change doesn't disturb `$param` filter fail-closed behavior.
- [ ] Full `cargo test -p sparrowdb --no-fail-fast` — running in the background at commit time (suite is slow, 60+ min); not blocking this PR per repo convention, CI is authoritative.

## Could not verify
- Python and Ruby bindings were **not** individually built/tested — I relied on the fact that they call the same `GraphDb::execute_with_params` verified directly and via Node, and confirmed by reading each binding's source that none re-implement the params-map conversion in a way that would bypass this check. Ruby doesn't have an `execute_with_params` binding at all currently, so it's unaffected either way.
- Whether an external caller (outside this repo) actually relies on a shared/reused param map with unreferenced keys — I found no such pattern in this codebase, but that's not proof none exists elsewhere. This is why I scoped the fix to the unambiguous `$`-prefix case only, per the issue's "at minimum" instruction.
- The full workspace suite (`cargo test -p sparrowdb --no-fail-fast`) was still running in the background when this PR was opened; will report results in a follow-up comment if anything unexpected turns up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parameter keys beginning with `$` now return a clear validation error instructing you to use the bare parameter name.
  * Valid parameter keys continue to work, while unused or misspelled keys retain their existing behavior.
  * Missing parameters continue to fail safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->