### PR TITLE
chore: bump 0.1.26 → 0.1.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.26"
+version = "0.1.27"
 edition = "2021"
 license = "MIT"
 authors = ["Rich Yaker"]
@@ -28,13 +28,13 @@ documentation = "https://docs.rs/sparrowdb"
 readme = "README.md"
 
 [workspace.dependencies]
-sparrowdb-common = { path = "crates/sparrowdb-common", version = "0.1.26" }
-sparrowdb-storage = { path = "crates/sparrowdb-storage", version = "0.1.26" }
-sparrowdb-catalog = { path = "crates/sparrowdb-catalog", version = "0.1.26" }
-sparrowdb-cypher  = { path = "crates/sparrowdb-cypher", version = "0.1.26" }
-sparrowdb-execution = { path = "crates/sparrowdb-execution", version = "0.1.26" }
-sparrowdb = { path = "crates/sparrowdb", version = "0.1.26" }
-sparrowdb-metrics = { path = "crates/sparrowdb-metrics", version = "0.1.26" }
+sparrowdb-common = { path = "crates/sparrowdb-common", version = "0.1.27" }
+sparrowdb-storage = { path = "crates/sparrowdb-storage", version = "0.1.27" }
+sparrowdb-catalog = { path = "crates/sparrowdb-catalog", version = "0.1.27" }
+sparrowdb-cypher  = { path = "crates/sparrowdb-cypher", version = "0.1.27" }
+sparrowdb-execution = { path = "crates/sparrowdb-execution", version = "0.1.27" }
+sparrowdb = { path = "crates/sparrowdb", version = "0.1.27" }
+sparrowdb-metrics = { path = "crates/sparrowdb-metrics", version = "0.1.27" }
 tiny_http         = "0.12"
 tempfile          = "3"
 crc32fast         = "1"

--- a/crates/sparrowdb-python/pyproject.toml
+++ b/crates/sparrowdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "sparrowdb-py"
-version = "0.1.26"
+version = "0.1.27"
 description = "Python bindings for SparrowDB embedded graph database"
 requires-python = ">=3.9"
 license = { text = "MIT OR Apache-2.0" }

--- a/crates/sparrowdb-ruby/Cargo.toml
+++ b/crates/sparrowdb-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sparrowdb-ruby"
-version = "0.1.26"
+version = "0.1.27"
 edition = "2021"
 # Ships as a Ruby gem (extconf.rb + Gemfile + lib/), not as a crate. It has never
 # been published to crates.io and cannot be: its path dependencies carry no version

--- a/npm/sparrowdb/package-lock.json
+++ b/npm/sparrowdb/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparrowdb",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparrowdb",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",

--- a/npm/sparrowdb/package.json
+++ b/npm/sparrowdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparrowdb",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Native Node.js/TypeScript bindings for SparrowDB — embedded graph database with Cypher query support",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Version bump for **0.1.27**. Cut primarily to ship #524.

## Why now

**On 0.1.26, two processes writing concurrently to one database root permanently corrupt it.** The database then cannot be opened at all — `corruption: duplicate label_id 0 in catalog file`. Measured **4 of 5 runs**. There was no lock file and no guard at `open()`, so nothing stopped a second process attaching. A CLI invoked beside a daemon, two workers, or a health check was enough.

## What ships

- **#531 / #524** — exclusive `flock` on `<db_root>/db.lock`, taken once in `open()` before catalog or WAL touch the root. Kernel-released on fd close, so a `SIGKILL`'d holder leaves **no stale lock** — verified by killing a holder and confirming the next `open()` succeeds immediately with data intact. Sequential access unchanged.
- **#529 / #515** — every non-`PropAccess` RETURN expression silently returned `Null`. `RETURN n.age + 1` gave null; a mixed row gave one correct column beside a silent null, which looks like real data. The gate was a deny-list that had to enumerate every unsafe shape forever — inverted to an allow-list.
- **#527 / #523** — a mis-keyed `$param` returned zero rows with no error, indistinguishable from a legitimate no-match.
- **#526 / #521** — traversal **fabricated** `Int64(0)` for an absent property, so `{score: 0}` matched nodes lacking it entirely. The issue described this as under-matching; it over-matched.
- **#528 / #513, #518** — `index.d.ts` casing regenerated wrong forever because the earlier fix patched the *generated* file; fixed at source with `ts_return_type`. Internal platform map removed from the public API surface.
- **#520 / #451** — vector writes to a quarantined-no-live-index pair now refuse loudly; also fixed a cross-label silent drop that no issue described.
- **#522 / #472, #479** — null-bound `$param` filters matched on read but silently no-op'd on `SET` and `DELETE`.

Every fix ships with regression tests confirmed to fail against their parent commit.

## Expected failure on the release run

`update-homebrew-tap` **will fail** — `TAP_GITHUB_TOKEN` is expired (#508). That job is a **leaf** in `release.yml` (nothing declares `needs:` on it), and `npm-publish` / `publish-crates` sit on independent branches. Confirmed empirically on the v0.1.25 run, where every job succeeded except the tap and **both registries published**. Check per-job outcomes, not the run-level conclusion.

## Verification

- `cargo check -p sparrowdb` clean at 0.1.27 across all workspace crates.
- No `0.1.26` remains in any tracked `.toml` / `.json` / `.lock`.
- `package.json` diff is **version-only** this time, and `optionalDependencies` is still absent — confirmed the sync script did not re-introduce what #517 removed.