### PR TITLE
fix(execution): route every non-PropAccess RETURN expr to the eval path (#515)

### DIFF
--- a/crates/sparrowdb-execution/src/engine/mod.rs
+++ b/crates/sparrowdb-execution/src/engine/mod.rs
@@ -2661,13 +2661,13 @@ fn eval_expr(expr: &Expr, vals: &HashMap<String, Value>) -> Value {
 /// whatever followed, which only happened to work when the alias equalled
 /// the property name.
 ///
-/// Every call site only reaches `project_row` once `id(var)`, `labels(var)`,
-/// bare `var`, and every other non-aggregate `FnCall` have already been
-/// routed to the eval path (`needs_node_ref_in_return` /
-/// `expr_needs_eval_path`, checked by every caller before choosing between
-/// this fast path and the eval path). So every item here is guaranteed to be
-/// a `PropAccess`; the `_ => Value::Null` arm is a defensive fallback, not a
-/// reachable case.
+/// Every call site checks `needs_node_ref_in_return` first and only reaches
+/// `project_row` when every RETURN item is `expr_projectable_by_row` — which
+/// (#515) is true only for `PropAccess`. So every item here is guaranteed to
+/// be a `PropAccess` on some variable; the `_ => Value::Null` arm exists only
+/// for a `PropAccess` on a variable other than `var_name` (a different,
+/// pre-existing gap tracked separately — this function is only ever invoked
+/// with a single scanned variable in scope), not for any other `Expr` shape.
 fn project_row(
     props: &[(u32, u64)],
     items: &[ReturnItem],
@@ -3094,64 +3094,46 @@ pub(crate) fn has_aggregate_in_return(items: &[ReturnItem]) -> bool {
     items.iter().any(|item| is_aggregate_expr(&item.expr))
 }
 
-/// Returns `true` if any RETURN item requires a `NodeRef` / `EdgeRef` value to
-/// be present in the row map in order to evaluate correctly.
+/// Returns `true` iff `expr` is a shape the fast `project_row` /
+/// `project_hop_row` / `project_three_var_row` column-lookup paths can
+/// actually resolve.
 ///
-/// This covers:
-/// - `id(var)` — a scalar function that receives the whole node reference.
-/// - Bare `var` — projecting a node variable as a property map (SPA-213).
+/// This is deliberately an **allow-list**, not a deny-list (#515). Every one
+/// of those fast paths has exactly one positive case in its match — a
+/// `PropAccess` on the scanned variable, looked up by hashed column id — and
+/// falls through to `_ => Value::Null` for everything else. So a variant is
+/// only safe to route through the fast path when it *is* that one shape;
+/// declaring anything else "safe" requires proving it has an equivalent fast
+/// lookup, which none of the other `Expr` variants do.
 ///
-/// When this returns `true`, the scan must use the eval path (which inserts
-/// `Value::Map` / `Value::NodeRef` under the variable key) instead of the fast
-/// `project_row` path (which only stores individual property columns).
-fn needs_node_ref_in_return(items: &[ReturnItem]) -> bool {
-    items.iter().any(|item| {
-        matches!(&item.expr, Expr::FnCall { name, .. } if name.to_lowercase() == "id")
-            || matches!(&item.expr, Expr::Var(_))
-            || expr_needs_graph(&item.expr)
-            || expr_needs_eval_path(&item.expr)
-    })
+/// Before this, the routing decision (`needs_node_ref_in_return`) was a
+/// deny-list: it OR'd together checks that each recursed looking for one
+/// specific thing it knew `project_row` couldn't handle (a scalar `FnCall`,
+/// a graph-only construct, `id(var)`, a bare `var`) and defaulted `_ =>
+/// false` for anything none of them recognized. A `BinOp`, `Literal`,
+/// `List`, or `InList` built purely from literals and `PropAccess` tripped
+/// none of those checks, so it silently took the fast path and hit
+/// `project_row`'s `_ => Value::Null` fallback — a wrong answer with no
+/// error. An allow-list can't repeat that mistake: a new `Expr` variant is
+/// unprojectable by construction until someone teaches `project_row` to
+/// resolve it and extends this match to match.
+fn expr_projectable_by_row(expr: &Expr) -> bool {
+    matches!(expr, Expr::PropAccess { .. })
 }
 
-/// Returns `true` when the expression contains a scalar `FnCall` that cannot
-/// be resolved by the fast `project_row` column-name lookup.
+/// Returns `true` if any RETURN item cannot be resolved by the fast
+/// `project_row` column-lookup path and must instead go through the eval
+/// path, which builds a full row map (inserting `Value::Map` /
+/// `Value::NodeRef` under the variable key, plus every property under a
+/// hashed-column key) and evaluates each item against it via `eval_expr` /
+/// `eval_expr_graph`.
 ///
-/// `project_row` maps column names like `"n.name"` directly to stored property
-/// values.  Any function call such as `coalesce(n.missing, n.name)`,
-/// `toUpper(n.name)`, or `size(n.name)` produces a column name like
-/// `"coalesce(n.missing, n.name)"` which has no matching stored property.
-/// Those expressions must be evaluated via `eval_expr` on the full row map.
-///
-/// Aggregate functions (`count`, `sum`, etc.) are already handled via the
-/// `use_agg` flag; we exclude them here to avoid double-counting.
-fn expr_needs_eval_path(expr: &Expr) -> bool {
-    match expr {
-        Expr::FnCall { name, args } => {
-            let name_lc = name.to_lowercase();
-            // Aggregates are handled separately by use_agg.
-            if matches!(
-                name_lc.as_str(),
-                "count" | "sum" | "avg" | "min" | "max" | "collect"
-            ) {
-                return false;
-            }
-            // Any other FnCall (coalesce, toUpper, size, labels, type, id, etc.)
-            // needs the eval path.  We include id/labels/type here even though
-            // they are special-cased in eval_expr, because the fast project_row
-            // path cannot handle them at all.
-            let _ = args; // args not needed for this check
-            true
-        }
-        // Recurse into compound expressions that may contain FnCalls.
-        Expr::BinOp { left, right, .. } => {
-            expr_needs_eval_path(left) || expr_needs_eval_path(right)
-        }
-        Expr::And(l, r) | Expr::Or(l, r) => expr_needs_eval_path(l) || expr_needs_eval_path(r),
-        Expr::Not(inner) | Expr::IsNull(inner) | Expr::IsNotNull(inner) => {
-            expr_needs_eval_path(inner)
-        }
-        _ => false,
-    }
+/// See [`expr_projectable_by_row`] for why this is an allow-list rather than
+/// a list of reasons to bail out.
+fn needs_node_ref_in_return(items: &[ReturnItem]) -> bool {
+    items
+        .iter()
+        .any(|item| !expr_projectable_by_row(&item.expr))
 }
 
 /// Collect the variable names that appear as bare `Expr::Var` in a RETURN clause (SPA-213).

--- a/crates/sparrowdb/tests/regression_515_return_expr_projection.rs
+++ b/crates/sparrowdb/tests/regression_515_return_expr_projection.rs
@@ -1,0 +1,283 @@
+//! Regression tests for #515 — every non-`PropAccess` expression in a
+//! RETURN following a MATCH silently returned `Null` instead of its value.
+//!
+//! # Root cause
+//!
+//! The routing decision between the fast `project_row` column-lookup path
+//! and the row-map eval path (`needs_node_ref_in_return`, `engine/mod.rs`)
+//! was a deny-list: it OR'd together checks that each recursed looking for
+//! one specific reason to bail out (a scalar `FnCall`, a graph-only
+//! construct, `id(var)`, a bare `var`) and defaulted `_ => false` for
+//! anything none of them recognized. A `BinOp` (`n.age + 1`), a bare
+//! `Literal` (`42`), a `List` (`[1, 2]`), or an `InList` (`n.age IN
+//! [10, 20]`) built purely from literals and `PropAccess` tripped none of
+//! those checks, so it silently took the fast `project_row` path — which
+//! only ever positively handles `PropAccess` and falls through to
+//! `_ => Value::Null` for everything else. The result was a wrong answer
+//! with no error, not a crash: the worst case is a *mixed* row where one
+//! column resolves correctly (a `PropAccess`) and the next is silently
+//! `Null` (anything else), which looks like real data.
+//!
+//! # The fix
+//!
+//! `needs_node_ref_in_return` is now built on an allow-list,
+//! `expr_projectable_by_row`, whose only positive case is `PropAccess` —
+//! matching the one positive case `project_row` itself handles. Anything
+//! else routes to the eval path by construction, so a future `Expr` variant
+//! cannot silently repeat this bug.
+//!
+//! Every expected value below is derived by hand from the fixture, never
+//! captured from program output (see repo `feedback_derive_expected_from_source`).
+
+use sparrowdb::GraphDb;
+use sparrowdb_execution::Value;
+
+/// One `Item` node: name="a", age=10. A second node, `Item` with name="b",
+/// has no `age` at all — the control for "genuinely null" below.
+fn setup() -> (GraphDb, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    db.execute("CREATE (n:Item {name: 'a', age: 10})")
+        .expect("CREATE a");
+    db.execute("CREATE (n:Item {name: 'b'})")
+        .expect("CREATE b (no age)");
+    (db, dir)
+}
+
+/// Query against just the `age: 10` node so every test below has one row.
+fn setup_single() -> (GraphDb, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    db.execute("CREATE (n:Item {name: 'a', age: 10})")
+        .expect("CREATE a");
+    (db, dir)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Bare literals (issue's original repro table)
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn bare_int_literal_after_match() {
+    let (db, _dir) = setup_single();
+    let r = db.execute("MATCH (n:Item) RETURN 42").unwrap();
+    assert_eq!(r.rows, vec![vec![Value::Int64(42)]], "actual: {:?}", r.rows);
+}
+
+#[test]
+fn bare_string_literal_after_match() {
+    let (db, _dir) = setup_single();
+    let r = db.execute("MATCH (n:Item) RETURN 'hello'").unwrap();
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::String("hello".into())]],
+        "actual: {:?}",
+        r.rows
+    );
+}
+
+#[test]
+fn bare_bool_literal_after_match() {
+    let (db, _dir) = setup_single();
+    let r = db.execute("MATCH (n:Item) RETURN true").unwrap();
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::Bool(true)]],
+        "actual: {:?}",
+        r.rows
+    );
+}
+
+#[test]
+fn aliased_literal_after_match() {
+    let (db, _dir) = setup_single();
+    let r = db.execute("MATCH (n:Item) RETURN 42 AS answer").unwrap();
+    assert_eq!(r.columns, vec!["answer"]);
+    assert_eq!(r.rows, vec![vec![Value::Int64(42)]], "actual: {:?}", r.rows);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Arithmetic / comparison / IS NULL / list construction / IN — the
+// re-scoped issue's actual claim (every non-PropAccess shape, not just
+// bare literals).
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn arithmetic_on_property_after_match() {
+    let (db, _dir) = setup_single();
+    let r = db.execute("MATCH (n:Item) RETURN n.age + 1").unwrap();
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::Int64(11)]],
+        "n.age (10) + 1 = 11; actual: {:?}",
+        r.rows
+    );
+}
+
+#[test]
+fn comparison_on_property_after_match() {
+    let (db, _dir) = setup_single();
+    let r = db.execute("MATCH (n:Item) RETURN n.age > 5").unwrap();
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::Bool(true)]],
+        "10 > 5; actual: {:?}",
+        r.rows
+    );
+}
+
+#[test]
+fn is_not_null_on_property_after_match() {
+    let (db, _dir) = setup_single();
+    let r = db
+        .execute("MATCH (n:Item) RETURN n.age IS NOT NULL")
+        .unwrap();
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::Bool(true)]],
+        "n.age is present; actual: {:?}",
+        r.rows
+    );
+}
+
+#[test]
+fn list_literal_after_match() {
+    let (db, _dir) = setup_single();
+    let r = db.execute("MATCH (n:Item) RETURN [1, 2]").unwrap();
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::List(vec![Value::Int64(1), Value::Int64(2)])]],
+        "actual: {:?}",
+        r.rows
+    );
+}
+
+#[test]
+fn in_list_on_property_after_match() {
+    let (db, _dir) = setup_single();
+    let r = db
+        .execute("MATCH (n:Item) RETURN n.age IN [10, 20]")
+        .unwrap();
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::Bool(true)]],
+        "10 is in [10, 20]; actual: {:?}",
+        r.rows
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// The worst case: a mixed row — one correct PropAccess column beside a
+// computed one. Pre-fix, the PropAccess column was right and the computed
+// one silently Null, which reads as real data.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn mixed_prop_and_literal_row() {
+    let (db, _dir) = setup_single();
+    let r = db.execute("MATCH (n:Item) RETURN n.name, 42").unwrap();
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::String("a".into()), Value::Int64(42)]],
+        "actual: {:?}",
+        r.rows
+    );
+}
+
+#[test]
+fn mixed_prop_and_arithmetic_row() {
+    let (db, _dir) = setup_single();
+    let r = db
+        .execute("MATCH (n:Item) RETURN n.name, n.age + 1")
+        .unwrap();
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::String("a".into()), Value::Int64(11)]],
+        "actual: {:?}",
+        r.rows
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Controls: what must NOT change.
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// A genuinely absent property must still project `Null` — the fix must not
+/// turn a real null into an error or a fabricated value. `n.age` here is a
+/// plain `PropAccess`, so it still takes the fast `project_row` path.
+#[test]
+fn genuinely_missing_property_still_projects_null() {
+    let (db, _dir) = setup();
+    let r = db
+        .execute("MATCH (n:Item {name: 'b'}) RETURN n.age")
+        .unwrap();
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::Null]],
+        "Item 'b' has no age property; this Null is real, not a routing failure: {:?}",
+        r.rows
+    );
+}
+
+/// `labels(n)` is a `FnCall` — it already took the eval path before this
+/// fix (#516 removed its `project_row` handling on the proven basis that
+/// every non-aggregate `FnCall` reaches the eval path). Must stay green.
+#[test]
+fn labels_fn_call_still_works() {
+    let (db, _dir) = setup_single();
+    let r = db.execute("MATCH (n:Item) RETURN labels(n)").unwrap();
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::List(vec![Value::String("Item".into())])]],
+        "actual: {:?}",
+        r.rows
+    );
+}
+
+/// `id(n)` must still resolve via the eval path (SPA-196 / #372).
+#[test]
+fn id_fn_call_still_works() {
+    let (db, _dir) = setup_single();
+    let r = db.execute("MATCH (n:Item) RETURN id(n)").unwrap();
+    match &r.rows[0][0] {
+        Value::Int64(_) => {}
+        other => panic!("expected Int64 node id, got {other:?}"),
+    }
+}
+
+/// Aliased `PropAccess` (#444) must still resolve correctly — this is the
+/// fast path's one true positive case.
+#[test]
+fn aliased_prop_access_still_works() {
+    let (db, _dir) = setup_single();
+    let r = db
+        .execute("MATCH (n:Item) RETURN n.name AS itemName")
+        .unwrap();
+    assert_eq!(r.columns, vec!["itemName"]);
+    assert_eq!(
+        r.rows,
+        vec![vec![Value::String("a".into())]],
+        "actual: {:?}",
+        r.rows
+    );
+}
+
+/// A mixed prop + fn-call row (#516's guarantee) must stay green: the
+/// `PropAccess` column and the `FnCall` column must both resolve correctly
+/// via the eval path.
+#[test]
+fn mixed_prop_and_fn_call_row_still_works() {
+    let (db, _dir) = setup_single();
+    let r = db
+        .execute("MATCH (n:Item) RETURN n.name, labels(n)")
+        .unwrap();
+    assert_eq!(
+        r.rows,
+        vec![vec![
+            Value::String("a".into()),
+            Value::List(vec![Value::String("Item".into())])
+        ]],
+        "actual: {:?}",
+        r.rows
+    );
+}


