### PR TITLE
fix(db): take exclusive cross-process lock at open() (closes #524)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,26 +18,33 @@
 
 ---
 
-> ## ⚠️ Single-process only — concurrent access can permanently destroy your database
+> ## ⚠️ Only one process may hold a database open at a time
 >
-> **Open a SparrowDB database from one process at a time.** Two processes writing concurrently to the
-> same database root can corrupt `catalog.tlv` beyond recovery, after which the database **cannot be
-> opened at all**:
+> **`GraphDb::open` takes an exclusive lock on the database root, process-wide.** A second process that
+> tries to open the same root while another process already has it open gets an immediate, clean error
+> instead of being let in:
 >
 > ```
-> Error: corruption: duplicate label_id 0 in catalog file
+> Error: database locked: another process already has '<path>' open for writing. SparrowDB allows
+> only one open handle per database root at a time — close the other process's connection (or wait
+> for it to exit) and retry.
 > ```
 >
-> Measured on `sparrowdb@0.1.26`: **4 of 5 concurrent runs left the database permanently unopenable.**
-> There is currently **no lock file and no guard at `open()`** — nothing stops a second process from
-> attaching. Sequential access (one process exits, the next opens) is safe.
+> This closes [#524](https://github.com/ryaker/SparrowDB/issues/524): on `sparrowdb@0.1.26` and
+> earlier, there was **no lock file and no guard at `open()`** at all, and two processes writing
+> concurrently to the same root could corrupt `catalog.tlv` beyond recovery — measured at 4 of 5
+> concurrent runs leaving the database permanently unopenable
+> (`Error: corruption: duplicate label_id 0 in catalog file`). If you hit that error on an older
+> version, upgrading does not repair an already-corrupted `catalog.tlv` — it only prevents new
+> corruption from this cause.
 >
-> This is easy to hit by accident: a CLI invoked while a daemon is running, two workers, a cron job
-> overlapping a service, or a health check. The bindings expose only `open()` with **no read-only
-> mode**, so *every* attach is a potential writer.
+> The lock is released automatically when the holding process's handle is dropped or the process
+> exits, including a crash or `SIGKILL` — there is nothing to clean up by hand. Sequential access (one
+> process exits, the next opens) has always been safe and still is.
 >
-> Tracked as [#524](https://github.com/ryaker/SparrowDB/issues/524). Until it is fixed, ensure exactly
-> one process holds a given database root.
+> The bindings still expose only `open()` with **no read-only mode**, so this remains a single-writer
+> constraint rather than true multi-reader support: a second process must wait for the first to close
+> its handle (or exit) before it can attach at all, even just to read.
 
 ---
 

--- a/crates/sparrowdb-common/src/lib.rs
+++ b/crates/sparrowdb-common/src/lib.rs
@@ -70,6 +70,19 @@ pub enum Error {
     /// grows beyond the limit set via `EngineBuilder::with_memory_limit`.
     /// Use a larger limit or restructure the query to reduce fan-out.
     QueryMemoryExceeded,
+    /// `GraphDb::open`/`open_encrypted` could not acquire the exclusive
+    /// cross-process lock on the database root because another process
+    /// already holds it open (#524).
+    ///
+    /// Two processes each deriving `next_label_id` (and other catalog
+    /// counters) from their own in-memory state, with no coordination
+    /// between them, can both allocate the same id and permanently corrupt
+    /// `catalog.tlv` — `GraphDb::open` refuses to hand out a second handle
+    /// to the same root instead of risking that. The lock is released
+    /// automatically when the other process's handle is dropped or the
+    /// process exits (including on crash/kill), so retrying after the
+    /// holder closes its handle succeeds.
+    DatabaseLocked(String),
 }
 
 impl std::fmt::Display for Error {
@@ -107,6 +120,12 @@ impl std::fmt::Display for Error {
             Error::QueryMemoryExceeded => write!(
                 f,
                 "query memory exceeded: BFS frontier exceeded the configured memory limit"
+            ),
+            Error::DatabaseLocked(path) => write!(
+                f,
+                "database locked: another process already has '{path}' open for writing. \
+                 SparrowDB allows only one open handle per database root at a time — close \
+                 the other process's connection (or wait for it to exit) and retry."
             ),
         }
     }

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -71,6 +71,12 @@ impl GraphDb {
     ///
     /// # Errors
     ///
+    /// Returns [`Error::DatabaseLocked`] if another process already has this
+    /// root open — SparrowDB allows only one open handle per database root
+    /// across processes at a time (#524). Retry once the other process
+    /// closes its handle or exits; the lock cannot be stolen or broken, by
+    /// design (see [`process_lock`](crate::process_lock)'s module docs).
+    ///
     /// Besides the usual I/O and WAL-replay failures, this returns
     /// [`Error::Corruption`] when a persisted vector index file exists under
     /// `<path>/vector_indexes/` but cannot be loaded — or when that directory
@@ -163,7 +169,9 @@ impl GraphDb {
     /// fail with [`Error::EncryptionAuthFailed`].
     ///
     /// # Errors
-    /// Returns an error if the directory cannot be created, or
+    /// Returns [`Error::DatabaseLocked`] if another process already has this
+    /// root open — see [`GraphDb::open`]'s identical note (#524). Also
+    /// returns an error if the directory cannot be created, or
     /// [`Error::Corruption`] if a persisted vector index file exists but cannot
     /// be loaded — see [`GraphDb::open`] for why that is fatal.
     pub fn open_encrypted(path: &Path, key: [u8; 32]) -> Result<Self> {

--- a/crates/sparrowdb/src/db.rs
+++ b/crates/sparrowdb/src/db.rs
@@ -86,6 +86,9 @@ impl GraphDb {
     /// unaffected — absent is not the same as damaged.
     pub fn open(path: &Path) -> Result<Self> {
         std::fs::create_dir_all(path)?;
+        // Must be first: refuses a second concurrent handle to this root
+        // before anything below touches the catalog or WAL (#524).
+        let db_lock = crate::process_lock::ProcessLock::acquire(path)?;
         let wal_dir = path.join("wal");
         let wal_writer = WalWriter::open(&wal_dir)?;
         // Replay any WAL records that were fsync'd but not yet written to disk
@@ -147,6 +150,7 @@ impl GraphDb {
                 commits_since_gc: AtomicU64::new(0),
                 vector_indexes,
                 quarantined_vector_writes,
+                _db_lock: db_lock,
             }),
         })
     }
@@ -164,6 +168,8 @@ impl GraphDb {
     /// be loaded — see [`GraphDb::open`] for why that is fatal.
     pub fn open_encrypted(path: &Path, key: [u8; 32]) -> Result<Self> {
         std::fs::create_dir_all(path)?;
+        // Must be first — see the identical comment in `GraphDb::open` (#524).
+        let db_lock = crate::process_lock::ProcessLock::acquire(path)?;
         let wal_dir = path.join("wal");
         let wal_writer = WalWriter::open_encrypted(&wal_dir, key)?;
         // Replay any WAL records that were fsync'd but not yet written to disk.
@@ -215,6 +221,7 @@ impl GraphDb {
                 commits_since_gc: AtomicU64::new(0),
                 vector_indexes,
                 quarantined_vector_writes,
+                _db_lock: db_lock,
             }),
         })
     }
@@ -791,6 +798,9 @@ impl GraphDb {
         // with an active WriteTx that also holds an open Catalog handle.
         // Both paths derive next_label_id from their own in-memory counter, so
         // concurrent catalog writes without this guard can assign duplicate IDs.
+        // This guard is in-process only; the equivalent cross-process race —
+        // two separate `GraphDb::open` calls on the same root — is closed at
+        // `open()` by `ProcessLock` instead (#524).
         let _guard = WriteGuard::try_acquire(&self.inner).ok_or(Error::WriterBusy)?;
         let mut catalog = sparrowdb_catalog::catalog::Catalog::open(&self.inner.path)?;
         let label_id: u32 = match catalog.get_label(label)? {

--- a/crates/sparrowdb/src/lib.rs
+++ b/crates/sparrowdb/src/lib.rs
@@ -35,6 +35,7 @@
 mod batch;
 mod db;
 mod helpers;
+mod process_lock;
 mod read_tx;
 mod types;
 mod wal_codec;

--- a/crates/sparrowdb/src/process_lock.rs
+++ b/crates/sparrowdb/src/process_lock.rs
@@ -179,22 +179,42 @@ mod tests {
         let _b = ProcessLock::acquire(dir.path()).expect("re-acquire after drop");
     }
 
+    /// Deliberately does not inspect `reg.len()` or count entries across the
+    /// whole map: `registry()` is one process-wide static, and `cargo test`
+    /// runs every `#[test]` in this binary in parallel by default — other,
+    /// unrelated tests elsewhere in this crate call `GraphDb::open` (hence
+    /// `ProcessLock::acquire`) on their own tempdirs concurrently with this
+    /// one. A whole-map assertion is an assertion about every other test that
+    /// happens to be mid-`open()` at this exact instant, not about this
+    /// test's own behaviour — exactly the flake an earlier version of this
+    /// test had (caught by a full `cargo test -p sparrowdb` run: a sibling
+    /// unit test's still-live entry made `live == 0` false).
+    ///
+    /// So this only ever inspects entries keyed by paths *this test itself*
+    /// created — `tempfile::tempdir()` paths are unique per call, so no
+    /// concurrently-running test can plausibly collide with `key_a`.
     #[test]
-    fn registry_does_not_grow_across_unrelated_roots() {
-        for _ in 0..8 {
-            let dir = tempfile::tempdir().expect("tempdir");
-            let lock = ProcessLock::acquire(dir.path()).expect("acquire");
-            drop(lock);
-        }
+    fn dead_entry_for_a_specific_root_is_swept_by_the_next_acquire_anywhere() {
+        let dir_a = tempfile::tempdir().expect("tempdir a");
+        let key_a = dir_a
+            .path()
+            .canonicalize()
+            .expect("canonicalize dir_a (it exists — tempdir created it)");
+
+        let lock_a = ProcessLock::acquire(dir_a.path()).expect("acquire a");
+        drop(lock_a);
+        // `key_a`'s entry is now a dead Weak, still physically present until
+        // some call to `acquire` (for any root, not necessarily this one)
+        // sweeps it.
+
+        let dir_b = tempfile::tempdir().expect("tempdir b");
+        let _lock_b = ProcessLock::acquire(dir_b.path()).expect("acquire b — triggers the sweep");
+
         let reg = registry().lock().expect("registry lock");
-        let live: usize = reg.values().filter(|w| w.strong_count() > 0).count();
-        assert_eq!(live, 0, "no handle should still be held");
-        // The sweep in `acquire` only runs on the next call, so a bounded
-        // number of dead entries may linger — but not one per iteration.
         assert!(
-            reg.len() <= 1,
-            "dead entries must not accumulate unboundedly, got {}",
-            reg.len()
+            !reg.contains_key(&key_a),
+            "a dead entry for a specific, no-longer-referenced root must be swept by the next \
+             acquire() call anywhere, not linger indefinitely"
         );
     }
 }

--- a/crates/sparrowdb/src/process_lock.rs
+++ b/crates/sparrowdb/src/process_lock.rs
@@ -1,0 +1,200 @@
+// ── Cross-process database lock (#524) ───────────────────────────────────────
+//
+// `GraphDb::open` used to place no lock at all on the database root. Two
+// processes opening the same root each derive counters like `next_label_id`
+// from their own in-memory state (see the comment on `WriteGuard` usage in
+// `db.rs`), so concurrent catalog writes from two independent handles can
+// assign the same id twice. The result isn't a wrong answer — it is
+// `catalog.tlv` corrupted beyond what `open()` will even parse again
+// ("corruption: duplicate label_id 0 in catalog file"), for every future
+// process, including the ones that caused it. `ProcessLock` closes that at
+// the door: a second `open()` against a root some *other process* already
+// holds fails immediately and cleanly instead of racing.
+
+use sparrowdb_common::{Error, Result};
+use std::collections::HashMap;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+
+/// Name of the lock file created at the database root.
+const LOCK_FILE_NAME: &str = "db.lock";
+
+/// The held `flock`, released when the last [`ProcessLock`] pointing at it
+/// (and thus the last `Arc` below) drops.
+struct LockedFile(File);
+
+impl Drop for LockedFile {
+    fn drop(&mut self) {
+        // Closing the descriptor releases the lock on its own — including on
+        // panic unwind and process kill, which is the whole point (see the
+        // module doc). Unlocking first just keeps the release explicit and
+        // independent of exactly when the `File` is actually dropped.
+        let _ = self.0.unlock();
+    }
+}
+
+/// Live in-process locks, keyed by canonicalized database root.
+///
+/// [`std::fs::File::try_lock`] is `flock(2)` on Unix, scoped to the *open
+/// file description* — not the process. Two threads (or two sequential
+/// `GraphDb::open` calls) in one process that each open the lock file fresh
+/// would therefore exclude each other exactly as two separate OS processes
+/// do. That is correct for the bug this module fixes, but it is *not* what
+/// several existing tests intentionally rely on: opening two live `GraphDb`
+/// handles on one root from the same process to test how a stale in-process
+/// handle behaves (e.g.
+/// `vector_index_durability::a_stale_handle_cannot_silently_revert_...`).
+/// #524 is about two *processes* racing an uncoordinated in-memory counter
+/// — it does not intend to forbid two handles sharing one address space.
+///
+/// So the registry hands out the *same* `Arc<LockedFile>` to every
+/// `ProcessLock::acquire` in this process for a given root, and only the
+/// first caller for that root actually contends for the OS-level lock. A
+/// second process, with its own empty registry, still calls `try_lock` on
+/// the same file fresh and is refused by the kernel exactly as before.
+fn registry() -> &'static Mutex<HashMap<PathBuf, Weak<LockedFile>>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<PathBuf, Weak<LockedFile>>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// A lock over one database root: exclusive across processes, shared within
+/// this one. Held for the lifetime of the
+/// [`DbInner`](crate::types::DbInner) that acquired it.
+///
+/// # Why `flock` and not a PID file
+///
+/// A PID file has to answer "what if the holder died?", and every answer is
+/// a heuristic: a liveness probe races with PID reuse, an age threshold
+/// either wedges the database after a crash or breaks the lock out from
+/// under a slow-but-live writer — and a broken lock is exactly the
+/// corruption this exists to prevent. An `flock`-style advisory lock is
+/// released by the kernel when the file descriptor closes, including when
+/// the process is `SIGKILL`ed, so a crashed holder leaves nothing to
+/// reclaim and nothing stale to reason about. This mirrors `SaveLock` in
+/// `sparrowdb_storage::vector_index`, which made the identical call for
+/// per-index locking (#452).
+///
+/// # Why exclusive, not scoped to catalog mutation
+///
+/// An advisory lock scoped only to catalog-mutating calls would preserve
+/// concurrent *readers*. But every language binding exposes only `open()`
+/// with no read-only mode, so "concurrent readers" is not a case this gives
+/// up — it is aspirational today regardless. Exclusive-at-`open()` now, and
+/// a real read-only mode later, is the honest ordering. Decision recorded
+/// on issue #524.
+///
+/// # Why non-blocking
+///
+/// `open()` uses `try_lock` rather than blocking `lock`: a second process
+/// racing to open the same root should get an immediate, actionable
+/// [`Error::DatabaseLocked`] it can report to an operator, not a hang with
+/// no indication of what it is waiting for.
+// Never read in normal operation — `LockedFile`'s presence (and its `Drop`
+// impl) is the entire point. Read directly (via `.0`) only by the
+// `Arc::ptr_eq` unit test above, which is why `dead_code` fires without this.
+#[allow(dead_code)]
+pub(crate) struct ProcessLock(Arc<LockedFile>);
+
+impl ProcessLock {
+    /// Path of the lock file for a database rooted at `db_path`.
+    fn lock_path(db_path: &Path) -> PathBuf {
+        db_path.join(LOCK_FILE_NAME)
+    }
+
+    /// Acquire the lock for the database rooted at `db_path`.
+    ///
+    /// `db_path` must already exist (`GraphDb::open` creates it before
+    /// calling this). Returns [`Error::DatabaseLocked`] if another
+    /// process's handle already holds it; succeeds and shares the existing
+    /// lock if this process already holds it.
+    pub(crate) fn acquire(db_path: &Path) -> Result<Self> {
+        // Canonicalize so two spellings of one root (relative vs. absolute,
+        // a symlinked temp dir) register as the same key within this
+        // process. Falls back to the given path on failure rather than
+        // block opening on a bookkeeping concern — `db_path` exists at this
+        // point, so canonicalize only fails for genuinely exotic filesystem
+        // issues, and the worst outcome of the fallback is this process not
+        // sharing its own lock with itself under the alternate spelling,
+        // which just means it contends with itself as if it were a second
+        // process (safe, merely a spurious `DatabaseLocked`).
+        let key = db_path
+            .canonicalize()
+            .unwrap_or_else(|_| db_path.to_path_buf());
+
+        let mut reg = registry().lock().expect("process lock registry poisoned");
+        // Sweep dead entries so this map doesn't grow without bound across a
+        // long-running process that opens many different roots over its
+        // lifetime (every test in this workspace's suite, for instance).
+        reg.retain(|_, weak| weak.strong_count() > 0);
+
+        if let Some(shared) = reg.get(&key).and_then(Weak::upgrade) {
+            return Ok(ProcessLock(shared));
+        }
+
+        let path = Self::lock_path(db_path);
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .map_err(Error::Io)?;
+        match file.try_lock() {
+            Ok(()) => {
+                let locked = Arc::new(LockedFile(file));
+                reg.insert(key, Arc::downgrade(&locked));
+                Ok(ProcessLock(locked))
+            }
+            Err(std::fs::TryLockError::WouldBlock) => {
+                Err(Error::DatabaseLocked(db_path.display().to_string()))
+            }
+            Err(std::fs::TryLockError::Error(e)) => Err(Error::Io(e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn second_handle_in_this_process_shares_the_lock() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let a = ProcessLock::acquire(dir.path()).expect("first acquire");
+        let b = ProcessLock::acquire(dir.path()).expect("second acquire, same process");
+        assert!(
+            Arc::ptr_eq(&a.0, &b.0),
+            "same-process handles must share one Arc<LockedFile>, not contend"
+        );
+    }
+
+    #[test]
+    fn lock_is_released_when_every_handle_in_this_process_drops() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let a = ProcessLock::acquire(dir.path()).expect("first acquire");
+        drop(a);
+        // Re-acquiring after the only holder dropped must succeed, not see
+        // a stale "still locked" state.
+        let _b = ProcessLock::acquire(dir.path()).expect("re-acquire after drop");
+    }
+
+    #[test]
+    fn registry_does_not_grow_across_unrelated_roots() {
+        for _ in 0..8 {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let lock = ProcessLock::acquire(dir.path()).expect("acquire");
+            drop(lock);
+        }
+        let reg = registry().lock().expect("registry lock");
+        let live: usize = reg.values().filter(|w| w.strong_count() > 0).count();
+        assert_eq!(live, 0, "no handle should still be held");
+        // The sweep in `acquire` only runs on the next call, so a bounded
+        // number of dead entries may linger — but not one per iteration.
+        assert!(
+            reg.len() <= 1,
+            "dead entries must not accumulate unboundedly, got {}",
+            reg.len()
+        );
+    }
+}

--- a/crates/sparrowdb/src/types.rs
+++ b/crates/sparrowdb/src/types.rs
@@ -325,6 +325,17 @@ pub(crate) struct DbInner {
     /// scope for #451, which is about a single handle's `open()` being
     /// stale, not about multiple handles disagreeing.
     pub quarantined_vector_writes: RwLock<HashMap<(String, String), Vec<PathBuf>>>,
+    /// Exclusive cross-process lock on the database root, acquired in
+    /// `GraphDb::open`/`open_encrypted` (#524).
+    ///
+    /// Never read after `open()` — held purely for its `Drop` impl, which
+    /// releases the underlying `flock` when the last `GraphDb` clone sharing
+    /// this `DbInner` goes away (or, independent of Rust-level `Drop`, when
+    /// the process exits or is killed — the OS closes the descriptor either
+    /// way). See `process_lock` module docs for why this is exclusive rather
+    /// than scoped to catalog mutation.
+    #[allow(dead_code)]
+    pub(crate) _db_lock: crate::process_lock::ProcessLock,
 }
 
 /// Run GC on the version store every this many commits.

--- a/crates/sparrowdb/tests/regression_524_process_lock.rs
+++ b/crates/sparrowdb/tests/regression_524_process_lock.rs
@@ -1,0 +1,332 @@
+//! Regression tests for issue #524 — two processes writing concurrently to
+//! one database root permanently corrupt `catalog.tlv`, and the database
+//! then cannot be opened at all:
+//!
+//! ```text
+//! Error: corruption: duplicate label_id 0 in catalog file
+//! ```
+//!
+//! ## Root cause
+//!
+//! `GraphDb::open` derives `next_label_id` (and other catalog counters) from
+//! its own in-memory state, with no coordination across handles. Two
+//! processes each opening the same root, each `CREATE`ing a node of a label
+//! the catalog does not yet have, both allocate `label_id` 0 and both write
+//! it to `catalog.tlv` — confirmed against pre-fix `origin/main` (4d15340)
+//! using the CLI's `query` subcommand as two racing processes, mirroring the
+//! Node.js repro in the issue:
+//!
+//! ```text
+//! run 1: BRICKED -> Error: corruption: duplicate label_id 0 in catalog file
+//! run 2: BRICKED -> Error: corruption: duplicate label_id 0 in catalog file
+//! run 3: BRICKED -> Error: corruption: duplicate label_id 0 in catalog file
+//! run 4: BRICKED -> Error: corruption: duplicate label_id 0 in catalog file
+//! run 5: BRICKED -> Error: corruption: duplicate label_id 0 in catalog file
+//! run 6: BRICKED -> Error: corruption: duplicate label_id 0 in catalog file
+//! run 7: BRICKED -> Error: corruption: duplicate label_id 0 in catalog file
+//! run 8: BRICKED -> Error: corruption: duplicate label_id 0 in catalog file
+//! ```
+//!
+//! (8/8 here rather than the issue's 4/5 — likely because the CLI pays
+//! process-startup cost before `open()`, which widens the race window
+//! relative to the in-process Node repro.)
+//!
+//! ## The fix
+//!
+//! `GraphDb::open`/`open_encrypted` now take an exclusive `flock` on
+//! `<db_root>/db.lock` (`crate::process_lock::ProcessLock`) before touching
+//! anything else. A second *process* racing to open the same root gets an
+//! immediate `Error::DatabaseLocked` instead of a chance to corrupt the
+//! catalog; released automatically — by the kernel, on fd close — when the
+//! holder's handle drops, including on crash or `SIGKILL`.
+//!
+//! ## What these tests prove, across real OS processes
+//!
+//! * [`concurrent_open_one_wins_one_gets_a_clean_error`]: two processes
+//!   racing `GraphDb::open` + `CREATE` against a fresh root never both get
+//!   in — exactly one succeeds, the other gets `Error::DatabaseLocked`, and
+//!   a subsequent open sees exactly the winner's data with no corruption.
+//! * [`lock_is_released_when_holder_is_sigkilled`]: a second open is refused
+//!   while a holder is alive, and succeeds immediately after the holder is
+//!   `SIGKILL`ed — proving release does not depend on the holder's `Drop`
+//!   impl running.
+//! * [`sequential_open_write_close_reopen_still_works`]: the ordinary
+//!   single-process open/write/close/reopen pattern — what real callers
+//!   actually do — is unaffected.
+
+use sparrowdb::GraphDb;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+/// Deadline for every cross-process rendezvous below. Generous — it only has
+/// to cover process startup on a loaded CI box; a miss fails the test rather
+/// than hanging it. Mirrors `regression_464_quarantine_race.rs`.
+const RENDEZVOUS_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Spin until `flag` appears, or fail. Mirrors `regression_464_quarantine_race.rs`'s
+/// `await_flag`.
+fn await_flag(flag: &Path, who: &str) {
+    let deadline = Instant::now() + RENDEZVOUS_TIMEOUT;
+    while !flag.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "{who}: {} never appeared within {RENDEZVOUS_TIMEOUT:?}",
+            flag.display()
+        );
+        std::thread::yield_now();
+    }
+}
+
+// ── Test 1: two processes racing GraphDb::open ──────────────────────────────
+
+/// Set on each racing child; its value is `<scratch>/db` (shared) joined
+/// with the child's own result-file name to write to.
+const RACE_DB_ENV: &str = "SPARROWDB_524_RACE_DB";
+const RACE_LABEL_ENV: &str = "SPARROWDB_524_RACE_LABEL";
+const RACE_RESULT_ENV: &str = "SPARROWDB_524_RACE_RESULT_FILE";
+
+/// One racing child: open the shared root and `CREATE` one node carrying its
+/// own label, then record the outcome and exit. Never panics on a failed
+/// open — `Error::DatabaseLocked` from the loser is the expected, correct
+/// outcome for one of the two children, not a test failure by itself.
+///
+/// Inert unless `RACE_DB_ENV` is set, and `#[ignore]`d so an ordinary
+/// `cargo test` run never invokes it directly (see #464's identical
+/// convention).
+#[test]
+#[ignore = "worker process for concurrent_open_one_wins_one_gets_a_clean_error"]
+fn child_524_race_writer() {
+    let Ok(db_path) = std::env::var(RACE_DB_ENV) else {
+        eprintln!(
+            "child_524_race_writer is a worker for \
+             concurrent_open_one_wins_one_gets_a_clean_error and does nothing when run directly"
+        );
+        return;
+    };
+    let label = std::env::var(RACE_LABEL_ENV).expect("RACE_LABEL_ENV must be set for the child");
+    let result_file =
+        PathBuf::from(std::env::var(RACE_RESULT_ENV).expect("RACE_RESULT_ENV must be set"));
+
+    let outcome = match GraphDb::open(Path::new(&db_path)) {
+        Ok(db) => {
+            let cypher = format!("CREATE (n:{label} {{id: '{label}'}})");
+            match db.execute(&cypher) {
+                Ok(_) => "OPENED_AND_WROTE".to_string(),
+                Err(e) => format!("OPENED_BUT_WRITE_FAILED: {e}"),
+            }
+        }
+        Err(e) => format!("OPEN_FAILED: {e}"),
+    };
+    std::fs::write(&result_file, outcome).expect("write result file");
+}
+
+/// Hand-derivation: whichever child's `open()` wins the `flock`, its
+/// `CREATE` is the only mutation ever applied to this root, so after both
+/// children exit the root must contain **exactly one** node, whose `id`
+/// equals the winner's label — not both (that would be the pre-fix
+/// duplicate-`label_id` corruption avoided rather than reproduced) and not
+/// neither (that would mean the winner's write was lost).
+#[test]
+fn concurrent_open_one_wins_one_gets_a_clean_error() {
+    let scratch = tempfile::tempdir().expect("tempdir");
+    let db_path = scratch.path().join("db");
+    let result_alpha = scratch.path().join("result_alpha.txt");
+    let result_beta = scratch.path().join("result_beta.txt");
+
+    let exe = std::env::current_exe().expect("current_exe");
+
+    // Spawn both children back-to-back with no rendezvous between them —
+    // unlike #464's forced microsecond window, this fix's correctness does
+    // not depend on hitting a narrow interleaving: *no* interleaving of two
+    // concurrent opens may corrupt the catalog or let both in. Spawning
+    // back-to-back is what produced the 8/8 collision rate quoted in the
+    // module doc against the unfixed code, so it reliably exercises the
+    // race without extra synchronisation machinery.
+    let mut alpha = std::process::Command::new(&exe)
+        .args(["child_524_race_writer", "--exact", "--ignored", "--nocapture"])
+        .env(RACE_DB_ENV, &db_path)
+        .env(RACE_LABEL_ENV, "Alpha")
+        .env(RACE_RESULT_ENV, &result_alpha)
+        .spawn()
+        .expect("spawn child alpha");
+    let mut beta = std::process::Command::new(&exe)
+        .args(["child_524_race_writer", "--exact", "--ignored", "--nocapture"])
+        .env(RACE_DB_ENV, &db_path)
+        .env(RACE_LABEL_ENV, "Beta")
+        .env(RACE_RESULT_ENV, &result_beta)
+        .spawn()
+        .expect("spawn child beta");
+
+    let status_alpha = alpha.wait().expect("alpha must exit");
+    let status_beta = beta.wait().expect("beta must exit");
+    assert!(status_alpha.success(), "alpha child process itself must not crash");
+    assert!(status_beta.success(), "beta child process itself must not crash");
+
+    let outcome_alpha = std::fs::read_to_string(&result_alpha).expect("read alpha result");
+    let outcome_beta = std::fs::read_to_string(&result_beta).expect("read beta result");
+
+    let alpha_won = outcome_alpha == "OPENED_AND_WROTE";
+    let beta_won = outcome_beta == "OPENED_AND_WROTE";
+    assert!(
+        alpha_won ^ beta_won,
+        "exactly one racer must win the lock and write; got alpha={outcome_alpha:?} beta={outcome_beta:?}"
+    );
+
+    let loser_outcome = if alpha_won { &outcome_beta } else { &outcome_alpha };
+    assert!(
+        loser_outcome.starts_with("OPEN_FAILED:"),
+        "the loser must fail at open(), not at the write, got: {loser_outcome}"
+    );
+    assert!(
+        loser_outcome.contains("database locked"),
+        "the loser's error must name the real cause (Error::DatabaseLocked's Display), got: {loser_outcome}"
+    );
+
+    // No corruption: a fresh open succeeds and sees exactly the winner's row.
+    let db = GraphDb::open(&db_path).expect("reopen after the race must succeed cleanly");
+    let result = db
+        .execute("MATCH (n) RETURN n.id")
+        .expect("query after the race must succeed — no catalog corruption");
+    let winner_label = if alpha_won { "Alpha" } else { "Beta" };
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "exactly one node must exist after the race, got: {:?}",
+        result.rows
+    );
+    assert_eq!(
+        result.rows[0],
+        vec![sparrowdb_execution::types::Value::String(winner_label.to_string())],
+        "the surviving node must be the winner's, not the loser's or a corrupted mix"
+    );
+}
+
+// ── Test 2: lock is released on SIGKILL, not just on graceful Drop ─────────
+
+const HOLD_DB_ENV: &str = "SPARROWDB_524_HOLD_DB";
+const HOLD_READY_FLAG_ENV: &str = "SPARROWDB_524_HOLD_READY_FLAG";
+
+/// Opens the shared root, signals readiness, then sleeps far longer than
+/// this test ever waits — it is expected to be `SIGKILL`ed, never to exit on
+/// its own. Inert unless `HOLD_DB_ENV` is set (see #464's identical
+/// convention for why: an `--ignored` sweep must not fail on this).
+#[test]
+#[ignore = "worker process for lock_is_released_when_holder_is_sigkilled"]
+fn child_524_lock_holder() {
+    let Ok(db_path) = std::env::var(HOLD_DB_ENV) else {
+        eprintln!(
+            "child_524_lock_holder is a worker for \
+             lock_is_released_when_holder_is_sigkilled and does nothing when run directly"
+        );
+        return;
+    };
+    let ready_flag = PathBuf::from(std::env::var(HOLD_READY_FLAG_ENV).expect("READY_FLAG_ENV"));
+
+    let _db = GraphDb::open(Path::new(&db_path)).expect("holder open");
+    std::fs::write(&ready_flag, b"1").expect("signal ready");
+    // Never returns on its own; the parent SIGKILLs this process.
+    std::thread::sleep(Duration::from_secs(300));
+}
+
+/// Kills a spawned child on drop, including on an unwinding panic.
+///
+/// Without this, a child that outlives its intended lifetime — e.g. the
+/// SIGKILL test's holder, still sleeping if an assertion panics before this
+/// test reaches its own `kill()` call — keeps a duplicate of this test
+/// process's captured stdout/stderr pipe open. `cargo test`'s harness then
+/// blocks forever reading for EOF on that pipe waiting to report the
+/// (already-decided) failure: a hang masquerading as a slow test, not the
+/// clean failure the assertion actually produced. Piping the child's own
+/// stdio to `/dev/null` (see `spawn_holder` below) already prevents that
+/// specific pipe-inheritance hang; this guard is the second, independent
+/// reason not to leak the process itself — a stray sleeper left running
+/// after `cargo test` exits, one per flaky rerun.
+struct KillOnDrop(std::process::Child);
+
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Proves release does not depend on `ProcessLock`'s `Drop` impl running —
+/// `SIGKILL` skips destructors entirely, so if this passes, release comes
+/// from the kernel closing the file descriptor, exactly as the module docs
+/// on `ProcessLock` claim.
+#[test]
+fn lock_is_released_when_holder_is_sigkilled() {
+    let scratch = tempfile::tempdir().expect("tempdir");
+    let db_path = scratch.path().join("db");
+    let ready_flag = scratch.path().join("holder_ready");
+
+    let exe = std::env::current_exe().expect("current_exe");
+    let mut holder = KillOnDrop(
+        std::process::Command::new(&exe)
+            .args(["child_524_lock_holder", "--exact", "--ignored", "--nocapture"])
+            .env(HOLD_DB_ENV, &db_path)
+            .env(HOLD_READY_FLAG_ENV, &ready_flag)
+            // Not inherited: see `KillOnDrop`'s doc comment for the hang
+            // this avoids if an assertion below panics before this test
+            // reaches its own explicit kill.
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn holder"),
+    );
+
+    await_flag(&ready_flag, "parent (waiting for holder to open)");
+
+    // While the holder is alive, a second open from this (different)
+    // process must be refused cleanly.
+    let err = GraphDb::open(&db_path)
+        .err()
+        .expect("open must fail while another process holds the lock");
+    assert!(
+        err.to_string().contains("database locked"),
+        "must be the actionable DatabaseLocked error, got: {err}"
+    );
+
+    // SIGKILL the holder — no graceful shutdown, no Drop impls run in it.
+    holder.0.kill().expect("SIGKILL holder");
+    let status = holder.0.wait().expect("reap killed holder");
+    assert!(
+        !status.success(),
+        "a SIGKILLed process must not report success"
+    );
+
+    // The kernel released the flock the instant the fd closed. This must
+    // succeed now, not require a wait — the point of `flock` over a PID
+    // file is precisely that there is nothing to time out or reclaim.
+    let db =
+        GraphDb::open(&db_path).expect("open must succeed immediately after the holder is killed");
+    db.execute("CREATE (n:PostKill {id: 'ok'})")
+        .expect("db must be fully usable, not just openable, after reclaiming the lock");
+}
+
+// ── Test 3: the ordinary single-process case is unaffected ─────────────────
+
+/// The pattern real callers actually use: open, write, close, reopen. No
+/// subprocess needed — this exercises `ProcessLock`'s release-on-`Drop`
+/// path, the counterpart to the SIGKILL test's release-without-`Drop` path.
+#[test]
+fn sequential_open_write_close_reopen_still_works() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("db");
+
+    {
+        let db = GraphDb::open(&db_path).expect("first open");
+        db.execute("CREATE (n:Seq {id: 'x'})").expect("create");
+        // db dropped here — releases the lock.
+    }
+
+    let db2 = GraphDb::open(&db_path).expect("reopen after close must succeed");
+    let result = db2
+        .execute("MATCH (n:Seq) RETURN n.id")
+        .expect("query after reopen");
+    assert_eq!(
+        result.rows,
+        vec![vec![sparrowdb_execution::types::Value::String("x".to_string())]],
+        "sequential open/write/close/reopen must see the earlier write, unaffected by the lock"
+    );
+}

--- a/crates/sparrowdb/tests/regression_524_process_lock.rs
+++ b/crates/sparrowdb/tests/regression_524_process_lock.rs
@@ -143,14 +143,24 @@ fn concurrent_open_one_wins_one_gets_a_clean_error() {
     // module doc against the unfixed code, so it reliably exercises the
     // race without extra synchronisation machinery.
     let mut alpha = std::process::Command::new(&exe)
-        .args(["child_524_race_writer", "--exact", "--ignored", "--nocapture"])
+        .args([
+            "child_524_race_writer",
+            "--exact",
+            "--ignored",
+            "--nocapture",
+        ])
         .env(RACE_DB_ENV, &db_path)
         .env(RACE_LABEL_ENV, "Alpha")
         .env(RACE_RESULT_ENV, &result_alpha)
         .spawn()
         .expect("spawn child alpha");
     let mut beta = std::process::Command::new(&exe)
-        .args(["child_524_race_writer", "--exact", "--ignored", "--nocapture"])
+        .args([
+            "child_524_race_writer",
+            "--exact",
+            "--ignored",
+            "--nocapture",
+        ])
         .env(RACE_DB_ENV, &db_path)
         .env(RACE_LABEL_ENV, "Beta")
         .env(RACE_RESULT_ENV, &result_beta)
@@ -159,8 +169,14 @@ fn concurrent_open_one_wins_one_gets_a_clean_error() {
 
     let status_alpha = alpha.wait().expect("alpha must exit");
     let status_beta = beta.wait().expect("beta must exit");
-    assert!(status_alpha.success(), "alpha child process itself must not crash");
-    assert!(status_beta.success(), "beta child process itself must not crash");
+    assert!(
+        status_alpha.success(),
+        "alpha child process itself must not crash"
+    );
+    assert!(
+        status_beta.success(),
+        "beta child process itself must not crash"
+    );
 
     let outcome_alpha = std::fs::read_to_string(&result_alpha).expect("read alpha result");
     let outcome_beta = std::fs::read_to_string(&result_beta).expect("read beta result");
@@ -172,7 +188,11 @@ fn concurrent_open_one_wins_one_gets_a_clean_error() {
         "exactly one racer must win the lock and write; got alpha={outcome_alpha:?} beta={outcome_beta:?}"
     );
 
-    let loser_outcome = if alpha_won { &outcome_beta } else { &outcome_alpha };
+    let loser_outcome = if alpha_won {
+        &outcome_beta
+    } else {
+        &outcome_alpha
+    };
     assert!(
         loser_outcome.starts_with("OPEN_FAILED:"),
         "the loser must fail at open(), not at the write, got: {loser_outcome}"
@@ -196,7 +216,9 @@ fn concurrent_open_one_wins_one_gets_a_clean_error() {
     );
     assert_eq!(
         result.rows[0],
-        vec![sparrowdb_execution::types::Value::String(winner_label.to_string())],
+        vec![sparrowdb_execution::types::Value::String(
+            winner_label.to_string()
+        )],
         "the surviving node must be the winner's, not the loser's or a corrupted mix"
     );
 }
@@ -263,7 +285,12 @@ fn lock_is_released_when_holder_is_sigkilled() {
     let exe = std::env::current_exe().expect("current_exe");
     let mut holder = KillOnDrop(
         std::process::Command::new(&exe)
-            .args(["child_524_lock_holder", "--exact", "--ignored", "--nocapture"])
+            .args([
+                "child_524_lock_holder",
+                "--exact",
+                "--ignored",
+                "--nocapture",
+            ])
             .env(HOLD_DB_ENV, &db_path)
             .env(HOLD_READY_FLAG_ENV, &ready_flag)
             // Not inherited: see `KillOnDrop`'s doc comment for the hang
@@ -326,7 +353,9 @@ fn sequential_open_write_close_reopen_still_works() {
         .expect("query after reopen");
     assert_eq!(
         result.rows,
-        vec![vec![sparrowdb_execution::types::Value::String("x".to_string())]],
+        vec![vec![sparrowdb_execution::types::Value::String(
+            "x".to_string()
+        )]],
         "sequential open/write/close/reopen must see the earlier write, unaffected by the lock"
     );
 }


### PR DESCRIPTION
## Root cause

Two processes opening the same database root each derive catalog counters
(`next_label_id`, etc.) from independent in-memory state, with nothing
coordinating them across process boundaries. Concurrent `CREATE`s of a new
label can both allocate `label_id` 0, corrupting `catalog.tlv` beyond what
`open()` will parse again:

```
Error: corruption: duplicate label_id 0 in catalog file
```

`GraphDb::open` took no lock at all before this change — a freshly created
db root had no lock file, nothing preventing a second process from
attaching mid-write.

**Reproduced against pre-fix `origin/main` (4d15340)**, built via
`sparrowdb-cli` and run as two racing OS processes (mirrors the Node.js
repro from the issue):

```
run 1: BRICKED -> Error: corruption: duplicate label_id 0 in catalog file
run 2: BRICKED -> Error: corruption: duplicate label_id 0 in catalog file
run 3: BRICKED -> Error: corruption: duplicate label_id 0 in catalog file
run 4: BRICKED -> Error: corruption: duplicate label_id 0 in catalog file
run 5: BRICKED -> Error: corruption: duplicate label_id 0 in catalog file
run 6: BRICKED -> Error: corruption: duplicate label_id 0 in catalog file
run 7: BRICKED -> Error: corruption: duplicate label_id 0 in catalog file
run 8: BRICKED -> Error: corruption: duplicate label_id 0 in catalog file
```

8/8 here (vs. the issue's 4/5) — the CLI pays process-startup cost before
`open()`, which widens the race window relative to the in-process Node repro.

## The fix

`GraphDb::open`/`open_encrypted` now take an exclusive `flock` on
`<db_root>/db.lock` (`ProcessLock`, new module `crates/sparrowdb/src/process_lock.rs`)
before touching anything else — catalog, WAL, vector indexes. A second
process racing to open the same root gets an immediate `Error::DatabaseLocked`
instead of a chance to corrupt the catalog.

**Decision, recorded per the issue discussion**: exclusive rather than a
narrower lock scoped to catalog mutation. Every language binding (Node,
Python, Ruby) exposes only `open()` with no read-only mode today, so
"preserve concurrent readers" is not a real case being traded away — it's
aspirational regardless of what this lock does. Exclusive-at-`open()` now,
a real read-only mode later, is the honest ordering.

**Why `flock` and not a PID file**: a PID file has to answer "what if the
holder died?", and every answer is a heuristic — liveness probes race PID
reuse, age thresholds either wedge the database after a crash or break the
lock out from under a slow-but-live writer. `flock` is released by the
kernel when the file descriptor closes, including on `SIGKILL`, so a
crashed holder leaves nothing to reclaim and nothing stale to reason about.
This mirrors `SaveLock` in `sparrowdb-storage::vector_index` (#452), which
made the identical call for per-index locking.

**The one subtlety**: `flock` is scoped to the *open file description*, not
the process. A naive per-`open()` `try_lock()` would therefore also block a
second `GraphDb::open` from the *same* process — which several existing
tests intentionally rely on (e.g. `vector_index_durability`'s
`a_stale_handle_cannot_silently_revert_another_writers_vectors`, which holds
two live handles on one root to test how a stale in-process handle behaves).
#524 is about two *processes* racing an uncoordinated in-memory counter, not
about forbidding two handles in one address space. `ProcessLock` resolves
this with a process-local registry (keyed by canonicalized root) that hands
out the same `Arc` to every same-process caller — only the first caller per
root actually contends for the OS-level lock. A second, genuinely separate
process still calls `try_lock` fresh and is refused by the kernel exactly as
before.

## What changed, per file

- `crates/sparrowdb-common/src/lib.rs` — new `Error::DatabaseLocked(String)`
  variant with an actionable message (names the path, says what's holding it,
  says what to do).
- `crates/sparrowdb/src/process_lock.rs` (new) — `ProcessLock`: the flock +
  process-local sharing registry described above. 3 unit tests.
- `crates/sparrowdb/src/types.rs` — `DbInner` gains a `_db_lock: ProcessLock`
  field, held only for its `Drop` side effect.
- `crates/sparrowdb/src/db.rs` — `open()`/`open_encrypted()` acquire the lock
  as their first action, before `create_dir_all`'s directory is touched by
  anything else; updated `# Errors` doc sections; added a cross-reference
  comment on the existing in-process `WriteGuard` note (db.rs:~799) pointing
  at the new cross-process guard.
- `crates/sparrowdb/tests/regression_524_process_lock.rs` (new) — see below.
- `README.md` — the `#525` safety banner said "no lock file and no guard at
  `open()`"; that's now false, so it's rewritten to describe the lock, the
  crash-release guarantee, and that sequential access remains safe (kept the
  pre-fix corruption history as context for anyone already hit by it).

## Testing

All three properties below are exercised across **real OS processes**
(`std::process::Command` + `current_exe()` re-invocation, the same pattern
`regression_464_quarantine_race.rs` already uses in this repo), not threads
— threads would share one `DbInner`'s in-memory state and couldn't
reproduce the bug at all.

- **Concurrent case fails cleanly** — `concurrent_open_one_wins_one_gets_a_clean_error`:
  two processes race `open()` + `CREATE` against a fresh root. Exactly one
  wins (asserted via XOR, not "at least one"); the loser's error is asserted
  to both originate at `open()` (not the write) and contain "database
  locked". A subsequent open sees exactly the winner's row — no corruption,
  no lost write. Verified this test **fails against pre-fix `origin/main`**
  (copied into a worktree at 4d15340): 4/4 runs failed, symptom was the
  loser's write hitting a raw I/O race (`No such file or directory`) rather
  than the classic duplicate-`label_id` corruption — a different symptom of
  the same missing-coordination root cause, not a new bug.
- **Abnormal exit releases the lock** — `lock_is_released_when_holder_is_sigkilled`:
  holder process opens and signals ready; parent confirms a second `open()`
  is refused while it's alive; `SIGKILL`s it (`Child::kill` is SIGKILL on
  Unix); confirms the very next `open()` succeeds immediately and the db is
  fully usable (not just openable) — proving release comes from the kernel
  closing the fd, not from `ProcessLock`'s `Drop` impl (which SIGKILL skips
  entirely). Verified this **fails against pre-fix `origin/main`** at the
  "must be refused while alive" assertion (open just succeeds, no lock at
  all pre-fix).
- **Sequential access is unaffected** — `sequential_open_write_close_reopen_still_works`,
  plus the pre-existing suite: every "session 1 / session 2" reopen test in
  the crate (`spa191_rel_type_persistence`, `regression_485_stale_count`,
  `regression_491_stale_db_counts`, `spa_415_unwind_match_mutate`,
  `spa_209_schema_introspection`, `regression_436_dangling_edges`,
  `spa_184_wal_durability`, `spa_222_csr_lazy_load`,
  `regression_502_call_subquery_mutation_dispatch`) still passes.
- **Same-process multi-handle case unaffected** —
  `vector_index_durability::a_stale_handle_cannot_silently_revert_another_writers_vectors`
  still passes (this is what the process-local sharing registry exists for;
  a naive implementation breaks it).
- **No per-query cost** — the lock is acquired exactly once, inside
  `open()`/`open_encrypted()`; nothing was added to any query or write path.
- **Full suite**: `cargo test -p sparrowdb --no-fail-fast` — all binaries
  green after one fix (see "could not verify" — one flaky unit test was
  caught and fixed by this exact run). `cargo fmt --check` and
  `cargo clippy -p sparrowdb -p sparrowdb-execution --all-targets --keep-going`
  clean. `cargo check --workspace --exclude sparrowdb-ruby --all-targets`
  clean (Ruby doesn't compile locally per this repo's `CLAUDE.md`, unrelated
  to this change).

Every expected value in the new test file is derived by hand from what the
fix's contract requires (exactly one winner, exactly one row after), not
captured from a run.

## Could not verify

- **CI's Ruby job** — cannot compile locally (`RUBY_T_MOVED` / `dcompact`
  against the installed Ruby, per this repo's own `CLAUDE.md`). The `Error`
  enum change is additive and every binding (`sparrowdb-node`,
  `sparrowdb-python`, `sparrowdb-ruby`) converts errors via a catch-all
  `.to_string()` / `Display`, so I don't expect breakage, but I have not
  built or run the Ruby binding itself.
- **Windows.** `std::fs::File::try_lock` is `LockFileEx` there per the std
  docs, and the design doesn't lean on any Unix-only semantics I'm aware of,
  but this was only run on macOS (aarch64-apple-darwin) — no Windows CI leg
  exists in this repo to cross-check against.
- **A true multi-day / many-thousand-cycle stress run.** I ran the
  concurrent-race test dozens of times across the pre-fix and post-fix
  checks (pre-fix: consistent failure; post-fix: consistent pass — never
  flaky either direction in ~15 combined runs), and the full lib-test suite
  4x clean after fixing the one flaky unit test. I have not run it for
  hours or under real production-like load.
- **NFS or other network filesystems.** `flock` semantics on NFS are a
  known trouble spot in general (this is why `SaveLock` in
  `vector_index.rs` doesn't claim NFS support either); this PR doesn't
  claim it either. Only tested on local disk.
- **The out-of-scope repair tool** for already-corrupted databases —
  explicitly not attempted, per the brief. A database already bricked
  before this fix lands is not repaired by it.

Closes #524. Does not fix or attempt the repair-tool question raised in the
issue's peer-review comment — that's tracked as its own, separately-scoped
problem (node ids embed `label_id` in their upper bits, so affected nodes
may be genuinely ambiguous; feasibility unresolved).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>