### PR TITLE
fix(npm): reconcile index.d.ts with its napi generator; de-export PLATFORM_BINARIES

### DIFF
--- a/crates/sparrowdb-node/src/lib.rs
+++ b/crates/sparrowdb-node/src/lib.rs
@@ -334,8 +334,8 @@ pub struct VectorIndexLoadFailure {
     /// not authoritative and not machine-parseable.
     pub reason: String,
     /// `"live_unserviceable"` or `"quarantined_no_live_index"` — see the
-    /// struct doc comment. Check this before deciding whether a vector write
-    /// against this `(label, prop)` would currently succeed or throw.
+    /// interface doc comment. Check this before deciding whether a vector
+    /// write against this `(label, prop)` would currently succeed or throw.
     pub kind: String,
 }
 
@@ -469,7 +469,16 @@ impl SparrowDB {
     /// Open (or create) a SparrowDB database at `path`.
     ///
     /// Throws if the path cannot be created or the database files are corrupt.
-    #[napi(factory)]
+    //
+    // `ts_return_type` below is required, not decorative: napi-derive-backend
+    // derives a factory method's TS return type from the raw Rust struct
+    // ident via `to_case(Case::Pascal)`, which does not consult this struct's
+    // `#[napi(js_name = "SparrowDB")]` and instead treats "DB" as an all-caps
+    // acronym word, re-casing it to "Db". Without the override below, a
+    // regenerated `index.d.ts` reads `static open(...): SparrowDb` — the
+    // exact factory-casing bug fixed by hand in #405. `js_name` alone only
+    // controls the `export declare class SparrowDB` line.
+    #[napi(factory, ts_return_type = "SparrowDB")]
     pub fn open(path: String) -> napi::Result<Self> {
         let db = ::sparrowdb::GraphDb::open(std::path::Path::new(&path)).map_err(to_napi)?;
         Ok(SparrowDB { inner: db })
@@ -622,6 +631,12 @@ impl SparrowDB {
     /// embeddings must be passed as parameters.  The engine surface
     /// (`GraphDb::execute_with_params`) has supported this since SPA-218; this
     /// binding simply exposes it to JS callers.
+    ///
+    /// **HNSW note (as of 0.1.23):** when the target property has a vector
+    /// index, `SET n.prop = $vec` now also writes the vector into the HNSW
+    /// index. Previously the property was stored but the HNSW file was not
+    /// updated — a silent data-loss bug surfaced by KMSmcp channel message
+    /// #202 (#410).
     ///
     /// **`CREATE` support (SPA-480):** standalone `CREATE` and
     /// `MATCH ... CREATE` — including edge properties — now accept `$param`

--- a/npm/sparrowdb/index.d.ts
+++ b/npm/sparrowdb/index.d.ts
@@ -122,8 +122,8 @@ export interface VectorIndexLoadFailure {
   reason: string
   /**
    * `"live_unserviceable"` or `"quarantined_no_live_index"` — see the
-   * interface doc comment. Check this before deciding whether a vector write
-   * against this `(label, prop)` would currently succeed or throw.
+   * interface doc comment. Check this before deciding whether a vector
+   * write against this `(label, prop)` would currently succeed or throw.
    */
   kind: string
 }
@@ -140,36 +140,40 @@ export interface VectorIndexLoadFailure {
  * }
  * ```
  *
- * Not to be confused with the instance method `db.vectorIndexHealth(label,
+ * Not to be confused with the **instance** method `db.vectorIndexHealth(label,
  * prop)`, which returns per-index vector reachability counts. This type is
- * about which index FILES are in service; that one is about how many vectors
+ * about which index *files* are in service; that one is about how many vectors
  * inside one healthy file a search can reach.
  *
- * Three fields, because a report has three things to say (#456). Before #456
- * this was a bare `VectorIndexLoadFailure[]`, and `[]` meant all three at once:
+ * # Three fields, because a report has three things to say (#456)
  *
- * - `unscannable` — `[]` also meant "I could not read the directory". A
+ * Before #456 this was a bare `VectorIndexLoadFailure[]`, and `[]` meant three
+ * different things at once. Each collapse cost something:
+ *
+ * - **`unscannable`** — `[]` also meant "I could not read the directory". A
  *   `chmod 000` on `vector_indexes/`, a bad mount during a poll, or a
  *   misconfigured service account produced output byte-identical to a healthy
- *   store, so a monitor could not tell green from blind. When this is non-null,
- *   `active` and `historical` are empty FOR LACK OF OBSERVATION, not lack of
- *   damage. Check it before concluding anything.
- * - `historical` — a quarantine artifact whose `(label, prop)` is served again
- *   by a working index. It used to stay in the one array forever, because #442
- *   never cleans artifacts up, so a repaired store could go green to red and
- *   never back. An alert that will not clear after the problem is fixed gets
- *   muted, and a muted alert is worse than none. Reported rather than
- *   suppressed because #442 records no reason at quarantine time and writes no
- *   sidecar: the artifact file is the only surviving evidence of the incident.
- * - `healthy` — computed natively as `!unscannable && active.length === 0`, so
- *   a caller cannot get the composition wrong. An unscannable report is NOT
- *   healthy: not knowing is not the same as being fine.
+ *   store. A monitor could not tell green from blind. When this is non-null,
+ *   `active` and `historical` are empty *for lack of observation, not lack of
+ *   damage* — check it before concluding anything.
+ * - **`historical`** — a quarantine artifact whose `(label, prop)` is served
+ *   again by a working index. It used to stay in the one array forever,
+ *   because #442 never cleans artifacts up, so a store that had been repaired
+ *   could go green → red and never back. An alert that will not clear after
+ *   the problem is fixed gets muted, and a muted alert is worse than none.
+ *   These are reported rather than suppressed because #442 records no reason
+ *   at quarantine time and writes no sidecar: the artifact file is the only
+ *   surviving evidence the incident happened.
+ * - **`healthy`** — computed in Rust as `unscannable.is_none() &&
+ *   active.is_empty()`, so a JS caller cannot get the composition wrong. Note
+ *   that an unscannable report is **not** healthy: not knowing is not the same
+ *   as being fine.
  */
 export interface VectorIndexDamageReport {
   /**
-   * Present when `vector_indexes/` could not be listed; the string says why.
-   * ABSENT (not null) when the scan succeeded — the native layer omits the
-   * property rather than setting it, so test it for truthiness.
+   * Set when `vector_indexes/` could not be listed; the string says why.
+   * `None` becomes an **absent** JS property rather than `null`, so JS
+   * callers should test it for truthiness.
    *
    * While set, `active` and `historical` are empty because nothing was
    * observed — not because nothing is wrong.
@@ -185,7 +189,10 @@ export interface VectorIndexDamageReport {
    * Forensics for an operator; a monitor ignores this.
    */
   historical: Array<VectorIndexLoadFailure>
-  /** `!unscannable && active.length === 0`. Computed natively. */
+  /**
+   * `!unscannable && active.length === 0`. Computed in Rust so a JS
+   * caller cannot get the composition wrong.
+   */
   healthy: boolean
 }
 /**
@@ -210,8 +217,8 @@ export declare class SparrowDB {
    */
   static open(path: string): SparrowDB
   /**
-   * Deep damage report for the vector indexes at `path`: reads and validates
-   * every live index file.
+   * Deep damage report for the vector indexes at `path`: reads and
+   * validates every live index file.
    *
    * **Static**, and deliberately so: the database this diagnoses is usually
    * one that will not open. `open` fails with a `Corruption` error when a
@@ -223,11 +230,11 @@ export declare class SparrowDB {
    * the diagnostic itself into a second failure to diagnose. A directory it
    * cannot list is reported in `unscannable` rather than raised.
    *
-   * **Not for a poll loop.** This deserialises every HEALTHY index it finds —
-   * for an 8 MB `Knowledge.embedding` index polled hourly, 8 MB of I/O and a
-   * complete HNSW graph rebuild an hour, spent confirming that nothing is
-   * wrong. Use `SparrowDB.vectorIndexDamageScan` for monitoring and this for
-   * "why will my database not open?".
+   * **Not for a poll loop.** This deserialises every *healthy* index it
+   * finds — for an 8 MB `Knowledge.embedding` index polled hourly, 8 MB of
+   * I/O and a complete HNSW graph rebuild an hour, spent confirming that
+   * nothing is wrong. Use `SparrowDB.vectorIndexDamageScan` for monitoring
+   * and this for "why will my database not open?".
    *
    * Damage is reported in both places it can live:
    *
@@ -254,8 +261,8 @@ export declare class SparrowDB {
    *
    * **Read-only since #456.** It used to quarantine the live entries it
    * probed, so a second call answered differently from the first and the
-   * `path` it reported had already been renamed away by the time you read it.
-   * Both are fixed: run it as often as you like, and `path` resolves.
+   * `path` it reported had already been renamed away by the time you read
+   * it. Both are fixed: run it as often as you like, and `path` resolves.
    *
    * ```typescript
    * const report = SparrowDB.vectorIndexLoadFailures('/path/to/my.db')
@@ -269,25 +276,25 @@ export declare class SparrowDB {
    * Cheap damage report for the vector indexes at `path`: directory metadata
    * only, no index file contents read.
    *
-   * **This is the call for a monitor.** Its cost is one directory listing plus
-   * one `stat` per live index, independent of index size, so it is safe at any
-   * poll frequency. `SparrowDB.vectorIndexLoadFailures` is the deep
+   * **This is the call for a monitor.** Its cost is one directory listing
+   * plus one `stat` per live index, independent of index size, so it is safe
+   * at any poll frequency. `SparrowDB.vectorIndexLoadFailures` is the deep
    * counterpart and deserialises every healthy index on every call.
    *
    * **Static** and **never throws**, for the same reasons.
    *
    * What it sees: quarantine artifacts, split into `active` and `historical`
-   * by whether a live index now serves the pair, and live entries that do not
-   * resolve. What it does not: whether a live index still DECODES.
+   * by whether a live index now serves the pair, and live entries that do
+   * not resolve. What it does not: whether a live index still *decodes*.
    *
-   * That is sound for a RUNNING store, and the reason is structural rather
-   * than convenient: `open` loads and validates every live index and refuses
-   * to start when one fails, so a store that is up has had every live file
-   * verified already. The question a monitor is left asking is "did we
-   * quarantine something and lose vectors?", which is exactly what this
-   * answers without reading a payload byte.
+   * That is sound for a **running** store, and the reason is structural
+   * rather than convenient: `open` loads and validates every live index and
+   * refuses to start when one fails, so a store that is up has had every
+   * live file verified already. The question a monitor is left asking is
+   * "did we quarantine something and lose vectors?", which is exactly what
+   * this answers without reading a payload byte.
    *
-   * It cannot tell you why a database refuses to OPEN. Use
+   * It cannot tell you why a database refuses to *open*. Use
    * `SparrowDB.vectorIndexLoadFailures` for that.
    *
    * Not to be confused with the instance method `db.vectorIndexHealth(label,
@@ -331,21 +338,17 @@ export declare class SparrowDB {
    * (`GraphDb::execute_with_params`) has supported this since SPA-218; this
    * binding simply exposes it to JS callers.
    *
-   * **HNSW note (as of 0.1.23):** When the target property has a vector index,
-   * `SET n.prop = $vec` now ALSO writes the vector into the HNSW index.
-   * Previously the property was stored but the HNSW file was not updated —
-   * a silent data-loss bug surfaced by KMSmcp channel message #202.
+   * **HNSW note (as of 0.1.23):** when the target property has a vector
+   * index, `SET n.prop = $vec` now also writes the vector into the HNSW
+   * index. Previously the property was stored but the HNSW file was not
+   * updated — a silent data-loss bug surfaced by KMSmcp channel message
+   * #202 (#410).
    *
-   * **`CREATE` support (SPA-480):** standalone `CREATE (:Label {prop: $p})`
-   * and `MATCH ... CREATE` (including edge properties, e.g.
-   * `CREATE (a)-[:R {weight: $w}]->(b)`) now accept `$param` values. This
-   * closes the last gap in the parameterized-query story: building a
-   * `CREATE` from untrusted input via `executeWithParams` no longer
-   * requires string interpolation, so a value like `'", role: "admin'` is
-   * stored as a literal property value instead of being able to inject
-   * Cypher syntax. Previously these statements threw
-   * `"parameterized MATCH...CREATE and standalone CREATE are not yet
-   * supported"`.
+   * **`CREATE` support (SPA-480):** standalone `CREATE` and
+   * `MATCH ... CREATE` — including edge properties — now accept `$param`
+   * values, closing the last gap in the parameterized-query story: a
+   * `CREATE` built from untrusted input no longer needs string
+   * interpolation to bind a runtime value.
    *
    * ```typescript
    * const emb = Array.from(new Float32Array(768))  // your model output
@@ -391,7 +394,8 @@ export declare class SparrowDB {
    */
   createVectorIndex(label: string, property: string, dimensions: number, similarity?: string | undefined | null): void
   /**
-   * Directly insert a vector into the HNSW index for an existing node.
+   * Directly insert (or replace) a vector in the HNSW index for an existing
+   * node.
    *
    * This is the explicit backfill API requested by KMSmcp (ch #202).  It is
    * useful when nodes were created without an inline embedding and you want to
@@ -402,6 +406,30 @@ export declare class SparrowDB {
    * - `node_id`  — the **user-facing** `id` property value (string), not the
    *                internal u64 slot number.
    * - `vector`   — Float32Array of `dimensions` elements.
+   *
+   * Calling it twice for the same node now *replaces* the stored vector
+   * (issue #441).  Before that fix the second call was a silent no-op, so a
+   * re-embedding pass could report success while changing nothing.
+   *
+   * # The node property is written too
+   *
+   * Before issue #441 this method wrote only the HNSW file, making that file
+   * the sole copy of every embedding it stored: not rebuildable from the
+   * column store, not covered by the WAL, not recoverable to a point in
+   * time.  A backfill of 1721 vectors was lost that way.
+   *
+   * It now also writes `n.<property>` as
+   * `sparrowdb:vec32:<little-endian f32 hex>` inside the same write
+   * transaction as the index update, so the embedding survives in the
+   * checkpointed column store and the index can be rebuilt from it.  The
+   * storage layer has no vector type yet — its `Value` is `Int64` / `Bytes`
+   * / `Float` — so the value reads back as that text form rather than as an
+   * array.  (For comparison, the Cypher path `SET n.embedding = $vec` still
+   * stores an `Int64(0)` placeholder; that is tracked separately.)
+   *
+   * Vectors above ~8189 dimensions cannot be encoded within the overflow
+   * heap's 65535-byte value limit; the call is refused rather than leaving
+   * an unrecoverable index entry.
    *
    * Throws `RangeError` if no vector index exists for `(label, property)`.
    * Throws `TypeError`  if `vector.length` does not match the index dimensions.
@@ -528,8 +556,12 @@ export declare class SparrowDB {
    * Hybrid vector + full-text search using Reciprocal Rank Fusion (RRF).
    *
    * Runs HNSW vector search and BM25 full-text search independently, then
-   * fuses the ranked lists.  Missing indexes are treated as empty — so if
-   * only a vector index exists the call degrades gracefully to vector-only.
+   * fuses the ranked lists.  A genuinely *unconfigured* index is treated as
+   * empty — so if only a vector index exists the call degrades gracefully
+   * to vector-only.  A *present but damaged* FTS index instead rejects the
+   * call (issue #462): the two are distinguishable (an absent file opens
+   * fine as an empty index; only a broken one errs), and collapsing them
+   * would silently mask index corruption as a normal vector-only result.
    *
    * `label`           — node label (e.g. `"Memory"`)
    * `text_property`   — property holding the text content (for BM25)

--- a/npm/sparrowdb/index.js
+++ b/npm/sparrowdb/index.js
@@ -2,17 +2,7 @@
 
 const { existsSync } = require('fs')
 const { join } = require('path')
-
-// There are no separate `@sparrowdb/<platform>` packages — the prebuilt
-// binaries for every platform this package supports are bundled directly
-// in this tarball (see .github/workflows/release.yml). Map platform+arch
-// to the bundled filename so we only ever try to load a binary that was
-// actually built for the running platform. See README for the supported
-// platform list and why musl/Alpine isn't one of them.
-const PLATFORM_BINARIES = {
-  'linux-x64': 'sparrowdb.linux-x64-gnu.node',
-  'darwin-arm64': 'sparrowdb.darwin-arm64.node',
-}
+const { PLATFORM_BINARIES } = require('./platforms')
 
 // A file existing under an expected name is not proof it's a valid,
 // loadable binary for this platform — issue #481 shipped for a year because
@@ -99,13 +89,3 @@ module.exports = native
 module.exports.SparrowDB = native.SparrowDB
 module.exports.ReadTx = native.ReadTx
 module.exports.WriteTx = native.WriteTx
-
-// Exposed so test/platform-resolution.test.js can look up the bundled
-// filename for the running platform+arch instead of re-deriving the naming
-// convention itself — a test that keeps its own copy of this rule is a
-// second place for it to drift from index.js (see issue #481, where a test
-// doing exactly that passed on darwin-arm64 by coincidence and failed on
-// linux-x64 because it reconstructed "sparrowdb.linux-x64.node" instead of
-// the real "sparrowdb.linux-x64-gnu.node"). Not part of the documented
-// public API.
-module.exports.PLATFORM_BINARIES = PLATFORM_BINARIES

--- a/npm/sparrowdb/package.json
+++ b/npm/sparrowdb/package.json
@@ -13,6 +13,7 @@
   },
   "files": [
     "index.js",
+    "platforms.js",
     "index.d.ts",
     "*.node"
   ],

--- a/npm/sparrowdb/platforms.js
+++ b/npm/sparrowdb/platforms.js
@@ -1,0 +1,18 @@
+'use strict'
+
+// There are no separate `@sparrowdb/<platform>` packages — the prebuilt
+// binaries for every platform this package supports are bundled directly
+// in this tarball (see .github/workflows/release.yml). Map platform+arch
+// to the bundled filename so we only ever try to load a binary that was
+// actually built for the running platform. See README for the supported
+// platform list and why musl/Alpine isn't one of them.
+//
+// This lives in its own module (rather than being exported from index.js)
+// so test/platform-resolution.test.js can read the real naming convention
+// without putting it on the package's public API. See issue #518.
+const PLATFORM_BINARIES = {
+  'linux-x64': 'sparrowdb.linux-x64-gnu.node',
+  'darwin-arm64': 'sparrowdb.darwin-arm64.node',
+}
+
+module.exports = { PLATFORM_BINARIES }

--- a/npm/sparrowdb/test/platform-resolution.test.js
+++ b/npm/sparrowdb/test/platform-resolution.test.js
@@ -29,14 +29,18 @@ const { spawnSync } = require('node:child_process')
 
 const PACKAGE_DIR = path.join(__dirname, '..')
 const INDEX_JS = path.join(PACKAGE_DIR, 'index.js')
+const PLATFORMS_JS = path.join(PACKAGE_DIR, 'platforms.js')
 
-// Read the real filename convention from index.js rather than reconstructing
-// it here. A hand-copied convention is a second place for it to drift from
-// the loader — which is exactly how #481 shipped: index.js looks for
-// "sparrowdb.linux-x64-gnu.node" (the `-gnu` suffix matters), and an earlier
-// version of this file built "sparrowdb.linux-x64.node" by concatenation,
-// so it passed on darwin-arm64 by coincidence and failed on Linux CI.
-const { PLATFORM_BINARIES } = require(INDEX_JS)
+// Read the real filename convention from platforms.js rather than
+// reconstructing it here. A hand-copied convention is a second place for it
+// to drift from the loader — which is exactly how #481 shipped: index.js
+// looks for "sparrowdb.linux-x64-gnu.node" (the `-gnu` suffix matters), and
+// an earlier version of this file built "sparrowdb.linux-x64.node" by
+// concatenation, so it passed on darwin-arm64 by coincidence and failed on
+// Linux CI. (platforms.js was split out of index.js in #518 so this map
+// isn't part of the package's public API — see makeIsolatedPackageDir
+// below, which now needs to copy it alongside index.js.)
+const { PLATFORM_BINARIES } = require(PLATFORMS_JS)
 
 // Locate a real, loadable compiled binary for the machine running this
 // suite — the same places index.js's own dev fallback (steps 2/3) looks,
@@ -66,6 +70,9 @@ function findRealBinary() {
 function makeIsolatedPackageDir() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sparrowdb-pkgtest-'))
   fs.copyFileSync(INDEX_JS, path.join(dir, 'index.js'))
+  // index.js requires('./platforms') — the isolated copy needs it too,
+  // same as npm publish bundles it alongside index.js in the real tarball.
+  fs.copyFileSync(PLATFORMS_JS, path.join(dir, 'platforms.js'))
   return dir
 }
 


### PR DESCRIPTION
## Summary

Fixes two npm-packaging issues, both scoped to `npm/sparrowdb/` and `crates/sparrowdb-node/src/lib.rs`.

closes #513, closes #518

### #513 — index.d.ts had drifted from its napi-rs generator

Ran the actual regen procedure (`napi build --release --platform --dts <scratch> --js false --cargo-cwd ../../crates/sparrowdb-node --cargo-name sparrowdb_node`) to a scratch path and diffed against the checked-in `index.d.ts`. Every difference fell into one of three buckets:

1. **A real napi-derive-backend bug**, not a hand-fix gone stale: `static open(path: string): SparrowDb` (wrong casing). `napi-derive-backend`'s `gen_ts_func_ret()` derives a `#[napi(factory)]` method's TS return type from the raw Rust struct ident via `to_case(Case::Pascal)` — it never consults `#[napi(js_name = "SparrowDB")]`, so "DB" gets re-cased to "Db" as an all-caps-acronym word. The #405 hand-fix patched the *artifact* but a regen would silently reintroduce the bug. Fixed at the source with `#[napi(factory, ts_return_type = "SparrowDB")]`, which overrides the derived return type outright (confirmed against `napi-derive-2.16.13`'s attribute parser — `ts_return_type` is a real, valid fn-level override).
2. **Artifact ahead of source**: the "HNSW note (as of 0.1.23)" paragraph on `executeWithParams` existed only in the checked-in `.d.ts`. Traced via `git log -S` — it was hand-added to `index.d.ts` in #410 despite that commit's message claiming a regen; it was never in `lib.rs`. Moved into the Rust doc comment so it survives a regen. Also synced "struct doc comment" → "interface doc comment" (correct for TS-facing prose) from the artifact into `lib.rs`.
3. **Source ahead of artifact**: doc-comment prose for #441 (`addToVectorIndex` now replaces rather than no-ops, and writes the node property as a recovery path) and #462 (`hybridSearch` distinguishes a damaged FTS index from a merely-unconfigured one) existed in `lib.rs` but had never been synced into the checked-in `.d.ts`. Took the regenerated text.

Result: `tsc -p tsconfig.json` passes. `kind` (hand-patched into `VectorIndexLoadFailure` in #520) is confirmed present and now reproduced by its own `lib.rs` doc comment — no longer at risk from a future regen.

### #518 — PLATFORM_BINARIES exported on the public API purely for test access

`npm/sparrowdb/index.js` exported the platform→filename map so `test/platform-resolution.test.js` could read it instead of re-deriving the naming convention (the re-derivation bug is what broke #517's first CI run: `sparrowdb.linux-x64.node` vs the real `sparrowdb.linux-x64-gnu.node`). Moved the map to `npm/sparrowdb/platforms.js`, required by both `index.js` and the test — same single source, zero public surface. Added to `package.json`'s `files` array so it ships in the tarball, and `test/platform-resolution.test.js`'s `makeIsolatedPackageDir()` now copies it alongside `index.js`.

## Verification

- **Regen diff**: full diff shown above, every hunk accounted for.
- **`tsc -p tsconfig.json`**: passes clean.
- **`kind` field survival**: confirmed present in regenerated output at the correct location, `grep -c "SparrowDb\b"` (bare, wrong casing) = 0, `SparrowDB\b` = 18.
- **`npm test`** (`node --test test/*.test.js`): 50/50 pass, 0 failures — using a binary built fresh in this task's own isolated `CARGO_TARGET_DIR=/Volumes/Dev/target-npm` (not the shared/contaminated cache). An earlier run against a borrowed binary from the shared cache showed 3 unrelated failures in `integration.test.js` (vector-index/param tests); those are not present with a clean build and were never touched by this PR.
- **`npm pack --dry-run`**: 4 files — `index.js`, `index.d.ts`, `package.json`, `platforms.js` (no stray `.node`, confirmed after removing a leftover local build artifact from my own regen runs).
- **`platforms.js` not picked up as a test**: `npm test` globs `test/*.test.js`; `platforms.js` lives at package root.
- **Unsupported-platform path forced manually** (`process.platform='win32'`, `arch='x64'`): throws a catchable `Error` (not a bare `MODULE_NOT_FOUND`) with the clear "no prebuilt native module" message.
- **Regression-detector still works**: proved the naive-reconstruction bug pattern from #481/#517 (`` `sparrowdb.${platform}-${arch}.node` ``) mismatches on `linux-x64` (`sparrowdb.linux-x64.node` vs real `sparrowdb.linux-x64-gnu.node`) while coincidentally matching on `darwin-arm64` — exactly the original failure mode. Since both `index.js` and the test now `require()` the identical `platforms.js`, this class of drift is structurally impossible, not just avoided by convention.
- **`cargo check -p sparrowdb-node`**, **`cargo clippy -p sparrowdb-node --no-deps`**, **`cargo fmt --check`**: all clean.
- **Prettier**: repo has no `.prettierrc`, so `prettier --write` would reformat to double-quotes/semicolons against the existing single-quote/no-semi style (same issue #517 hit). Left unformatted; only the functional diff was hand-applied.

### Could not verify

- Did not test on an actual `linux-x64` machine/CI — verification of the `-gnu` suffix correctness relies on reading `platforms.js`'s value and CI's own pass/fail, not a local linux run (this machine is darwin-arm64).
- Did not run the full `cargo test --workspace` suite (excluded per repo `CLAUDE.md`: `sparrowdb-ruby` doesn't compile locally) — only `cargo check`/`clippy`/`fmt` on the touched crate, since the scope here is npm packaging, not engine behavior.
- Have not run this against a real `npm publish --dry-run` with 2FA/registry auth — no publish was attempted per instructions.
- Did not add the CI "regenerate-and-assert-no-diff" check that issue #513 calls "the real deliverable" for preventing *future* drift — out of scope for what was asked (regen-and-reconcile + verification), flagging as a natural follow-up.

**Not merged** — left for review per instructions.