### PR DESCRIPTION
closes #515

## Root cause

The routing decision between the fast `project_row` column-lookup path and the row-map eval path (`needs_node_ref_in_return`, `crates/sparrowdb-execution/src/engine/mod.rs`) was a **deny-list**: it OR'd together checks that each recursed looking for one specific reason to bail out (a scalar `FnCall`, a graph-only construct, `id(var)`, a bare `var`) and defaulted `_ => false` for anything none of them recognized.

A `BinOp` (`n.age + 1`), a bare `Literal` (`42`), a `List` (`[1, 2]`), or an `InList` (`n.age IN [10, 20]`) built purely from literals and `PropAccess` tripped none of those checks, so it silently took the fast `project_row` path — which only ever positively handles `PropAccess` and falls through to `_ => Value::Null` for everything else. Result: a wrong answer with no error. The worst case is a mixed row where one column (a `PropAccess`) resolves correctly and the next (anything else) is silently `Null` — it looks like real data.

## Fix shape: allow-list, not more deny-list entries

I took the preferred/durable route the brief asked for, **not** the narrow one (adding the missing variants to the deny-list). Reason: that's exactly how this bug came to exist — `project_row`, `project_hop_row`, and `project_three_var_row` each have exactly **one** positive case in their match (`PropAccess`) and fall through to `Value::Null` for everything else, so a deny-list has to enumerate every unsafe shape correctly forever, and missed one silently. An allow-list can't repeat that: a new `Expr` variant is unprojectable by construction until someone teaches `project_row` to resolve it and extends the allow-list to match.

Replaced `needs_node_ref_in_return`'s deny-list body with:

```rust
fn expr_projectable_by_row(expr: &Expr) -> bool {
    matches!(expr, Expr::PropAccess { .. })
}

fn needs_node_ref_in_return(items: &[ReturnItem]) -> bool {
    items.iter().any(|item| !expr_projectable_by_row(&item.expr))
}
```

This is the *only* function I changed. `expr_needs_eval_path` (the old deny-list helper) is now dead code and removed. `expr_needs_graph` is untouched — it's still called independently from `aggregate_rows_graph` (`engine/expr.rs`) for a different purpose (graph-vs-plain `eval_expr` dispatch), and its own pinned unit tests (`expr_needs_graph_covers_every_name_in_the_dispatch_table` etc.) still pass unmodified.

## Per-file changes

- `crates/sparrowdb-execution/src/engine/mod.rs` — replaced `needs_node_ref_in_return` + `expr_needs_eval_path` with the allow-list `expr_projectable_by_row` + `needs_node_ref_in_return`. Updated `project_row`'s doc comment accordingly. No other function touched.
- `crates/sparrowdb/tests/regression_515_return_expr_projection.rs` — new regression suite (16 tests).

`needs_node_ref_in_return` is the single shared gate for **every** caller: `scan.rs`'s `use_eval_path` decision (3 call sites), `pipeline_exec.rs`'s `return_requires_row_engine` (which gates all 4 chunked-pipeline eligibility checks: one-hop, two-hop, mutual-neighbors, scan), and `hop.rs`'s two call sites. Fixing the one function fixes every path without touching `scan.rs`, `pipeline_exec.rs`, or `hop.rs` directly.

## Testing — quoted pre-fix output

I temporarily swapped in the pre-fix `mod.rs` (from the parent commit) with the new test file present, confirmed every new failure-shape test failed with the exact reported symptom, then restored the fix. Quoted output:

```
thread 'arithmetic_on_property_after_match' panicked:
assertion `left == right` failed: n.age (10) + 1 = 11; actual: [[Null]]
  left: [[Null]]
 right: [[Int64(11)]]

thread 'bare_string_literal_after_match' panicked:
assertion `left == right` failed: actual: [[Null]]
  left: [[Null]]
 right: [[String("hello")]]

thread 'is_not_null_on_property_after_match' panicked:
assertion `left == right` failed: n.age is present; actual: [[Null]]
  left: [[Null]]
 right: [[Bool(true)]]

thread 'list_literal_after_match' panicked:
assertion `left == right` failed: actual: [[Null]]
  left: [[Null]]
 right: [[List([Int64(1), Int64(2)])]]

thread 'mixed_prop_and_literal_row' panicked:
assertion `left == right` failed: actual: [[String("a"), Null]]
  left: [[String("a"), Null]]
 right: [[String("a"), Int64(42)]]

thread 'mixed_prop_and_arithmetic_row' panicked:
assertion `left == right` failed: actual: [[String("a"), Null]]
  left: [[String("a"), Null]]
 right: [[String("a"), Int64(11)]]
```

11/16 new tests failed pre-fix (the exact 11 non-PropAccess shapes); the other 5 (the controls) already passed pre-fix and still pass post-fix — confirming they're pre-existing guarantees, not accidentally broken by the new test additions.

Post-fix: all 16 pass. Named guard suites also pass unmodified: `regression_444_430_null_projection` (12/12) and `regression_459_hybrid_search_return` (6/6). `expr_needs_graph`'s pinned unit tests (3/3) pass.

### `id(n)` / `labels(n)` / aliased forms — confirmed still green (#516 guarantee)

- `id_fn_call_still_works` — `RETURN id(n)` resolves to the real node id via the eval path.
- `labels_fn_call_still_works` — `RETURN labels(n)` → `[["Item"]]`.
- `aliased_prop_access_still_works` — `RETURN n.name AS itemName` → `[["a"]]` under column `itemName`.
- `mixed_prop_and_fn_call_row_still_works` — `RETURN n.name, labels(n)` → both columns correct in the same row.

I did not touch `project_row`'s `FnCall` handling (there isn't any — #516 already removed it) or `expr_needs_graph`, so the mechanism PR #516 relies on (every non-aggregate `FnCall` reaching the eval path) is untouched and still exercised by these tests.

### Genuinely-null control

`genuinely_missing_property_still_projects_null` — `MATCH (n:Item {name:'b'}) RETURN n.age` where `b` has no `age` property returns `[[Null]]`, not an error. This is a plain `PropAccess`, so it still takes the fast path; the fix doesn't touch this case at all.

## Verification run

- `cargo fmt` — clean (reformatted the new test file only).
- `cargo clippy -p sparrowdb -p sparrowdb-execution --all-targets --keep-going` — zero warnings.
- `cargo check -p sparrowdb` — passes.
- `cargo test -p sparrowdb --no-fail-fast` — full local run in progress in background at PR-open time (repo notes: 60-85 min). All output observed so far (~20+ min in, hundreds of tests across dozens of binaries including `spa_299_phase4_parity`'s mutual-neighbors chunked-path parity tests) is green with zero failures. CI is authoritative per team-lead's direction; I'll report the local run's final result as a follow-up comment once it finishes rather than holding the PR open for it.
- Branch is already based on current `origin/main` (4d15340) — no rebase was needed; no conflicts.

## Blast radius

- Any RETURN item that isn't a plain `PropAccess` now takes the eval path instead of the fast `project_row`/`project_hop_row`/`project_three_var_row` path. This is strictly a correctness fix, not a new capability — those non-PropAccess shapes were already being *attempted* on the fast path and silently returning wrong `Null` answers; they now correctly evaluate.
- Performance: queries whose RETURN previously matched none of the old deny-list's recognized shapes (bare literals, arithmetic, list literals, IN) will now go through the eval path (row-map construction + `eval_expr`) instead of the direct column lookup. This trades a small, previously-invisible perf cost for correctness on a shape that was producing wrong answers. No change for the common case (`RETURN n.prop [AS alias]`), which is still the fast path.
- The four chunked-pipeline eligibility gates (`can_use_one_hop_chunked`, `can_use_two_hop_chunked`, `can_use_mutual_neighbors_chunked`, and `execute_scan_chunked`'s gate) all route through the same `return_requires_row_engine` → `needs_node_ref_in_return` function, so they now correctly decline chunked execution (falling back to the row engine) for the same non-PropAccess shapes, rather than materializing wrong `Null` rows via their own `project_row` calls.

## Could not verify

- I did not run the full CI matrix (GitHub Actions), including the Ruby binding job that doesn't compile locally on this machine per repo `CLAUDE.md`. CI is authoritative per team-lead's direction — deferring to it.
- The full local `cargo test -p sparrowdb --no-fail-fast` run was still in progress when I opened this PR (green through ~20+ minutes and hundreds of tests, including the mutual-neighbors/two-hop chunked parity suites most likely to be affected by the `needs_node_ref_in_return` change). I will post its final pass/fail count as a follow-up PR comment.
- I did not audit every one of the dozens of existing integration test files for a RETURN shape that happens to be non-PropAccess-but-not-FnCall and was previously silently passing *because* it got `Null` on both sides of an assertion (the class of bug called out in `reference_test_passing_because_of_bug.md`). The full local run in progress is the check for this; I have not manually grepped for it.
- I did not investigate the pre-existing, out-of-scope gap noted in `project_row`'s updated doc comment: a `PropAccess` referencing a variable other than the one being scanned (e.g. in the mutual-neighbors chunked path, `RETURN a.name` where only `x` is the scanned var) still silently falls through to `Null` in `project_row`'s `_ => Value::Null` arm. This is a distinct, pre-existing bug not covered by #515's scope (it's a `PropAccess`, which is the allow-list's one positive case — the bug is in *which* variable's props get consulted, not in routing). Flagging it as a separate follow-up rather than fixing it here.
- I did not touch `hop.rs` (owned by another agent per the brief) even though its two call sites (`hop.rs:100`, `hop.rs:2064`) consume the same `needs_node_ref_in_return` function and therefore inherit this fix automatically. I did not independently test hop.rs's own multi-hop RETURN-projection code paths (`project_hop_row`/`project_three_var_row` callers within `hop.rs` itself) for the same non-PropAccess-shape bug beyond what the shared regression suites already exercise indirectly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE